### PR TITLE
refactor: remove redundant tmux snapshot-merge accumulation

### DIFF
--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -202,18 +202,10 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 		//   - active + content=screen  → captureTerminalVisiblePaneWithStats (visible pane)
 		//   - active + content=history → the pipe-pane recording (live byte stream)
 		//   - idle                     → captureTerminalPaneForDetail = capture-pane -S (full buffer)
-		// It uses ReplaceContentWithSource, NOT the mergeTmuxScreenSnapshot accumulation
-		// (that path serves only the query_step poller + streaming accumulation). If the
-		// viewer shows wrong/duplicate content, fix it HERE, not in the merge.
+		// It always stores the latest capture via ReplaceContentWithSource — the
+		// store keeps the latest content only, with no snapshot accumulation. If the
+		// viewer shows wrong/duplicate content, fix it HERE.
 		ctx, cancel := context.WithTimeout(r.Context(), terminalTmuxActionTimeout)
-		// Only accumulate/merge captured snapshots while the pane is ACTIVE (live).
-		// Once it's idle/ended, captureTerminalPaneForDetail grabs tmux's full
-		// scrollback buffer directly — that IS the complete, correctly-formatted
-		// content, so merging it into the previously-accumulated snapshots only
-		// re-introduces duplicate lines and formatting drift. Use the real buffer
-		// as-is. (The merge heuristic only exists to fake scrollback from
-		// visible-pane snapshots during a live run.)
-		preserveScrollback := snapshot.Active && shouldPreserveCapturedTerminalScrollback(r)
 		var pipeContent string
 		var pipeStats terminalPaneCaptureStats
 		var havePipeContent bool
@@ -246,18 +238,12 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 			haveDisplayContent = havePipeContent && shouldUseTerminalPipeContentForDetail(r, pipeStats, stats)
 			if debugTerminal {
 				runtimeStats, haveRuntimeStats = inspectTerminalPaneRuntimeStats(ctx, snapshot.TmuxSession)
-				writeTerminalDebugHeaders(w, stats, preserveScrollback, runtimeStats, haveRuntimeStats)
+				writeTerminalDebugHeaders(w, stats, runtimeStats, haveRuntimeStats)
 				if haveDisplayContent {
 					terminalPipeRecorderDebugHeaders(w, displayStats)
 				}
 			}
-			var refreshed terminals.Snapshot
-			var ok bool
-			if preserveScrollback {
-				refreshed, ok = api.terminalStore.RefreshContentWithSource(snapshot.TerminalID, content, stats.ContentSource)
-			} else {
-				refreshed, ok = api.terminalStore.ReplaceContentWithSource(snapshot.TerminalID, content, stats.ContentSource)
-			}
+			refreshed, ok := api.terminalStore.ReplaceContentWithSource(snapshot.TerminalID, content, stats.ContentSource)
 			if ok {
 				snapshot = refreshed
 			}
@@ -275,7 +261,7 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 				snapshot.ContentSource = stats.ContentSource
 			}
 			if debugTerminal {
-				log.Printf("[TERMINAL_DEBUG] capture ok source=%q terminal_id=%q tmux_session=%q requested_lines=%d capture_lines=%d raw_lines=%d raw_bytes=%d collapsed_lines=%d collapsed_bytes=%d duration_ms=%d preserve_scrollback=%t content_source=%q display_bytes=%d refreshed_chunk=%d history_limit=%q history_size=%q alternate_on=%q pane_height=%q pane_width=%q pane_in_mode=%q scroll_position=%q",
+				log.Printf("[TERMINAL_DEBUG] capture ok source=%q terminal_id=%q tmux_session=%q requested_lines=%d capture_lines=%d raw_lines=%d raw_bytes=%d collapsed_lines=%d collapsed_bytes=%d duration_ms=%d content_source=%q display_bytes=%d refreshed_chunk=%d history_limit=%q history_size=%q alternate_on=%q pane_height=%q pane_width=%q pane_in_mode=%q scroll_position=%q",
 					debugSource,
 					snapshot.TerminalID,
 					snapshot.TmuxSession,
@@ -286,7 +272,6 @@ func (api *StreamingAPI) handleGetTerminal(w http.ResponseWriter, r *http.Reques
 					stats.CollapsedLines,
 					stats.CollapsedBytes,
 					stats.Duration.Milliseconds(),
-					preserveScrollback,
 					snapshot.ContentSource,
 					displayStats.RawBytes,
 					snapshot.ChunkIndex,
@@ -374,13 +359,6 @@ func terminalCaptureSkipReason(snapshot terminals.Snapshot, r *http.Request, sho
 		return "active_without_screen_or_history_request"
 	}
 	return "capture_not_requested"
-}
-
-func shouldPreserveCapturedTerminalScrollback(r *http.Request) bool {
-	if wantsScreenTerminalContent(r) {
-		return false
-	}
-	return !wantsHistoryTerminalContent(r)
 }
 
 func captureTerminalPaneForDetail(ctx context.Context, snapshot terminals.Snapshot, r *http.Request) (string, terminalPaneCaptureStats, error) {
@@ -887,7 +865,7 @@ func inspectTerminalPaneRuntimeStats(ctx context.Context, tmuxSession string) (t
 	}, true
 }
 
-func writeTerminalDebugHeaders(w http.ResponseWriter, stats terminalPaneCaptureStats, preserveScrollback bool, runtimeStats terminalPaneRuntimeStats, haveRuntimeStats bool) {
+func writeTerminalDebugHeaders(w http.ResponseWriter, stats terminalPaneCaptureStats, runtimeStats terminalPaneRuntimeStats, haveRuntimeStats bool) {
 	w.Header().Set("X-Runloop-Terminal-Content-Source", stats.ContentSource)
 	w.Header().Set("X-Runloop-Terminal-Requested-Lines", strconv.Itoa(stats.RequestedLines))
 	w.Header().Set("X-Runloop-Terminal-Capture-Lines", strconv.Itoa(stats.CaptureLines))
@@ -895,7 +873,9 @@ func writeTerminalDebugHeaders(w http.ResponseWriter, stats terminalPaneCaptureS
 	w.Header().Set("X-Runloop-Terminal-Raw-Bytes", strconv.Itoa(stats.RawBytes))
 	w.Header().Set("X-Runloop-Terminal-Collapsed-Lines", strconv.Itoa(stats.CollapsedLines))
 	w.Header().Set("X-Runloop-Terminal-Collapsed-Bytes", strconv.Itoa(stats.CollapsedBytes))
-	w.Header().Set("X-Runloop-Terminal-Preserve-Scrollback", strconv.FormatBool(preserveScrollback))
+	// Scrollback accumulation was removed; the store now always keeps the latest
+	// capture only. The header is retained (always false) for compatibility.
+	w.Header().Set("X-Runloop-Terminal-Preserve-Scrollback", strconv.FormatBool(false))
 	if !haveRuntimeStats {
 		return
 	}

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -109,8 +109,6 @@ type Store struct {
 const terminalInactiveAfter = 2 * time.Minute
 const terminalPromptCompletionInactiveAfter = time.Minute
 const terminalToolTextMaxRunes = 2400
-const terminalShortPaneSnapshotMaxLines = 160
-const terminalAccumulatedScrollbackMaxLines = 10000
 
 var (
 	regexpMCPToken    = regexp.MustCompile(`(?i)(MCP_API_TOKEN=)[^\s"'\\]+`)
@@ -411,9 +409,10 @@ func (s *Store) markTerminalState(terminalID, state string) (Snapshot, bool) {
 	return snapshot, true
 }
 
-// RefreshContent replaces the terminal pane content from an operator-requested
-// tmux capture. It keeps manual inactive overrides inactive, but otherwise lets
-// the same lifecycle heuristics classify the refreshed pane.
+// RefreshContent stores the latest terminal pane content from an
+// operator-requested tmux capture. It keeps manual inactive overrides inactive,
+// but otherwise lets the same lifecycle heuristics classify the refreshed pane.
+// It simply replaces the stored content (no snapshot accumulation).
 func (s *Store) RefreshContent(terminalID, content string) (Snapshot, bool) {
 	return s.RefreshContentWithSource(terminalID, content, "")
 }
@@ -421,11 +420,11 @@ func (s *Store) RefreshContent(terminalID, content string) (Snapshot, bool) {
 // RefreshContentWithSource is RefreshContent plus a display-source marker used
 // by the UI to keep retained tmux snapshots on the xterm rendering path.
 func (s *Store) RefreshContentWithSource(terminalID, content, contentSource string) (Snapshot, bool) {
-	return s.refreshContent(terminalID, content, contentSource, true)
+	return s.refreshContent(terminalID, content, contentSource)
 }
 
-// ReplaceContent refreshes a terminal pane with an authoritative capture. Unlike
-// RefreshContent, it does not preserve previously accumulated screen snapshots.
+// ReplaceContent refreshes a terminal pane with an authoritative capture,
+// storing the latest content. It is identical to RefreshContent.
 func (s *Store) ReplaceContent(terminalID, content string) (Snapshot, bool) {
 	return s.ReplaceContentWithSource(terminalID, content, "")
 }
@@ -433,7 +432,7 @@ func (s *Store) ReplaceContent(terminalID, content string) (Snapshot, bool) {
 // ReplaceContentWithSource is ReplaceContent plus a display-source marker used
 // by the UI to keep retained tmux snapshots on the xterm rendering path.
 func (s *Store) ReplaceContentWithSource(terminalID, content, contentSource string) (Snapshot, bool) {
-	return s.refreshContent(terminalID, content, contentSource, false)
+	return s.refreshContent(terminalID, content, contentSource)
 }
 
 func (s *Store) SetDisplayContent(terminalID, content, contentSource string) (Snapshot, bool) {
@@ -467,7 +466,7 @@ func (s *Store) SetDisplayContent(terminalID, content, contentSource string) (Sn
 	return snapshot, true
 }
 
-func (s *Store) refreshContent(terminalID, content, contentSource string, preserveTmuxScrollback bool) (Snapshot, bool) {
+func (s *Store) refreshContent(terminalID, content, contentSource string) (Snapshot, bool) {
 	terminalID = strings.TrimSpace(terminalID)
 	if s == nil || terminalID == "" {
 		return Snapshot{}, false
@@ -481,15 +480,8 @@ func (s *Store) refreshContent(terminalID, content, contentSource string, preser
 	}
 	now := time.Now()
 	lifecycleContent := content
-	nextContent := content
-	if preserveTmuxScrollback {
-		nextContent = mergeTmuxScreenSnapshot(snapshot, content)
-	}
-	if strings.TrimSpace(lifecycleContent) == "" {
-		lifecycleContent = nextContent
-	}
-	contentChanged := snapshot.Content != nextContent
-	snapshot.Content = nextContent
+	contentChanged := snapshot.Content != content
+	snapshot.Content = content
 	if contentChanged {
 		snapshot.ChunkIndex++
 	}
@@ -651,7 +643,6 @@ func (s *Store) upsertTerminal(sessionID string, event storeevents.Event, metada
 	current.StepTransport = firstNonEmpty(stringValue(metadata, "step_transport"), current.StepTransport)
 	current.StepTriggeredBy = firstNonEmpty(stringValue(metadata, "step_triggered_by"), current.StepTriggeredBy)
 	current.AgentName = firstNonEmpty(stringValue(metadata, "agent_name"), stringValue(metadata, "orchestrator_agent_name"), current.AgentName)
-	previousTmuxSession := current.TmuxSession
 	current.TmuxSession = firstNonEmpty(
 		stringValue(metadata, "tmux_session"),
 		stringValue(metadata, "tmux_session_name"),
@@ -663,9 +654,6 @@ func (s *Store) upsertTerminal(sessionID string, event storeevents.Event, metada
 	)
 	content = s.contentWithToolLinesLocked(terminalID, content)
 	lifecycleContent := content
-	if exists && !freshTurn && strings.TrimSpace(previousTmuxSession) != "" && strings.TrimSpace(previousTmuxSession) == strings.TrimSpace(current.TmuxSession) {
-		content = mergeTmuxScreenSnapshot(current, content)
-	}
 	contentChanged := !exists || current.Content != content
 	current.Content = content
 	if rows := terminalRowsFromMetadata(metadata); len(rows) > 0 {
@@ -1101,207 +1089,6 @@ func terminalContentExtends(existing, next string) bool {
 		return false
 	}
 	return strings.HasPrefix(next, existing)
-}
-
-// mergeTmuxScreenSnapshot accumulates a polled visible-pane capture onto the
-// stored snapshot content (reconstructing scrollback from snapshots).
-//
-// IMPORTANT — the live terminal *viewer* does NOT go through this path. The
-// viewer (handleGetTerminal) serves the pipe-pane recording while the pane is
-// ACTIVE and a static `capture-pane -S` full buffer once it is idle; it never
-// merges. This merge runs only for:
-//   - the query_step agent-context poller (via RefreshContent), and
-//   - the live streaming-event accumulation (HandleEvent),
-// and its output is used as the capture-failure fallback + the terminal-list
-// content — never as the viewer's rendered content. Do NOT "fix" viewer
-// formatting/duplication here; it is the wrong path (see terminal_routes.go).
-func mergeTmuxScreenSnapshot(snapshot Snapshot, next string) string {
-	if !shouldAccumulateTmuxScreenSnapshot(snapshot, next) {
-		return next
-	}
-	existing := strings.TrimRight(snapshot.Content, "\n")
-	next = strings.TrimRight(next, "\n")
-	if existing == "" || next == "" {
-		return next
-	}
-	if existing == next || terminalContentExtends(next, existing) || terminalContentContainsScreen(existing, next) {
-		return existing
-	}
-	if terminalContentExtends(existing, next) {
-		return next
-	}
-
-	existingLines := strings.Split(existing, "\n")
-	nextLines := strings.Split(next, "\n")
-	overlap := terminalLineOverlap(existingLines, nextLines)
-	if overlap >= len(nextLines) {
-		return existing
-	}
-	// Idle re-capture dedup: when the visible pane is polled repeatedly while a
-	// CLI sits at the prompt, only the bottom status line (timer/spinner/token
-	// count) changes between polls. That defeats the overlap and exact-contains
-	// checks above, so without this guard the whole pane would be appended again
-	// every poll. If the TAIL of the accumulated content is mostly the same as
-	// the incoming pane, this is a re-capture of the same visible pane: replace
-	// that tail in place with the fresh capture instead of appending a duplicate.
-	// This preserves any real scrollback that sits ABOVE the visible pane. When
-	// there is genuine new output (next mostly different from the tail), the
-	// tail is NOT mostly-same and we fall through to the overlap-based append.
-	if len(existingLines) >= len(nextLines) {
-		tailStart := len(existingLines) - len(nextLines)
-		if terminalScreensMostlySame(existingLines[tailStart:], nextLines) {
-			merged := make([]string, 0, tailStart+len(nextLines))
-			merged = append(merged, existingLines[:tailStart]...)
-			merged = append(merged, nextLines...)
-			if len(merged) > terminalAccumulatedScrollbackMaxLines {
-				merged = merged[len(merged)-terminalAccumulatedScrollbackMaxLines:]
-			}
-			return strings.Join(merged, "\n")
-		}
-	}
-	if terminalScreensMostlySame(existingLines, nextLines) && overlap < terminalSmallScreenOverlapThreshold(nextLines) {
-		return next
-	}
-	merged := append(existingLines, nextLines[overlap:]...)
-	if len(merged) > terminalAccumulatedScrollbackMaxLines {
-		merged = merged[len(merged)-terminalAccumulatedScrollbackMaxLines:]
-	}
-	return strings.Join(merged, "\n")
-}
-
-func shouldAccumulateTmuxScreenSnapshot(snapshot Snapshot, next string) bool {
-	if strings.TrimSpace(snapshot.TmuxSession) == "" {
-		return false
-	}
-	if strings.TrimSpace(snapshot.Content) == "" || strings.TrimSpace(next) == "" {
-		return false
-	}
-	if terminalContentLineCount(next) > terminalShortPaneSnapshotMaxLines {
-		return false
-	}
-	return true
-}
-
-func terminalContentContainsScreen(existing, screen string) bool {
-	existingLines := terminalCanonicalLines(existing)
-	screenLines := terminalCanonicalLines(screen)
-	if len(existingLines) == 0 || len(screenLines) == 0 || len(screenLines) > len(existingLines) {
-		return false
-	}
-	for start := 0; start <= len(existingLines)-len(screenLines); start++ {
-		matched := true
-		for i := range screenLines {
-			if existingLines[start+i] != screenLines[i] {
-				matched = false
-				break
-			}
-		}
-		if matched {
-			return true
-		}
-	}
-	return false
-}
-
-func terminalLineOverlap(existingLines, nextLines []string) int {
-	maxOverlap := len(nextLines)
-	if len(existingLines) < maxOverlap {
-		maxOverlap = len(existingLines)
-	}
-	for overlap := maxOverlap; overlap > 0; overlap-- {
-		matched := true
-		for i := 0; i < overlap; i++ {
-			if terminalCanonicalLine(existingLines[len(existingLines)-overlap+i]) != terminalCanonicalLine(nextLines[i]) {
-				matched = false
-				break
-			}
-		}
-		if matched {
-			return overlap
-		}
-	}
-	return 0
-}
-
-func terminalSmallScreenOverlapThreshold(nextLines []string) int {
-	threshold := len(nextLines) / 2
-	if threshold < 2 {
-		return 1
-	}
-	if threshold > 3 {
-		return 3
-	}
-	return threshold
-}
-
-func terminalScreensMostlySame(existingLines, nextLines []string) bool {
-	existing := terminalMeaningfulCanonicalLines(existingLines)
-	next := terminalMeaningfulCanonicalLines(nextLines)
-	minLen := len(existing)
-	if len(next) < minLen {
-		minLen = len(next)
-	}
-	if minLen < 4 {
-		return false
-	}
-	common := terminalLineLCS(existing, next)
-	return common*3 >= minLen*2
-}
-
-func terminalMeaningfulCanonicalLines(lines []string) []string {
-	out := make([]string, 0, len(lines))
-	for _, line := range lines {
-		canonical := strings.TrimSpace(terminalCanonicalLine(line))
-		if canonical != "" {
-			out = append(out, canonical)
-		}
-	}
-	return out
-}
-
-func terminalLineLCS(a, b []string) int {
-	if len(a) == 0 || len(b) == 0 {
-		return 0
-	}
-	prev := make([]int, len(b)+1)
-	curr := make([]int, len(b)+1)
-	for i := 1; i <= len(a); i++ {
-		for j := 1; j <= len(b); j++ {
-			if a[i-1] == b[j-1] {
-				curr[j] = prev[j-1] + 1
-			} else if prev[j] >= curr[j-1] {
-				curr[j] = prev[j]
-			} else {
-				curr[j] = curr[j-1]
-			}
-		}
-		prev, curr = curr, prev
-		for j := range curr {
-			curr[j] = 0
-		}
-	}
-	return prev[len(b)]
-}
-
-func terminalCanonicalLines(content string) []string {
-	raw := strings.Split(strings.TrimRight(content, "\n"), "\n")
-	lines := make([]string, 0, len(raw))
-	for _, line := range raw {
-		lines = append(lines, terminalCanonicalLine(line))
-	}
-	return lines
-}
-
-func terminalCanonicalLine(line string) string {
-	line = ansiEscapePattern.ReplaceAllString(line, "")
-	return strings.TrimRight(line, " \t\r")
-}
-
-func terminalContentLineCount(content string) int {
-	if content == "" {
-		return 0
-	}
-	return strings.Count(content, "\n") + 1
 }
 
 func dedupeCurrentMainAgentSnapshots(snapshots []Snapshot) []Snapshot {

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -1579,7 +1579,7 @@ func TestStoreRefreshContentDoesNotRefreshUpdatedAtWhenPaneUnchanged(t *testing.
 	}
 }
 
-func TestStoreAccumulatesShortTmuxScreenSnapshots(t *testing.T) {
+func TestStoreStoresLatestShortTmuxScreenSnapshot(t *testing.T) {
 	store := NewStore()
 	metadata := map[string]interface{}{"execution_kind": "main_agent", "scope": "main", "tmux_session": "mlp-claude-main-test"}
 	store.HandleEvent("session-1", terminalEventWithMetadata("main:session-1", "old answer\nshared prompt", 10, metadata, time.Now()))
@@ -1589,9 +1589,10 @@ func TestStoreAccumulatesShortTmuxScreenSnapshots(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected terminal snapshot")
 	}
-	want := "old answer\nshared prompt\nnew answer"
+	// Snapshot accumulation was removed: the store keeps the latest capture only.
+	want := "shared prompt\nnew answer"
 	if snapshot.Content != want {
-		t.Fatalf("content = %q, want accumulated scrollback %q", snapshot.Content, want)
+		t.Fatalf("content = %q, want latest snapshot %q", snapshot.Content, want)
 	}
 }
 
@@ -1629,7 +1630,7 @@ func TestStoreDoesNotAccumulateShortNonTmuxSnapshots(t *testing.T) {
 	}
 }
 
-func TestStoreRefreshContentPreservesShortTmuxScrollback(t *testing.T) {
+func TestStoreRefreshContentReplacesTmuxScrollback(t *testing.T) {
 	store := NewStore()
 	metadata := map[string]interface{}{"execution_kind": "workflow_step", "scope": "workflow_step", "tmux_session": "mlp-codex-cli-int-test"}
 	store.HandleEvent("session-1", terminalEventWithMetadata("exec-1", "old output\ncurrent prompt", 10, metadata, time.Now()))
@@ -1638,9 +1639,10 @@ func TestStoreRefreshContentPreservesShortTmuxScrollback(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected terminal snapshot")
 	}
-	want := "old output\ncurrent prompt\nfresh output"
+	// Snapshot accumulation was removed: RefreshContent stores the latest capture.
+	want := "current prompt\nfresh output"
 	if refreshed.Content != want {
-		t.Fatalf("content = %q, want accumulated scrollback %q", refreshed.Content, want)
+		t.Fatalf("content = %q, want replacement %q", refreshed.Content, want)
 	}
 }
 
@@ -2684,131 +2686,5 @@ func TestStoreHandlesStatusLineUpdate(t *testing.T) {
 	}
 	if other.Status.ProviderLabel == "agy-cli · claude-3-5-sonnet" {
 		t.Errorf("unrelated pane received provider label %q", other.Status.ProviderLabel)
-	}
-}
-
-// makeIdlePaneSnapshot builds a visible tmux pane whose bottom line is a status
-// line whose timer changes between captures (the only difference between polls).
-func makeIdlePaneStatus(timer string) string {
-	lines := []string{
-		"$ run coding agent",
-		"Reading project files...",
-		"  - main.go",
-		"  - store.go",
-		"Thinking about the task",
-		"Editing store.go",
-		"Applied 3 changes",
-		"Running tests",
-		"All tests passed",
-		"",
-		"",
-		"▸ working · " + timer + " · mcp-agent-XYZ",
-	}
-	return strings.Join(lines, "\n")
-}
-
-// TestMergeTmuxScreenSnapshotDedupesIdleRecapture verifies that repeatedly
-// re-capturing the same visible pane while a CLI sits idle at the prompt — with
-// only the bottom status-line timer changing each poll — does NOT pile up
-// duplicate copies of the pane. Regression test for the idle-recapture
-// duplication bug in mergeTmuxScreenSnapshot.
-func TestMergeTmuxScreenSnapshotDedupesIdleRecapture(t *testing.T) {
-	content := makeIdlePaneStatus("0:03")
-	paneLines := strings.Count(content, "\n") + 1
-
-	for _, timer := range []string{"0:04", "0:05", "0:06", "0:07", "0:08"} {
-		snap := Snapshot{TmuxSession: "mlp-agy-idle", Content: content}
-		content = mergeTmuxScreenSnapshot(snap, makeIdlePaneStatus(timer))
-	}
-
-	gotLines := strings.Count(content, "\n") + 1
-	if gotLines > paneLines {
-		t.Fatalf("idle re-capture grew the buffer: started with %d pane lines, ended with %d lines (duplicate panes accumulated)\n---\n%s", paneLines, gotLines, content)
-	}
-
-	// The pane body must appear exactly once (no duplicated lines), and the
-	// latest status-line timer must be reflected.
-	if n := strings.Count(content, "Applied 3 changes"); n != 1 {
-		t.Fatalf("expected pane body line exactly once, found %d times:\n%s", n, content)
-	}
-	if !strings.Contains(content, "0:08") {
-		t.Fatalf("expected latest status-line timer 0:08 in merged content:\n%s", content)
-	}
-	if strings.Contains(content, "0:03") {
-		t.Fatalf("stale status-line timer 0:03 should have been replaced:\n%s", content)
-	}
-}
-
-// TestMergeTmuxScreenSnapshotPreservesScrollbackOnIdleRecapture verifies that
-// when real scrollback sits ABOVE the visible pane, an idle re-capture (changed
-// status line) replaces only the visible pane tail and preserves the scrollback
-// rather than collapsing the whole buffer down to just the latest pane.
-func TestMergeTmuxScreenSnapshotPreservesScrollbackOnIdleRecapture(t *testing.T) {
-	scrollback := make([]string, 0, 20)
-	for i := 0; i < 20; i++ {
-		scrollback = append(scrollback, "earlier log line "+strings.Repeat("x", i%3)+" #"+string(rune('A'+i)))
-	}
-	content := strings.Join(scrollback, "\n") + "\n" + makeIdlePaneStatus("0:03")
-	startLines := strings.Count(content, "\n") + 1
-
-	for _, timer := range []string{"0:04", "0:05", "0:06"} {
-		snap := Snapshot{TmuxSession: "mlp-agy-scroll", Content: content}
-		content = mergeTmuxScreenSnapshot(snap, makeIdlePaneStatus(timer))
-	}
-
-	endLines := strings.Count(content, "\n") + 1
-	if endLines != startLines {
-		t.Fatalf("scrollback+idle-recapture changed line count: start=%d end=%d (expected stable)\n%s", startLines, endLines, content)
-	}
-	// Scrollback above the pane must be preserved.
-	if !strings.Contains(content, "earlier log line ") || !strings.HasPrefix(content, scrollback[0]) {
-		t.Fatalf("scrollback was lost on idle re-capture; first line=%q\n%s", strings.SplitN(content, "\n", 2)[0], content)
-	}
-	if !strings.Contains(content, "0:06") {
-		t.Fatalf("expected latest status-line timer 0:06:\n%s", content)
-	}
-}
-
-// TestMergeTmuxScreenSnapshotAppendsRealNewOutput verifies that genuine new
-// output (a scrolled pane with brand-new lines, mostly different from the prior
-// tail) is appended via the overlap-based path — old content is retained and
-// the new lines are added.
-func TestMergeTmuxScreenSnapshotAppendsRealNewOutput(t *testing.T) {
-	existing := strings.Join([]string{
-		"line A",
-		"line B",
-		"line C",
-		"line D",
-		"line E",
-	}, "\n")
-
-	// Pane scrolled by 2: top two lines (A,B) scrolled off, two genuinely new
-	// lines (F,G) appeared at the bottom. The overlapping window is C,D,E.
-	next := strings.Join([]string{
-		"line C",
-		"line D",
-		"line E",
-		"line F",
-		"line G",
-	}, "\n")
-
-	snap := Snapshot{TmuxSession: "mlp-agy-scroll2", Content: existing}
-	merged := mergeTmuxScreenSnapshot(snap, next)
-
-	// Old content retained.
-	if !strings.Contains(merged, "line A") || !strings.Contains(merged, "line B") {
-		t.Fatalf("old content was dropped on real scroll:\n%s", merged)
-	}
-	// New lines appended.
-	if !strings.Contains(merged, "line F") || !strings.Contains(merged, "line G") {
-		t.Fatalf("new output was not appended on real scroll:\n%s", merged)
-	}
-	// Content grew (new lines added, not a no-op replace).
-	if got := strings.Count(merged, "\n") + 1; got <= strings.Count(existing, "\n")+1 {
-		t.Fatalf("expected merged content to grow with new output, got %d lines:\n%s", got, merged)
-	}
-	// The overlap window must not be duplicated.
-	if n := strings.Count(merged, "line C"); n != 1 {
-		t.Fatalf("overlap window duplicated: 'line C' appears %d times:\n%s", n, merged)
 	}
 }


### PR DESCRIPTION
Removes the merge-reconstruction path (the source of the recurring terminal bugs). The viewer already serves fresh content (pipe recording active / `capture-pane -S` idle, stored via Replace), and the idle -S capture covers the capture-failure fallback — so the accumulation was dead weight.

Store collapses to **latest content only**: `refreshContent` drops `preserveTmuxScrollback` (Refresh == Replace now), the streaming merge is gone, the viewer always Replaces. Deleted ~11 heuristic functions + the merge size constants; kept `terminalContentExtends` (still used). Tests updated to latest-content semantics.

build · go vet · terminal tests all pass. No merge symbols remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)