### PR TITLE
Fix: inject DB_PATH in the scripted fast path (execScriptedScript)

### DIFF
--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_scripted.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_scripted.go
@@ -756,6 +756,13 @@ func (hcpo *StepBasedWorkflowOrchestrator) execScriptedScript(
 		hcpo.UnlockWorkspaceEnv()
 	}
 
+	// DB_PATH: the scripted fast path execs python3 directly — it does NOT go
+	// through the agent's execute_shell_command wrapper (injectStepEnvIntoShellExecutor)
+	// that injects DB_PATH. Without it a saved main.py doing os.environ['DB_PATH']
+	// fails with "DB_PATH unset and no root found". Set it here to the same absolute
+	// path the agent path uses. Set AFTER the workspace-env merge so it always wins.
+	extraEnv["DB_PATH"] = filepath.Join(docsRoot, hcpo.GetWorkspacePath(), DBFolderName, "db.sqlite")
+
 	envKeys := make([]string, 0, len(extraEnv))
 	for k := range extraEnv {
 		envKeys = append(envKeys, k)


### PR DESCRIPTION
## Symptom
A scripted step's saved `main.py` fails in pre-validation:
```
FATAL: could not locate workflow db/db.sqlite (DB_PATH unset and no root found)
❌ PRE-VALIDATION FAILED
```

## Root cause
The scripted fast path execs `python3 main.py` **directly** via `execScriptedScript`, which builds its own `ExtraEnv` (`STEP_OUTPUT_DIR`, `STEP_EXECUTION_DIR`, secrets) but **never sets `DB_PATH`**.

The agentic `execute_shell_command` path gets `DB_PATH` injected by `injectStepEnvIntoShellExecutor`, but the direct scripted exec **bypasses that wrapper** — so any saved script doing `os.environ['DB_PATH']` sees it unset and falls through to its walk-up fallback, which can't find the workflow root from the `execution/code/` CWD. That's why it only happens in **scripted** steps.

## Fix
Inject `DB_PATH` in `execScriptedScript` to the same absolute path the agent path uses (`<docsRoot>/<workspace>/db/db.sqlite`), set after the workspace-env merge so it always wins. One-line env addition.

Build + full `step_based_workflow` package tests pass. (No unit test added — `execScriptedScript` does workspace-API I/O; testing it in isolation needs a refactor not worth bundling with a one-line fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)