### PR TITLE
fix: tmux terminal duplicates + scroll snap (real root causes)

### DIFF
--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -210,7 +210,13 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 		var pipeContent string
 		var pipeStats terminalPaneCaptureStats
 		var havePipeContent bool
-		if shouldReadTerminalPipeRecorderForDetail(r) && api.terminalPipeRecorder != nil {
+		// Only use the pipe-pane recording (the appended live byte stream) while the
+		// pane is ACTIVE. Once the agent is idle/completed it keeps repainting its
+		// prompt/footer/spinner, and pipe-pane appends every one of those raw frames;
+		// replayed onto the seed buffer (different geometry) they land at the wrong
+		// rows and pile up as duplicate lines. For an idle pane fall through to the
+		// single static full-buffer capture-pane (-S) below, which renders once.
+		if snapshot.Active && shouldReadTerminalPipeRecorderForDetail(r) && api.terminalPipeRecorder != nil {
 			var ok bool
 			var pipeErr error
 			pipeContent, pipeStats, ok, pipeErr = api.terminalPipeRecorder.Content(ctx, snapshot, wantsHistoryTerminalContent(r))

--- a/agent_go/cmd/server/terminal_routes_test.go
+++ b/agent_go/cmd/server/terminal_routes_test.go
@@ -716,7 +716,7 @@ func TestTerminalRoutesGetTerminalCanHistoryRefreshSelectedPane(t *testing.T) {
 	}
 }
 
-func TestTerminalRoutesGetTerminalHistoryPrefersLongerPipeRecording(t *testing.T) {
+func TestTerminalRoutesGetTerminalHistoryIdlePaneUsesCaptureNotPipe(t *testing.T) {
 	store := terminals.NewStore()
 	sessionID := "session-terminal-pipe-history"
 	terminalID := sessionID + ":workflow-step:review-plan"
@@ -764,11 +764,15 @@ func TestTerminalRoutesGetTerminalHistoryPrefersLongerPipeRecording(t *testing.T
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatalf("decode history response: %v", err)
 	}
-	if response.Content != pipeContent {
-		t.Fatalf("terminal content = %q, want pipe content %q", response.Content, pipeContent)
+	// An idle/completed pane must NOT use the appended pipe recording (it
+	// accumulates duplicate repaint frames replayed on a mismatched seed buffer);
+	// it serves the static full-buffer capture instead. The pipe recording exists
+	// on disk here only to prove it is deliberately ignored once the pane is inactive.
+	if response.Content != "short pane" {
+		t.Fatalf("idle terminal content = %q, want capture %q", response.Content, "short pane")
 	}
-	if response.ContentSource != "tmux_pipe" {
-		t.Fatalf("content source = %q, want tmux_pipe", response.ContentSource)
+	if response.ContentSource == "tmux_pipe" {
+		t.Fatalf("idle pane used the pipe recording (source %q); want the static capture", response.ContentSource)
 	}
 }
 

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -2137,10 +2137,17 @@ const XtermTerminalPane: React.FC<{
         return
       }
       const nextBaseY = term.buffer.active.baseY
-      // When the user is reading older output, keep the absolute viewport line
-      // stable across live refreshes. Preserving distance-from-bottom would drag
-      // the viewport downward every time new accumulated screen lines append.
-      term.scrollToLine(Math.max(0, Math.min(previousViewportY, nextBaseY)))
+      // Append case: new lines land at the bottom and existing lines keep their
+      // absolute index, so preserve the absolute viewport line.
+      // Rebuild case (term.reset() on a non-append refresh): the capture is a
+      // bottom-anchored sliding window — old lines drop off the TOP, so absolute
+      // indices shift down each refresh. Pinning to the old absolute line drifts the
+      // view downward and, when the buffer gets shorter, clamps it to the bottom
+      // ("scroll works, then snaps"). Distance-from-bottom is the stable coordinate.
+      const targetLine = appendOnly
+        ? Math.min(previousViewportY, nextBaseY)
+        : nextBaseY - distanceFromBottom
+      term.scrollToLine(Math.max(0, targetLine))
     }
     const afterWrite = () => {
       restoreScroll()


### PR DESCRIPTION
Prior attempts touched a dead path (the viewer never runs the merge). The real causes:

**Dups (idle):** idle panes serve the **pipe-pane recording** (appended raw byte stream); the idle CLI repaints its prompt/footer/spinner and pipe-pane appends every frame → replayed on a mismatched seed buffer they duplicate. Fix: use the pipe recording **only while active**; idle panes use one static `capture-pane -S` (rendered once).

**Scroll snap:** `restoreScroll` re-pinned to the **absolute** old line, but the capture is a bottom-anchored sliding window (old lines drop off the top) → drifts down / clamps to bottom. Fix: absolute line for appends, **distance-from-bottom for rebuilds**.

Build + terminal tests + tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)