### PR TITLE
fix: re-enable api-bridge tools when resuming a stopped scheduled run

### DIFF
--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -2508,6 +2508,12 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 	// This must happen AFTER session reactivation and BEFORE workshop creation,
 	// so the workshop code path sees a clean slate.
 	api.clearSessionStopped(sessionID)
+	// Also lift the registry-level zombie-prevention flag. A scheduled/workflow run
+	// stopped via the stop icon marks its MCP session IDs "stopped" (CloseHTTPSession);
+	// without clearing them here, an intentional resume reuses the same coding-agent
+	// bridge session, the registry refuses its connections, and its api-bridge tools
+	// read as "No such tool available" until a full reload.
+	mcpagent.ClearHTTPSessionStopped(sessionID)
 
 	// Track active session for page refresh recovery (no observer needed)
 	api.trackActiveSession(sessionID, req.AgentMode, req.Query, currentUserID, req.BotPlatform, req.TriggeredBy)


### PR DESCRIPTION
**Repro:** stop a scheduled coding-agent run via the stop icon, then talk to the session → `No such tool available: mcp__api-bridge__execute_shell_command` for all api-bridge tools until a full reload.

**Cause:** `handleStopSession` → `CloseHTTPSession` marks the run's MCP session IDs *stopped* (zombie prevention) and never clears them. The interactive resume reuses the same coding-agent bridge session; the registry refuses its connections, so the CLI's api-bridge tools read as unavailable. `handleQuery` cleared only the API-level guard, not the registry flag.

**Fix:** pair `api.clearSessionStopped` with `mcpagent.ClearHTTPSessionStopped(sessionID)` (added in mcpagent `efce7fa`) so an intentional resume lifts the registry flag and the bridge reconnects. Zombie prevention stays intact for leftover async/cancel paths (which carry no new user message). Cross-repo with mcpagent. Builds against mcpagent main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)