### PR TITLE
docs: clarify terminal viewer vs merge content paths

### DIFF
--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -198,6 +198,13 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 		)
 	}
 	if shouldCaptureTmux {
+		// This is the live terminal viewer's content path. Its sources, by state:
+		//   - active + content=screen  → captureTerminalVisiblePaneWithStats (visible pane)
+		//   - active + content=history → the pipe-pane recording (live byte stream)
+		//   - idle                     → captureTerminalPaneForDetail = capture-pane -S (full buffer)
+		// It uses ReplaceContentWithSource, NOT the mergeTmuxScreenSnapshot accumulation
+		// (that path serves only the query_step poller + streaming accumulation). If the
+		// viewer shows wrong/duplicate content, fix it HERE, not in the merge.
 		ctx, cancel := context.WithTimeout(r.Context(), terminalTmuxActionTimeout)
 		// Only accumulate/merge captured snapshots while the pane is ACTIVE (live).
 		// Once it's idle/ended, captureTerminalPaneForDetail grabs tmux's full

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -1103,6 +1103,18 @@ func terminalContentExtends(existing, next string) bool {
 	return strings.HasPrefix(next, existing)
 }
 
+// mergeTmuxScreenSnapshot accumulates a polled visible-pane capture onto the
+// stored snapshot content (reconstructing scrollback from snapshots).
+//
+// IMPORTANT — the live terminal *viewer* does NOT go through this path. The
+// viewer (handleGetTerminal) serves the pipe-pane recording while the pane is
+// ACTIVE and a static `capture-pane -S` full buffer once it is idle; it never
+// merges. This merge runs only for:
+//   - the query_step agent-context poller (via RefreshContent), and
+//   - the live streaming-event accumulation (HandleEvent),
+// and its output is used as the capture-failure fallback + the terminal-list
+// content — never as the viewer's rendered content. Do NOT "fix" viewer
+// formatting/duplication here; it is the wrong path (see terminal_routes.go).
 func mergeTmuxScreenSnapshot(snapshot Snapshot, next string) string {
 	if !shouldAccumulateTmuxScreenSnapshot(snapshot, next) {
 		return next


### PR DESCRIPTION
Documents the two terminal content seams that repeatedly misled debugging: `mergeTmuxScreenSnapshot` (serves only the query_step poller + streaming accumulation, NOT the viewer) and `handleGetTerminal` (the viewer's real sources: visible pane / pipe recording / `capture-pane -S` by state; uses Replace, not the merge). Comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)