### PR TITLE
ui: rename Workflow Builder → Automation Builder

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -388,7 +388,7 @@ const PHASE_CHAT_INFO: Record<string, {
   showStepTypes?: boolean
 }> = {
   'workflow-builder': {
-    title: 'Workflow Builder',
+    title: 'Automation Builder',
     description: 'Execute steps, update the plan, debug, generate learnings, tweak configs, manage schedules, and run evaluations — all in one conversation.',
     capabilities: [
       'Run any plan step in the background and poll for results',

--- a/frontend/src/components/GlobalActivityMonitor.tsx
+++ b/frontend/src/components/GlobalActivityMonitor.tsx
@@ -125,7 +125,7 @@ function displaySessionTitle(
       genericTabName === 'bot' ||
       genericTabName === 'whatsapp' ||
       genericTabName === 'slack'
-    if (tab?.name && tab.name !== 'Workflow Builder' && !tab.metadata?.isViewOnly && !tabNameIsTypeLabel) {
+    if (tab?.name && tab.name !== 'Automation Builder' && !tab.metadata?.isViewOnly && !tabNameIsTypeLabel) {
       return tab.name
     }
     return sessionTitle(session, workflow, fallbackWorkflowName)
@@ -658,7 +658,7 @@ export const GlobalActivityMonitor: React.FC = () => {
       {activityItems.map((item, i) => {
         if (item.type === 'builder-tab') {
           const builderBusy = item.tab.isStreaming || item.tab.isSyntheticTurn
-          const builderWorkflowName = (item.tab.name && item.tab.name !== 'Workflow Builder')
+          const builderWorkflowName = (item.tab.name && item.tab.name !== 'Automation Builder')
             ? item.tab.name
             : currentWorkflowPresetName
 

--- a/frontend/src/components/QuickSwitcher.tsx
+++ b/frontend/src/components/QuickSwitcher.tsx
@@ -603,10 +603,10 @@ export const QuickSwitcher: React.FC<QuickSwitcherProps> = ({
       } else {
         // No tabs for this preset yet — create an empty builder tab. WorkflowLayout
         // watches this state and offers workspace builder-history restore when present.
-        const tabId = await updatedChatStore.createChatTab('Workflow Builder', {
+        const tabId = await updatedChatStore.createChatTab('Automation Builder', {
           mode: 'workflow',
           phaseId: 'workflow-builder',
-          phaseName: 'Workflow Builder',
+          phaseName: 'Automation Builder',
           presetQueryId: item.preset.id,
         })
         activateTab(tabId)

--- a/frontend/src/components/workflow/CostsPopup.tsx
+++ b/frontend/src/components/workflow/CostsPopup.tsx
@@ -186,7 +186,7 @@ interface DailyStepCostEntry {
 
 const formatPhaseTitle = (phaseID: string) => {
   const phaseTitles: Record<string, string> = {
-    'workflow-builder': 'Workflow Builder',
+    'workflow-builder': 'Automation Builder',
     'report-execution': 'Report Execution',
     planning: 'Planning',
     'plan-improvement': 'Plan Improvement',
@@ -1193,7 +1193,7 @@ const CostsPopup: React.FC<CostsPopupProps> = ({
           daily.date,
           'builder:total',
           'builder',
-          'Workflow Builder',
+          'Automation Builder',
           'Builder'
         )
         Object.entries(daily.tokenUsage.by_model).forEach(([modelID, usage]) => {
@@ -1447,14 +1447,14 @@ const CostsPopup: React.FC<CostsPopupProps> = ({
                 </div>
               )}
 
-              {/* Workflow Builder / Phase Costs */}
+              {/* Automation Builder / Phase Costs */}
               {phaseCostSummary && (
                 <div className="bg-card border border-border rounded-lg p-4 shadow-sm">
                   <div className="flex items-start justify-between gap-4 mb-4">
                     <div>
                       <h3 className="text-sm font-semibold text-foreground mb-1 flex items-center gap-2">
                         <DollarSign className="w-4 h-4 text-amber-500" />
-                        Workflow Builder Costs
+                        Automation Builder Costs
                       </h3>
                       <p className="text-xs text-muted-foreground">
                         Costs captured outside run folders, including workflow builder and other phase-only sessions.
@@ -1479,7 +1479,7 @@ const CostsPopup: React.FC<CostsPopupProps> = ({
                     </div>
 
                     <div className="bg-card border border-border rounded-lg p-3">
-                      <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Workflow Builder</div>
+                      <div className="text-xs text-muted-foreground uppercase tracking-wider mb-1">Automation Builder</div>
                       <div className="text-2xl font-bold text-foreground">
                         {formatUSD(phaseCostSummary.phaseCosts.find(phase => phase.phaseID === 'workflow-builder')?.totalCost)}
                       </div>

--- a/frontend/src/components/workflow/WorkflowChatTabs.tsx
+++ b/frontend/src/components/workflow/WorkflowChatTabs.tsx
@@ -41,7 +41,7 @@ const WorkflowTabItem = React.memo<WorkflowTabItemProps>(({
   onMakeInteractive,
   onStop,
 }) => {
-  const displayName = tab.metadata?.phaseId === 'workflow-builder' && tab.name === 'Workflow Builder'
+  const displayName = tab.metadata?.phaseId === 'workflow-builder' && tab.name === 'Automation Builder'
     ? 'Chat'
     : tab.name
 
@@ -94,7 +94,7 @@ const WorkflowTabItem = React.memo<WorkflowTabItemProps>(({
         </button>
       )}
 
-      {/* Convert a read-only scheduled/bot run into an interactive Workflow Builder chat */}
+      {/* Convert a read-only scheduled/bot run into an interactive Automation Builder chat */}
       {tab.metadata?.isViewOnly && (tab.metadata?.isScheduledRun || tab.metadata?.isBotRun) && (
         <button
           type="button"
@@ -103,8 +103,8 @@ const WorkflowTabItem = React.memo<WorkflowTabItemProps>(({
             onMakeInteractive(tab.tabId)
           }}
           className="ml-0.5 rounded p-0.5 text-blue-600 opacity-80 hover:bg-blue-100 hover:opacity-100 dark:text-blue-300 dark:hover:bg-blue-900/40"
-          title="Interact in Workflow Builder"
-          aria-label="Interact in Workflow Builder"
+          title="Interact in Automation Builder"
+          aria-label="Interact in Automation Builder"
         >
           <MessageSquare className="w-3 h-3" />
         </button>
@@ -269,7 +269,7 @@ export const WorkflowChatTabs: React.FC<WorkflowChatTabsProps> = ({ onNewChat, e
     chatStore.setTabMetadata(tabId, {
       mode: 'workflow',
       phaseId: 'workflow-builder',
-      phaseName: 'Workflow Builder',
+      phaseName: 'Automation Builder',
       presetQueryId: tab.metadata?.presetQueryId,
       isViewOnly: false,
       isScheduledRun: false,
@@ -284,7 +284,7 @@ export const WorkflowChatTabs: React.FC<WorkflowChatTabsProps> = ({ onNewChat, e
       return {
         chatTabs: {
           ...state.chatTabs,
-          [tabId]: { ...current, name: 'Workflow Builder' },
+          [tabId]: { ...current, name: 'Automation Builder' },
         },
       }
     })

--- a/frontend/src/components/workflow/WorkflowLayout.tsx
+++ b/frontend/src/components/workflow/WorkflowLayout.tsx
@@ -315,10 +315,10 @@ const WorkflowPreviousChatsPanel: React.FC<{
       targetTab.metadata?.mode !== 'workflow' ||
       (activePresetId && targetPresetId && targetPresetId !== activePresetId)
     ) {
-      targetTabId = await chatStore.createChatTab('Workflow Builder', {
+      targetTabId = await chatStore.createChatTab('Automation Builder', {
         mode: 'workflow',
         phaseId: 'workflow-builder',
-        phaseName: 'Workflow Builder',
+        phaseName: 'Automation Builder',
         presetQueryId: activePresetId || undefined,
       })
       targetTab = useChatStore.getState().chatTabs[targetTabId]
@@ -332,7 +332,7 @@ const WorkflowPreviousChatsPanel: React.FC<{
     if (activePresetId && targetTab.metadata?.presetQueryId !== activePresetId) {
       chatStore.setTabMetadata(targetTabId, {
         phaseId: targetTab.metadata?.phaseId || 'workflow-builder',
-        phaseName: targetTab.metadata?.phaseName || 'Workflow Builder',
+        phaseName: targetTab.metadata?.phaseName || 'Automation Builder',
         presetQueryId: activePresetId,
       })
     }
@@ -926,10 +926,10 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
       await chatStore.closeTab(tab.tabId, false)
     }
 
-    const tabId = await chatStore.createChatTab('Workflow Builder', {
+    const tabId = await chatStore.createChatTab('Automation Builder', {
       mode: 'workflow',
       phaseId: 'workflow-builder',
-      phaseName: 'Workflow Builder',
+      phaseName: 'Automation Builder',
       presetQueryId: presetId
     })
     chatStore.switchTab(tabId)
@@ -1519,7 +1519,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
           }
           if (!phaseId && s.title) {
             // Fallback: try to extract from title
-            const match = s.title.match(/(?:workflow[- ]builder|planning|evaluation[- ]builder)/i)
+            const match = s.title.match(/(?:(?:workflow|automation)[- ]builder|planning|evaluation[- ]builder)/i)
             if (match) phaseId = match[0].toLowerCase().replace(/\s/g, '-')
           }
           sessionsToRestore.push({
@@ -1587,7 +1587,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
           //   3. Fallback to "Schedule" / "Bot" when we know the trigger,
           //      so a scheduled run reconnected on app boot doesn't get
           //      labelled the literal "Workflow"
-          //   4. Last resort: phaseId / "Workflow Builder" (so the chat
+          //   4. Last resort: phaseId / "Automation Builder" (so the chat
           //      input gating in WorkflowChatTabs treats it as the
           //      builder tab and shows the proper "Chat" label)
           let phaseName: string
@@ -1598,7 +1598,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
           } else if (session.botPlatform) {
             phaseName = session.botPlatform
           } else {
-            phaseName = phaseId || 'Workflow Builder'
+            phaseName = phaseId || 'Automation Builder'
           }
 
           // Create tab with scheduled-run / bot metadata so downstream
@@ -1656,10 +1656,10 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
           if (interactiveExistingWorkflowTabs.length === 0) {
             const excludedSessionIds = new Set(activeSessionIds)
             const latestSavedChat = await findLatestRestorableWorkflowChatSession(workspacePath, excludedSessionIds)
-            const defaultTabId = await createChatTab('Workflow Builder', {
+            const defaultTabId = await createChatTab('Automation Builder', {
               mode: 'workflow',
               phaseId: 'workflow-builder',
-              phaseName: 'Workflow Builder',
+              phaseName: 'Automation Builder',
               presetQueryId: activePresetId
             }, latestSavedChat?.session_id)
             if (latestSavedChat) {
@@ -1981,7 +1981,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
     setShowChatArea(true)
   }, [activePresetId, setCurrentWorkflowPhase, setShowChatArea, getPhaseById, setWorkflowWorkspaceView])
 
-  // Handle create plan - always opens Workflow Builder.
+  // Handle create plan - always opens Automation Builder.
   const handleCreatePlan = useCallback(() => {
     // Ensure we're in workflow mode before creating plan (only if we have an active preset)
     if (activePresetId) {

--- a/frontend/src/stores/useWorkflowStore.ts
+++ b/frontend/src/stores/useWorkflowStore.ts
@@ -705,7 +705,7 @@ export const useWorkflowStore = create<WorkflowStore>()(
         return phases.length > 0 ? phases[0].id : 'planning'
       },
 
-      // Get phases that can work on individual steps (currently none — use Workflow Builder instead)
+      // Get phases that can work on individual steps (currently none — use Automation Builder instead)
       getStepSpecificPhases: () => {
         return []
       },

--- a/frontend/src/utils/workflowSessionRestore.ts
+++ b/frontend/src/utils/workflowSessionRestore.ts
@@ -143,7 +143,7 @@ export async function restoreWorkflowSessionChat(
     if (
       existingTab?.metadata?.mode === 'workflow' &&
       existingTab.metadata?.phaseId === 'workflow-builder' &&
-      existingTab.name !== 'Workflow Builder'
+      existingTab.name !== 'Automation Builder'
     ) {
       await chatStore.closeTab(existingTab.tabId, false)
     }
@@ -167,10 +167,10 @@ export async function restoreWorkflowSessionChat(
         : undefined
     )
 
-    const tabId = builderTab?.tabId ?? await latestChatStore.createChatTab('Workflow Builder', {
+    const tabId = builderTab?.tabId ?? await latestChatStore.createChatTab('Automation Builder', {
       mode: 'workflow',
       phaseId: 'workflow-builder',
-      phaseName: 'Workflow Builder',
+      phaseName: 'Automation Builder',
       presetQueryId: presetId,
     }, session.session_id)
 


### PR DESCRIPTION
Completes the Workflow→Automations rename — the last UI surface still saying "Workflow."

"Workflow Builder" (with a space) is never an identifier, so the literal phrase is replaced across all 30 occurrences (display, `tab.name` value, `=== 'Workflow Builder'` comparisons, `createChatTab`, `phaseName`). The lowercase `workflow-builder` phaseId stays untouched (code value). The title-matching regex now matches `(?:workflow|automation)[- ]builder` so existing persisted tabs still resolve. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)