### PR TITLE
fix: serve tmux real scrollback when idle (one source of truth)

### DIFF
--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -199,7 +199,14 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 	}
 	if shouldCaptureTmux {
 		ctx, cancel := context.WithTimeout(r.Context(), terminalTmuxActionTimeout)
-		preserveScrollback := shouldPreserveCapturedTerminalScrollback(r)
+		// Only accumulate/merge captured snapshots while the pane is ACTIVE (live).
+		// Once it's idle/ended, captureTerminalPaneForDetail grabs tmux's full
+		// scrollback buffer directly — that IS the complete, correctly-formatted
+		// content, so merging it into the previously-accumulated snapshots only
+		// re-introduces duplicate lines and formatting drift. Use the real buffer
+		// as-is. (The merge heuristic only exists to fake scrollback from
+		// visible-pane snapshots during a live run.)
+		preserveScrollback := snapshot.Active && shouldPreserveCapturedTerminalScrollback(r)
 		var pipeContent string
 		var pipeStats terminalPaneCaptureStats
 		var havePipeContent bool


### PR DESCRIPTION
The durable fix for the recurring terminal corruption (fine while streaming → duplicate lines / wrong formatting once the agent stops).

**Cause:** two representations — live = the tmux stream (good); idle = content **reconstructed by merging capture-pane snapshots** (fragile, per-CLI edge cases). For an idle pane, `captureTerminalPaneForDetail` already grabs tmux's **full scrollback buffer**, but `preserveScrollback` stayed true so it got **merged** into the accumulated snapshots → duplicates + drift.

**Fix:** `preserveScrollback := snapshot.Active && shouldPreserveCapturedTerminalScrollback(r)`. Active panes still accumulate live; idle panes use the real captured buffer as-is. One source of truth = tmux's actual buffer; the merge heuristic no longer runs for the idle case. Build + terminal tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)