### PR TITLE
ui: previous-chats landing fills pane; compact tabs only in rail

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,7 +98,7 @@ const hasOpenWorkspaceCollapsingPopup = () => {
 // Helper component to get observerId and render ChatArea
 // Always renders ChatArea (even without observerId) so header with mode/preset selectors is visible
 // Uses Zustand hooks to reactively update when tabs change
-const ChatAreaWithObserverId = forwardRef<ChatAreaRef, { onNewChat: () => void }>(({ onNewChat }, ref) => {
+const ChatAreaWithObserverId = forwardRef<ChatAreaRef, { onNewChat: () => void; previousChatsCompact?: boolean }>(({ onNewChat, previousChatsCompact }, ref) => {
   // Pass null (not undefined) when the active tab is a workflow tab so this hidden
   // instance doesn't steal SSE connections, polling, or queue processing from
   // WorkflowLayout's ChatArea which is the primary instance for workflow tabs.
@@ -113,6 +113,7 @@ const ChatAreaWithObserverId = forwardRef<ChatAreaRef, { onNewChat: () => void }
       ref={ref}
       onNewChat={onNewChat}
       tabId={activeTabId}
+      previousChatsCompact={previousChatsCompact}
     />
   )
 })
@@ -1624,6 +1625,7 @@ function App() {
                         <ChatAreaWithObserverId
                           ref={chatAreaRef}
                           onNewChat={startNewChat}
+                          previousChatsCompact={!layoutWorkspaceMinimized}
                         />
                       </div>
                       {!layoutWorkspaceMinimized && (

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -499,6 +499,10 @@ interface ChatAreaProps {
   // Pass null explicitly to disable all active behavior (SSE, polling, queue) — used when
   // this ChatArea instance is hidden behind another instance for the same tab.
   tabId?: string | null
+  // Multi-agent landing previous-chats panel: icon-only (compact) tabs when the
+  // chat sits in the narrow rail; labeled tabs when it fills the pane (org panel
+  // minimized). The panel always renders in fill mode so it scrolls in both.
+  previousChatsCompact?: boolean
 }
 
 // Ref interface for ChatArea component
@@ -518,7 +522,7 @@ let globalHasRestored = false
 
 // Inner component for chat area
 const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAreaRef>) => {
-  const { onNewChat, hideHeader = false, hideInput = false, compact = false, hidePhaseChatEmptyState = false, suppressTerminalPane = false, tabId } = props
+  const { onNewChat, hideHeader = false, hideInput = false, compact = false, hidePhaseChatEmptyState = false, suppressTerminalPane = false, tabId, previousChatsCompact = false } = props
   // null means "inactive — don't subscribe to any tab or run any effects"
   const isInactive = tabId === null
 
@@ -3110,7 +3114,8 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
                 emptyText="No previous chats yet."
                 onHasChatsChange={setHasPreviousNormalChats}
                 onSelectSession={handleResumePreviousChat}
-                compact
+                fill
+                compact={previousChatsCompact}
               />
             )}
             {/* Empty State - Show when no events and not in historical session.


### PR DESCRIPTION
Codex review #101 (P2 #2/#3): the multiagent previous-chats landing was hardcoded `compact` → `shrink-0` with no scroll when chat fills the pane (org minimized). Now always `fill` (scrolls in both layouts) and `compact` only in the 360px rail. Plumbed `previousChatsCompact = !layoutWorkspaceMinimized`. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)