### PR TITLE
Pulse empty-state: point to /auto-improve, not /define-success

### DIFF
--- a/frontend/src/components/workflow/LogViewer.tsx
+++ b/frontend/src/components/workflow/LogViewer.tsx
@@ -110,8 +110,11 @@ export function LogViewer({ workspacePath }: LogViewerProps) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-center">
         <div className="max-w-md text-sm text-muted-foreground">
-          No workflow log yet. Run <code className="rounded bg-muted px-1">/define-success</code> to bootstrap it, then
-          improvements, reviews, and the post-run monitor will record entries here.
+          No Pulse log yet. Entries appear here after the post-run monitor runs on a{' '}
+          <strong>scheduled</strong> run (Pulse must be enabled), and when improvement or review
+          passes run. <code className="rounded bg-muted px-1">/define-success</code> seeds the
+          success-criteria section the Goal verdict is measured against — it's optional, not
+          required for the log.
         </div>
       </div>
     )

--- a/frontend/src/components/workflow/LogViewer.tsx
+++ b/frontend/src/components/workflow/LogViewer.tsx
@@ -110,11 +110,12 @@ export function LogViewer({ workspacePath }: LogViewerProps) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-center">
         <div className="max-w-md text-sm text-muted-foreground">
-          No Pulse log yet. Entries appear here after the post-run monitor runs on a{' '}
-          <strong>scheduled</strong> run (Pulse must be enabled), and when improvement or review
-          passes run. <code className="rounded bg-muted px-1">/define-success</code> seeds the
-          success-criteria section the Goal verdict is measured against — it's optional, not
-          required for the log.
+          No Pulse log yet. Run <code className="rounded bg-muted px-1">/auto-improve</code> to set
+          up recurring runs + self-improvement — its scheduled runs and improvement passes record
+          entries here, and it seeds the success criteria along the way. (The post-run monitor also
+          records here after any scheduled run;{' '}
+          <code className="rounded bg-muted px-1">/define-success</code> just seeds the criteria on
+          its own.)
         </div>
       </div>
     )


### PR DESCRIPTION
## Problem
A user with **Pulse enabled** and runs on disk opens the Pulse tab and sees *"Run `/define-success` to bootstrap it."* That's misleading on two counts:

1. The Pulse log doesn't **depend** on `/define-success` — the post-run monitor writes it (on scheduled runs), and improve passes write it. `/define-success` only seeds the success-criteria section.
2. `/define-success` alone **makes nothing run**, so following it leaves the log just as empty.

## Fix
Point the empty-state at **`/auto-improve`** instead — it's the complete, actionable flow:
- sets up **recurring run + optimizer schedules** (`guidance.go:87`) → creates the scheduled runs the post-run monitor needs to populate Pulse
- its improvement passes write entries to the log
- **bootstraps the success criteria inline** if missing (`auto-improve.md:27`)

`/define-success` stays mentioned as the lower-level seed. Behavior unchanged (Pulse stays scheduled-only); copy-only. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)