### PR TITLE
ui: org page 2-column (goals left/mobile, automations right)

### DIFF
--- a/frontend/src/components/WorkflowsOverviewPage.tsx
+++ b/frontend/src/components/WorkflowsOverviewPage.tsx
@@ -632,59 +632,50 @@ export const WorkflowsOverviewPage: React.FC = () => {
   return (
     <>
       <div className="h-full flex flex-col bg-white dark:bg-gray-900">
-        <div className="flex-1 min-h-0 overflow-auto">
-          <div className="mx-auto w-full max-w-[1400px] p-6 space-y-8">
-            {/* Header */}
-            <header className="flex items-center gap-3">
-              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-300">
-                <Building2 className="h-5 w-5" />
-              </div>
-              <div className="min-w-0">
-                <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Organization</h1>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Goals, automations, and the Chief of Staff that runs them.
-                </p>
-              </div>
-            </header>
-
-            {/* Goals section */}
-            <section className="space-y-3">
-              <div className="flex items-center gap-2">
-                <Target className="h-4 w-4 text-primary" />
-                <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                  Org Goals
-                </h2>
-              </div>
-              <div className="h-[420px] overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
-                <OrgGoalsPanel />
-              </div>
-            </section>
-
-            {/* Automations section */}
-            <section className="space-y-3">
-              <div className="flex items-center gap-2">
-                <Workflow className="h-4 w-4 text-primary" />
-                <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                  Automations
-                </h2>
-                {automationCount > 0 && (
-                  <span className="text-xs text-gray-400 dark:text-gray-500">
-                    {automationCount} total
-                  </span>
-                )}
-              </div>
-              <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
-                <WorkflowTable
-                  rows={rows}
-                  loading={loading}
-                  onOpenWorkflow={handleOpenWorkflow}
-                  onOpenLogs={popups.handleOpenLogs}
-                  onOpenEval={popups.handleOpenEval}
-                  onOpenCost={popups.handleOpenCost}
-                />
-              </div>
-            </section>
+        {/* Header */}
+        <header className="flex flex-none items-center gap-3 border-b border-gray-200 dark:border-gray-700 px-6 py-4">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-300">
+            <Building2 className="h-5 w-5" />
           </div>
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Organization</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Goals, automations, and the Chief of Staff that runs them.
+            </p>
+          </div>
+        </header>
+
+        {/* Two columns: Org Goals (left, mobile width) · Automations (right) */}
+        <div className="flex flex-1 min-h-0 flex-col lg:flex-row">
+          {/* Left: Org Goals — rendered in mobile width since the column is narrow */}
+          <aside className="h-[45vh] min-h-0 flex-none border-b border-gray-200 dark:border-gray-700 lg:h-auto lg:w-[420px] lg:border-b-0 lg:border-r">
+            <OrgGoalsPanel fixedDevice="mobile" />
+          </aside>
+
+          {/* Right: all Automations */}
+          <main className="min-h-0 flex-1 space-y-3 overflow-auto p-6">
+            <div className="flex items-center gap-2">
+              <Workflow className="h-4 w-4 text-primary" />
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                Automations
+              </h2>
+              {automationCount > 0 && (
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {automationCount} total
+                </span>
+              )}
+            </div>
+            <div className="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+              <WorkflowTable
+                rows={rows}
+                loading={loading}
+                onOpenWorkflow={handleOpenWorkflow}
+                onOpenLogs={popups.handleOpenLogs}
+                onOpenEval={popups.handleOpenEval}
+                onOpenCost={popups.handleOpenCost}
+              />
+            </div>
+          </main>
         </div>
       </div>
       <PopupGroup p={popups} />

--- a/frontend/src/components/org/OrgHtmlPanels.tsx
+++ b/frontend/src/components/org/OrgHtmlPanels.tsx
@@ -70,15 +70,18 @@ interface OrgHtmlPanelProps {
   Icon: React.ComponentType<{ className?: string }>
   toolbarLeading?: React.ReactNode
   onClosePanel?: () => void
+  // When set, the panel renders at this device width and hides the device toggle
+  // (used when embedded in a narrow column, e.g. the org page goals column).
+  fixedDevice?: OrgHtmlPreviewDevice
 }
 
 const toolbarIconBtnClass = 'inline-flex h-7 w-7 flex-none items-center justify-center rounded-lg border border-border bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50'
 
-const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, emptyText, Icon, toolbarLeading, onClosePanel }) => {
+const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, emptyText, Icon, toolbarLeading, onClosePanel, fixedDevice }) => {
   const [content, setContent] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [device, setDevice] = useState<OrgHtmlPreviewDevice>(() => getOrgHtmlPreviewDevice())
+  const [device, setDevice] = useState<OrgHtmlPreviewDevice>(() => fixedDevice ?? getOrgHtmlPreviewDevice())
   const { theme } = useTheme()
   const isDark = useMemo(() => {
     if (typeof document === 'undefined') return false
@@ -109,6 +112,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
 
   useEffect(() => { void load() }, [load])
   useEffect(() => {
+    if (fixedDevice) return // locked to fixedDevice — ignore the global preview preference
     const handler = (event: Event) => {
       const preference = (event as CustomEvent).detail?.preference
       if (preference === 'mobile' || preference === 'tablet' || preference === 'desktop') {
@@ -117,7 +121,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
     }
     window.addEventListener(ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT, handler)
     return () => window.removeEventListener(ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT, handler)
-  }, [])
+  }, [fixedDevice])
 
   const refresh = useCallback(() => {
     void load()
@@ -143,6 +147,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
           )}
         </div>
         <div className="flex flex-none items-center gap-1">
+          {!fixedDevice && (
           <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-muted/70 p-0.5 shadow-sm">
             {ORG_HTML_PREVIEW_DEVICE_OPTS.map(({ mode, Icon: DeviceIcon, label }) => (
               <button
@@ -159,6 +164,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
               </button>
             ))}
           </div>
+          )}
           <button type="button" onClick={refresh} disabled={loading} title="Refresh" aria-label="Refresh" className={toolbarIconBtnClass}>
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           </button>
@@ -189,7 +195,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
   )
 }
 
-export const OrgGoalsPanel: React.FC<{ toolbarLeading?: React.ReactNode; onClosePanel?: () => void }> = ({ toolbarLeading, onClosePanel }) => (
+export const OrgGoalsPanel: React.FC<{ toolbarLeading?: React.ReactNode; onClosePanel?: () => void; fixedDevice?: OrgHtmlPreviewDevice }> = ({ toolbarLeading, onClosePanel, fixedDevice }) => (
   <OrgHtmlPanel
     title="Org Goals"
     path={ORG_GOALS_PATH}
@@ -198,6 +204,7 @@ export const OrgGoalsPanel: React.FC<{ toolbarLeading?: React.ReactNode; onClose
     Icon={Target}
     toolbarLeading={toolbarLeading}
     onClosePanel={onClosePanel}
+    fixedDevice={fixedDevice}
   />
 )
 


### PR DESCRIPTION
Two-column org page: **Org Goals on the left** (rendered in mobile width since the column is narrow), **all Automations on the right**. Adds a `fixedDevice` prop to `OrgHtmlPanel`/`OrgGoalsPanel` that locks the preview device + hides the toggle; the org page passes `fixedDevice="mobile"`. Stacks vertically on small screens. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)