### PR TITLE
ui: org page default Goals + laptop-only (no device switcher)

### DIFF
--- a/frontend/src/components/EmployeeDashboard.tsx
+++ b/frontend/src/components/EmployeeDashboard.tsx
@@ -683,7 +683,7 @@ export const EmployeeDashboard: React.FC = () => {
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null)
-  const [orgView, setOrgView] = useState<'workflow' | 'goals' | 'pulse'>('workflow')
+  const [orgView, setOrgView] = useState<'workflow' | 'goals' | 'pulse'>('goals')
   const [reviewTab, setReviewTab] = useState<ReviewTab>('report')
   const [reviewState, setReviewState] = useState<WorkflowReviewState>(EMPTY_REVIEW_STATE)
   const [soulDocState, setSoulDocState] = useState<ImproveDocState>(EMPTY_SOUL_DOC_STATE)
@@ -1492,11 +1492,11 @@ export const EmployeeDashboard: React.FC = () => {
           <div className="lg:sticky lg:top-6 self-start">
             {orgView === 'goals' ? (
               <div className="h-[calc(100vh-160px)] min-h-[480px] overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-                <OrgGoalsPanel />
+                <OrgGoalsPanel fixedDevice="desktop" />
               </div>
             ) : orgView === 'pulse' ? (
               <div className="h-[calc(100vh-160px)] min-h-[480px] overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
-                <OrgPulsePanel />
+                <OrgPulsePanel fixedDevice="desktop" />
               </div>
             ) : (
             <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">

--- a/frontend/src/components/org/OrgHtmlPanels.tsx
+++ b/frontend/src/components/org/OrgHtmlPanels.tsx
@@ -208,7 +208,7 @@ export const OrgGoalsPanel: React.FC<{ toolbarLeading?: React.ReactNode; onClose
   />
 )
 
-export const OrgPulsePanel: React.FC<{ toolbarLeading?: React.ReactNode; onClosePanel?: () => void }> = ({ toolbarLeading, onClosePanel }) => (
+export const OrgPulsePanel: React.FC<{ toolbarLeading?: React.ReactNode; onClosePanel?: () => void; fixedDevice?: OrgHtmlPreviewDevice }> = ({ toolbarLeading, onClosePanel, fixedDevice }) => (
   <OrgHtmlPanel
     title="Org Pulse"
     path={ORG_PULSE_LOG_PATH}
@@ -217,6 +217,7 @@ export const OrgPulsePanel: React.FC<{ toolbarLeading?: React.ReactNode; onClose
     Icon={Activity}
     toolbarLeading={toolbarLeading}
     onClosePanel={onClosePanel}
+    fixedDevice={fixedDevice}
   />
 )
 


### PR DESCRIPTION
Org page opens on **Org Goals** by default, and the Goals/Pulse panels render in **laptop (desktop) width** with the mobile/tablet/desktop **switcher hidden** (`fixedDevice="desktop"`). Added `fixedDevice` to `OrgPulsePanel` to match `OrgGoalsPanel`. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)