### PR TITLE
fix: tmux terminal duplicate lines / scrollback loss when agent idle

### DIFF
--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -1125,6 +1125,28 @@ func mergeTmuxScreenSnapshot(snapshot Snapshot, next string) string {
 	if overlap >= len(nextLines) {
 		return existing
 	}
+	// Idle re-capture dedup: when the visible pane is polled repeatedly while a
+	// CLI sits at the prompt, only the bottom status line (timer/spinner/token
+	// count) changes between polls. That defeats the overlap and exact-contains
+	// checks above, so without this guard the whole pane would be appended again
+	// every poll. If the TAIL of the accumulated content is mostly the same as
+	// the incoming pane, this is a re-capture of the same visible pane: replace
+	// that tail in place with the fresh capture instead of appending a duplicate.
+	// This preserves any real scrollback that sits ABOVE the visible pane. When
+	// there is genuine new output (next mostly different from the tail), the
+	// tail is NOT mostly-same and we fall through to the overlap-based append.
+	if len(existingLines) >= len(nextLines) {
+		tailStart := len(existingLines) - len(nextLines)
+		if terminalScreensMostlySame(existingLines[tailStart:], nextLines) {
+			merged := make([]string, 0, tailStart+len(nextLines))
+			merged = append(merged, existingLines[:tailStart]...)
+			merged = append(merged, nextLines...)
+			if len(merged) > terminalAccumulatedScrollbackMaxLines {
+				merged = merged[len(merged)-terminalAccumulatedScrollbackMaxLines:]
+			}
+			return strings.Join(merged, "\n")
+		}
+	}
 	if terminalScreensMostlySame(existingLines, nextLines) && overlap < terminalSmallScreenOverlapThreshold(nextLines) {
 		return next
 	}

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -2686,3 +2686,129 @@ func TestStoreHandlesStatusLineUpdate(t *testing.T) {
 		t.Errorf("unrelated pane received provider label %q", other.Status.ProviderLabel)
 	}
 }
+
+// makeIdlePaneSnapshot builds a visible tmux pane whose bottom line is a status
+// line whose timer changes between captures (the only difference between polls).
+func makeIdlePaneStatus(timer string) string {
+	lines := []string{
+		"$ run coding agent",
+		"Reading project files...",
+		"  - main.go",
+		"  - store.go",
+		"Thinking about the task",
+		"Editing store.go",
+		"Applied 3 changes",
+		"Running tests",
+		"All tests passed",
+		"",
+		"",
+		"▸ working · " + timer + " · mcp-agent-XYZ",
+	}
+	return strings.Join(lines, "\n")
+}
+
+// TestMergeTmuxScreenSnapshotDedupesIdleRecapture verifies that repeatedly
+// re-capturing the same visible pane while a CLI sits idle at the prompt — with
+// only the bottom status-line timer changing each poll — does NOT pile up
+// duplicate copies of the pane. Regression test for the idle-recapture
+// duplication bug in mergeTmuxScreenSnapshot.
+func TestMergeTmuxScreenSnapshotDedupesIdleRecapture(t *testing.T) {
+	content := makeIdlePaneStatus("0:03")
+	paneLines := strings.Count(content, "\n") + 1
+
+	for _, timer := range []string{"0:04", "0:05", "0:06", "0:07", "0:08"} {
+		snap := Snapshot{TmuxSession: "mlp-agy-idle", Content: content}
+		content = mergeTmuxScreenSnapshot(snap, makeIdlePaneStatus(timer))
+	}
+
+	gotLines := strings.Count(content, "\n") + 1
+	if gotLines > paneLines {
+		t.Fatalf("idle re-capture grew the buffer: started with %d pane lines, ended with %d lines (duplicate panes accumulated)\n---\n%s", paneLines, gotLines, content)
+	}
+
+	// The pane body must appear exactly once (no duplicated lines), and the
+	// latest status-line timer must be reflected.
+	if n := strings.Count(content, "Applied 3 changes"); n != 1 {
+		t.Fatalf("expected pane body line exactly once, found %d times:\n%s", n, content)
+	}
+	if !strings.Contains(content, "0:08") {
+		t.Fatalf("expected latest status-line timer 0:08 in merged content:\n%s", content)
+	}
+	if strings.Contains(content, "0:03") {
+		t.Fatalf("stale status-line timer 0:03 should have been replaced:\n%s", content)
+	}
+}
+
+// TestMergeTmuxScreenSnapshotPreservesScrollbackOnIdleRecapture verifies that
+// when real scrollback sits ABOVE the visible pane, an idle re-capture (changed
+// status line) replaces only the visible pane tail and preserves the scrollback
+// rather than collapsing the whole buffer down to just the latest pane.
+func TestMergeTmuxScreenSnapshotPreservesScrollbackOnIdleRecapture(t *testing.T) {
+	scrollback := make([]string, 0, 20)
+	for i := 0; i < 20; i++ {
+		scrollback = append(scrollback, "earlier log line "+strings.Repeat("x", i%3)+" #"+string(rune('A'+i)))
+	}
+	content := strings.Join(scrollback, "\n") + "\n" + makeIdlePaneStatus("0:03")
+	startLines := strings.Count(content, "\n") + 1
+
+	for _, timer := range []string{"0:04", "0:05", "0:06"} {
+		snap := Snapshot{TmuxSession: "mlp-agy-scroll", Content: content}
+		content = mergeTmuxScreenSnapshot(snap, makeIdlePaneStatus(timer))
+	}
+
+	endLines := strings.Count(content, "\n") + 1
+	if endLines != startLines {
+		t.Fatalf("scrollback+idle-recapture changed line count: start=%d end=%d (expected stable)\n%s", startLines, endLines, content)
+	}
+	// Scrollback above the pane must be preserved.
+	if !strings.Contains(content, "earlier log line ") || !strings.HasPrefix(content, scrollback[0]) {
+		t.Fatalf("scrollback was lost on idle re-capture; first line=%q\n%s", strings.SplitN(content, "\n", 2)[0], content)
+	}
+	if !strings.Contains(content, "0:06") {
+		t.Fatalf("expected latest status-line timer 0:06:\n%s", content)
+	}
+}
+
+// TestMergeTmuxScreenSnapshotAppendsRealNewOutput verifies that genuine new
+// output (a scrolled pane with brand-new lines, mostly different from the prior
+// tail) is appended via the overlap-based path — old content is retained and
+// the new lines are added.
+func TestMergeTmuxScreenSnapshotAppendsRealNewOutput(t *testing.T) {
+	existing := strings.Join([]string{
+		"line A",
+		"line B",
+		"line C",
+		"line D",
+		"line E",
+	}, "\n")
+
+	// Pane scrolled by 2: top two lines (A,B) scrolled off, two genuinely new
+	// lines (F,G) appeared at the bottom. The overlapping window is C,D,E.
+	next := strings.Join([]string{
+		"line C",
+		"line D",
+		"line E",
+		"line F",
+		"line G",
+	}, "\n")
+
+	snap := Snapshot{TmuxSession: "mlp-agy-scroll2", Content: existing}
+	merged := mergeTmuxScreenSnapshot(snap, next)
+
+	// Old content retained.
+	if !strings.Contains(merged, "line A") || !strings.Contains(merged, "line B") {
+		t.Fatalf("old content was dropped on real scroll:\n%s", merged)
+	}
+	// New lines appended.
+	if !strings.Contains(merged, "line F") || !strings.Contains(merged, "line G") {
+		t.Fatalf("new output was not appended on real scroll:\n%s", merged)
+	}
+	// Content grew (new lines added, not a no-op replace).
+	if got := strings.Count(merged, "\n") + 1; got <= strings.Count(existing, "\n")+1 {
+		t.Fatalf("expected merged content to grow with new output, got %d lines:\n%s", got, merged)
+	}
+	// The overlap window must not be duplicated.
+	if n := strings.Count(merged, "line C"); n != 1 {
+		t.Fatalf("overlap window duplicated: 'line C' appears %d times:\n%s", n, merged)
+	}
+}


### PR DESCRIPTION
When a coding-agent CLI is idle at the prompt, the visible pane is re-captured each poll; the changing bottom status line (timer/spinner) broke `mergeTmuxScreenSnapshot`'s overlap + contains dedup, so the whole pane was appended again every poll (**duplicate lines**), and the whole-buffer mostly-same check could **collapse scrollback**. All CLIs.

Fix: tail-dedup — if the last `len(next)` lines mostly match the new capture, replace that tail in place (keeping scrollback above) instead of appending. Real new output still appends. Tests added. `go test ./internal/terminals/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)