### PR TITLE
org-pulse: gate alignment on goals + count goals edits as fresh

### DIFF
--- a/agent_go/cmd/server/guidance/templates/system/org-pulse.md
+++ b/agent_go/cmd/server/guidance/templates/system/org-pulse.md
@@ -23,8 +23,10 @@ A 1:1 copy of any source file is a failure of this pass.
 ### 1. Cheap freshness gate
 
 First, check whether anything has changed since your last Org Pulse — no new workflow runs,
-no new chats, and no new outputs means there is nothing to do. Write nothing and stop. A daily
-run over an idle org is correctly a no-op.
+no new chats, no new outputs, **and no change to `pulse/goals.html`** — means there is nothing
+to do. Write nothing and stop. A daily run over an idle org is correctly a no-op. A created or
+edited `pulse/goals.html` counts as a change even with zero other activity: the scorecard and
+alignment must be re-evaluated against the new goals, so do not stop at this gate when goals changed.
 
 Only when something is new do you continue.
 
@@ -85,7 +87,10 @@ If `pulse/goals.html` exists, evaluate each goal first:
   a proxy metric.
 - Surface workflow gaps as suggestions, not fixes.
 
-Then evaluate workflow alignment:
+Then evaluate workflow alignment — **only when `pulse/goals.html` exists.** With no goals file
+there is nothing to align to: do **not** classify workflows as Unaligned or emit attach/retire
+suggestions — the single "no explicit goals yet, create them" suggestion from the evidence sweep
+covers that case. When goals exist:
 - **Aligned** — named as contributing to one or more goals and producing relevant evidence.
 - **Supporting** — operational/maintenance work with a clear reason to exist but no direct
   goal metric.


### PR DESCRIPTION
Fixes the two P2 findings Codex raised on #81 (both valid):

1. **Alignment scoring gated on goals existing** — with no `pulse/goals.html`, every workflow was classified Unaligned → spurious attach/retire suggestions every daily pass. Now skips per-workflow alignment when no goals file; the create-goals suggestion covers it.
2. **Goals edits count as fresh** — the cheap freshness gate now treats a created/edited `pulse/goals.html` as a change, so a goals edit on an otherwise-idle day still re-scores.

Prose-only, agentic (no deterministic gates). Guidance test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)