### PR TITLE
Report: debounce switch-load + open terminal URLs in system browser

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1058,9 +1058,31 @@ function createWindow(initialUrl) {
     shell.openExternal(url).catch(err => {
       console.error('[main] Failed to open external URL:', err);
     });
-    
+
     return { action: 'deny' };
   });
+
+  // Same-window navigations — a plain <a href> click (e.g. a URL printed in
+  // terminal output) would otherwise REPLACE the app in the Electron window.
+  // Intercept external http(s) navigations and open them in the system browser;
+  // let internal app / dev-server navigation proceed normally.
+  const isInternalNavUrl = (u) =>
+    u.startsWith('http://127.0.0.1') ||
+    u.startsWith('http://localhost') ||
+    u.startsWith('file://') ||
+    u.startsWith('app://') ||
+    u.startsWith('about:');
+  const redirectExternalNavigation = (event, url) => {
+    if (!isInternalNavUrl(url) && /^https?:\/\//i.test(url)) {
+      event.preventDefault();
+      console.log('[main] will-navigate → opening external URL in system browser:', url);
+      shell.openExternal(url).catch(err => {
+        console.error('[main] Failed to open external URL:', err);
+      });
+    }
+  };
+  mainWindow.webContents.on('will-navigate', redirectExternalNavigation);
+  mainWindow.webContents.on('will-redirect', redirectExternalNavigation);
 
   const devUrl = process.env.DEV_URL;
   if (devUrl && process.env.ELECTRON_OPEN_DEVTOOLS === '1') {

--- a/frontend/src/components/workflow/ReportViewer.tsx
+++ b/frontend/src/components/workflow/ReportViewer.tsx
@@ -535,25 +535,34 @@ function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onC
     setLoading(true)
     setError(null)
 
-    loadReportDataSnapshot(workspacePath, isExplicitRefreshForWorkspace)
-      .then(snapshot => {
-        if (cancelled) return
-        setPlanSource(snapshot.planSource)
-        setSources(snapshot.sources)
-      })
-      .catch(error => {
-        if (cancelled) return
-        const message = error instanceof Error ? error.message : String(error)
-        setError(message || 'Failed to load report.')
-        setPlanSource(null)
-        setSources({})
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
+    // Debounce the heavy fetch+parse so flicking through workflows (Ctrl+K /
+    // header pills) only loads the report you actually LAND on — not every one
+    // you pass through. The skeleton shows immediately; cached workflows above
+    // skip this entirely and stay instant. An explicit refresh skips the wait.
+    const loadDelayMs = isExplicitRefreshForWorkspace ? 0 : 250
+    const loadTimer = setTimeout(() => {
+      if (cancelled) return
+      loadReportDataSnapshot(workspacePath, isExplicitRefreshForWorkspace)
+        .then(snapshot => {
+          if (cancelled) return
+          setPlanSource(snapshot.planSource)
+          setSources(snapshot.sources)
+        })
+        .catch(error => {
+          if (cancelled) return
+          const message = error instanceof Error ? error.message : String(error)
+          setError(message || 'Failed to load report.')
+          setPlanSource(null)
+          setSources({})
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false)
+        })
+    }, loadDelayMs)
 
     return () => {
       cancelled = true
+      clearTimeout(loadTimer)
     }
   }, [workspacePath, refreshNonce, mobilePreview])
 


### PR DESCRIPTION
- Debounce ReportView load 250ms so Ctrl+K workflow switching only loads the report you land on (cached/refresh stay instant).
- Electron: will-navigate/will-redirect → shell.openExternal so terminal URLs open in the system browser instead of replacing the app (needs app restart to take effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)