### PR TITLE
Fix: step stuck on "running" in UI when it ends early (scripted/errors)

### DIFF
--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_execution.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_execution.go
@@ -1251,6 +1251,23 @@ func (hcpo *StepBasedWorkflowOrchestrator) executeSingleStep(
 	// Note: Conditional steps emit their own step_started event in executeConditionalStep before calling executeSingleStep for branch steps
 	hcpo.emitStepStartedEvent(ctx, step, stepIndex, stepPath, isBranchStep)
 
+	// Guarantee the step leaves "running" on EVERY return path. This function has
+	// many early returns between here and the bottom (scripted fast-path failures,
+	// dependency/agent errors, context cancellations) — without this defer they'd
+	// skip the finished event and the UI would show the step stuck on "running"
+	// even after it completed or pre-validation failed. Emit "failed" on an error
+	// return, "end" otherwise. Use a background context so a cancellation-driven
+	// return still reaches the bridge. (Replaces the single success-path emit that
+	// used to live at the end of the function.)
+	defer func() {
+		emitCtx := context.Background()
+		if err != nil {
+			hcpo.emitStepFailedEvent(emitCtx, step, stepIndex, stepPath, isBranchStep, err.Error())
+		} else {
+			hcpo.emitStepFinishedEvent(emitCtx, step, stepIndex, stepPath, isBranchStep)
+		}
+	}()
+
 	// Narrow the session-level folder guard to this step's paths for the duration of
 	// the step. Session guard is set workspace-wide by the interactive builder and batch
 	// execution (server.go:4002, controller_batch_execution.go:323). Because shell commands
@@ -2795,10 +2812,8 @@ func (hcpo *StepBasedWorkflowOrchestrator) executeSingleStep(
 		updatedContextFiles = append(updatedContextFiles, contextOutput)
 	}
 
-	// Emit step_finished event (also emits step progress with status="end")
-	// Note: Conditional steps emit their own step_finished event in executeConditionalStep after branch execution completes
-	hcpo.emitStepFinishedEvent(ctx, step, stepIndex, stepPath, isBranchStep)
-
+	// step_finished (status="end") is emitted by the defer at the top of this
+	// function, which covers this success path AND every early return.
 	return executionResult, updatedContextFiles, nil
 }
 

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_progress.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/controller_progress.go
@@ -71,6 +71,25 @@ func (hcpo *StepBasedWorkflowOrchestrator) emitStepFinishedEvent(ctx context.Con
 	hcpo.GetLogger().Info(fmt.Sprintf("📤 Emitted step_progress_updated (end) for step %d: %s", stepIndex+1, stepTitle))
 }
 
+// emitStepFailedEvent emits a step "failed" progress event so the UI moves the
+// step out of "running" when a step ends in error. Mirrors emitStepFinishedEvent
+// but with status "failed" + the error message.
+func (hcpo *StepBasedWorkflowOrchestrator) emitStepFailedEvent(ctx context.Context, step PlanStepInterface, stepIndex int, stepPath string, isBranchStep bool, errorMsg string) {
+	bridge := hcpo.GetContextAwareBridge()
+	if bridge == nil {
+		return
+	}
+	stepId := step.GetID()
+	if stepId == "" {
+		stepId = fmt.Sprintf("step-%d", stepIndex+1)
+	}
+	progress, err := hcpo.loadStepProgress(ctx)
+	if err == nil && progress != nil {
+		hcpo.emitStepProgressUpdatedEvent(ctx, progress, "failed", stepId, errorMsg)
+	}
+	hcpo.GetLogger().Info(fmt.Sprintf("📤 Emitted step_progress_updated (failed) for step %d: %s", stepIndex+1, step.GetTitle()))
+}
+
 // emitStepProgressUpdatedEvent emits an event when step progress is updated
 // status can be "start" (step started), "stop" (step stopped), "end" (step ended), "failed" (step failed), or empty (regular progress update)
 // errorMsg is populated when status is "failed"


### PR DESCRIPTION
## Symptom
Scripted steps (and any step that ends via an early return) stay stuck on **"running"** in the UI even after they completed or pre-validation failed.

## Root cause
`executeSingleStep` emits `step_started` ("running") near the top, but the single `step_finished` ("end") emit lived only at the **bottom, on the success path**. The function has **16+ early returns** between them — scripted fast-path failures (`SavedScriptOnly` at 1639/1641), context cancellations, dependency/agent errors — and **every one skipped the finished event**, leaving the step on "running."

## Fix
Replace the bottom success-only emit with a **`defer`** placed right after `step_started`, so it fires on **every** return path:
- `failed` (with the error message) on an error return
- `end` otherwise

Uses a background context so a cancellation-driven return still reaches the bridge. Adds `emitStepFailedEvent` (mirrors `emitStepFinishedEvent`, status `failed`).

## Likely also helps the "auto-notification too fast/confusing" report
When the finished event was missing, the run could fire its completion AUTO-NOTIFICATION while step events still said "running" — a contradiction the builder agent reads and gets confused by. Steps now emit a proper finished/failed before the run wraps up.

Build + `step_based_workflow` + `orchestrator/types` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)