### PR TITLE
fix: global Models at top; CoS delegation-tier in CoS heading

### DIFF
--- a/frontend/src/components/ChatTabs.tsx
+++ b/frontend/src/components/ChatTabs.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Plus, ArrowDown, ListTree, Terminal, Globe, DollarSign, CalendarClock } from 'lucide-react'
-import LlmTriggerButton from './topbar/LlmTriggerButton'
+import { Plus, ArrowDown, ListTree, Terminal, Globe, DollarSign, CalendarClock, SlidersHorizontal } from 'lucide-react'
 import { normalizeEventViewMode, useChatStore, type ChatTab } from '../stores/useChatStore'
 import type { PollingEvent } from '../services/api-types'
 import { useAppStore } from '../stores/useAppStore'
@@ -12,6 +11,7 @@ import { TreeViewAlphaDialog, shouldShowTreeViewAlphaWarning } from './TreeViewA
 import ServerSelectionDropdown from './ServerSelectionDropdown'
 import SkillSelectionDropdown from './skills/SkillSelectionDropdown'
 import { useMCPStore } from '../stores/useMCPStore'
+import { useLLMStore } from '../stores'
 import { dispatchChatToolCommand } from '../utils/chatToolEvents'
 import CostDashboard from './CostDashboard'
 import MultiAgentSchedulesPopup from './scheduler/MultiAgentSchedulesPopup'
@@ -46,6 +46,12 @@ function getDisplaySafeUserMessageContent(content: string): string {
   return (markerIndex >= 0 ? content.slice(0, markerIndex) : content).trim()
 }
 
+// Compact model id for the delegation-tier summary tooltip (mirrors ModePresetBar).
+function shortModelName(modelId: string): string {
+  const name = modelId.split('/').pop() || modelId
+  return name.length > 18 ? `${name.slice(0, 18)}…` : name
+}
+
 // Short, single-line title from a user message — matches chatHistorySessionTitle's
 // whitespace-collapse + length-cap style (default 80 chars).
 function deriveConversationTitle(text: string, maxLength = 80): string {
@@ -77,6 +83,18 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
     setTabViewMode,
   } = useChatStore()
   const { toolList: mcpToolList, setChatSelectedServers } = useMCPStore()
+  const delegationTierConfig = useLLMStore(state => state.delegationTierConfig)
+  const setShowTierModal = useLLMStore(state => state.setShowTierModal)
+
+  // Delegation-tier summary for the heading's config icon tooltip (CoS-specific).
+  const tierLines = useMemo(() => {
+    const lines: string[] = []
+    if (delegationTierConfig?.main) lines.push(`Main: ${shortModelName(delegationTierConfig.main.model_id)} (${delegationTierConfig.main.provider})`)
+    if (delegationTierConfig?.high) lines.push(`High: ${shortModelName(delegationTierConfig.high.model_id)} (${delegationTierConfig.high.provider})`)
+    if (delegationTierConfig?.medium) lines.push(`Medium: ${shortModelName(delegationTierConfig.medium.model_id)} (${delegationTierConfig.medium.provider})`)
+    if (delegationTierConfig?.low) lines.push(`Low: ${shortModelName(delegationTierConfig.low.model_id)} (${delegationTierConfig.low.provider})`)
+    return lines
+  }, [delegationTierConfig])
 
   const activeViewMode = useMemo(
     () => normalizeEventViewMode(activeTabId ? chatTabs[activeTabId]?.viewMode : undefined),
@@ -329,10 +347,6 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
         </button>
       )}
 
-      {/* Models / LLM config — lives in the mode heading since the model is
-          per-context (opens the globally-mounted LLM modal via the store). */}
-      <LlmTriggerButton className="flex flex-none items-center rounded px-2 py-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200" />
-
       {/* View controls live next to the Chief of Staff title, matching workflow. */}
       <div className="flex flex-none items-center gap-1 border-l border-gray-200 pl-2 dark:border-gray-700">
         <div
@@ -479,6 +493,35 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
           </TooltipTrigger>
           <TooltipContent>
             <p>{multiAgentScheduleTooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+        {/* Delegation tiers (H/M/L) — CoS-specific config, lives in this heading
+            (the modal itself is rendered once by LlmModalHost via the store). */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setShowTierModal(true)}
+              className={`relative rounded-md p-1.5 transition-colors hover:bg-accent ${
+                tierLines.length > 0
+                  ? 'bg-gray-100 text-gray-600 hover:text-accent-foreground dark:bg-gray-700 dark:text-gray-300'
+                  : 'bg-muted text-muted-foreground hover:text-accent-foreground'
+              }`}
+              aria-label="Configure delegation tiers"
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {tierLines.length > 0 ? (
+              <div className="space-y-1 text-xs">
+                {tierLines.map((line) => (
+                  <p key={line}>{line}</p>
+                ))}
+              </div>
+            ) : (
+              <p>Configure delegation tiers (H/M/L)</p>
+            )}
           </TooltipContent>
         </Tooltip>
         <OrgPulseControl />

--- a/frontend/src/components/ModePresetBar.tsx
+++ b/frontend/src/components/ModePresetBar.tsx
@@ -1,19 +1,18 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { Workflow, Users, Settings, Copy, Keyboard, SlidersHorizontal, Bot, Building2, HelpCircle } from 'lucide-react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { Workflow, Users, Settings, Copy, Keyboard, Bot, Building2, HelpCircle } from 'lucide-react'
 import { useModeStore } from '../stores/useModeStore'
 import { useGlobalPresetStore, usePresetApplication, usePresetManagement } from '../stores/useGlobalPresetStore'
 import type { CustomPreset, PredefinedPreset } from '../types/preset'
 import type { PlannerFile, PresetLLMConfig, ScheduledJob, WorkflowManifest } from '../services/api-types'
 import PresetModal from './PresetModal'
 import WorkflowScheduleRunsPanel from './scheduler/WorkflowScheduleRunsPanel'
-import DelegationTierConfigModal from './DelegationTierConfigModal'
 import BotConnectorModal from './settings/BotConnectorModal'
 import { WorkflowsOverviewPopup } from './WorkflowsOverviewPage'
 import { schedulerApi } from '../api/scheduler'
 import { agentApi, workflowManifestApi } from '../services/api'
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from './ui/tooltip'
 import ModalPortal from './ui/ModalPortal'
-import { useLLMStore, useChatStore } from '../stores'
+import { useChatStore } from '../stores'
 import { useMCPStore } from '../stores/useMCPStore'
 import { useAppStore } from '../stores/useAppStore'
 import { useCommandDialogStore } from '../stores/useCommandDialogStore'
@@ -69,11 +68,6 @@ const MODE_PILLS = [
     inactiveClasses: 'text-gray-500 dark:text-gray-400',
   },
 ] as const
-
-const shortModelName = (modelId: string): string => {
-  const name = modelId.split('/').pop() || modelId
-  return name.length > 18 ? `${name.slice(0, 18)}…` : name
-}
 
 type WorkflowScheduleSummary = {
   scheduledWorkflows: number
@@ -211,9 +205,7 @@ export const ModePresetBar: React.FC = () => {
   const [showRunsPanel, setShowRunsPanel] = useState(false)
   const [workflowScheduleSummary, setWorkflowScheduleSummary] = useState<WorkflowScheduleSummary>(EMPTY_WORKFLOW_SCHEDULE_SUMMARY)
   const [showPlansManager, setShowPlansManager] = useState(false)
-  const [showTierModal, setShowTierModal] = useState(false)
   const [showBotConnector, setShowBotConnector] = useState(false)
-  const [restoreWorkspaceAfterTierModal, setRestoreWorkspaceAfterTierModal] = useState(false)
   const [restoreWorkspaceAfterBotConnector, setRestoreWorkspaceAfterBotConnector] = useState(false)
   const [showWorkflowsPopup, setShowWorkflowsPopup] = useState(false)
   const [showWorkflowWalkthrough, setShowWorkflowWalkthrough] = useState(false)
@@ -224,7 +216,6 @@ export const ModePresetBar: React.FC = () => {
   const setShowWorkflowsOverview = useAppStore(s => s.setShowWorkflowsOverview)
   const setSelectedFile = useWorkspaceStore(state => state.setSelectedFile)
   const setShowFileContent = useWorkspaceStore(state => state.setShowFileContent)
-  const delegationTierConfig = useLLMStore(state => state.delegationTierConfig)
   const isOrganizationView = showWorkflowsOverview
   const shouldShowScheduleHeader = selectedModeCategory === 'workflow' || isOrganizationView
   const isMultiAgentMode = selectedModeCategory === 'multi-agent'
@@ -338,16 +329,7 @@ export const ModePresetBar: React.FC = () => {
     }
   }, [showShortcuts])
 
-  const tierLines = useMemo(() => {
-    const lines: string[] = []
-    if (delegationTierConfig?.main) lines.push(`Main: ${shortModelName(delegationTierConfig.main.model_id)} (${delegationTierConfig.main.provider})`)
-    if (delegationTierConfig?.high) lines.push(`High: ${shortModelName(delegationTierConfig.high.model_id)} (${delegationTierConfig.high.provider})`)
-    if (delegationTierConfig?.medium) lines.push(`Medium: ${shortModelName(delegationTierConfig.medium.model_id)} (${delegationTierConfig.medium.provider})`)
-    if (delegationTierConfig?.low) lines.push(`Low: ${shortModelName(delegationTierConfig.low.model_id)} (${delegationTierConfig.low.provider})`)
-    return lines
-  }, [delegationTierConfig])
-
-  const workflowCountLabel = `${workflowScheduleSummary.scheduledWorkflows} automation${workflowScheduleSummary.scheduledWorkflows !== 1 ? 's' : ''}`
+  const workflowCountLabel =`${workflowScheduleSummary.scheduledWorkflows} automation${workflowScheduleSummary.scheduledWorkflows !== 1 ? 's' : ''}`
   const scheduleCountLabel = `${workflowScheduleSummary.totalSchedules} schedule${workflowScheduleSummary.totalSchedules !== 1 ? 's' : ''}`
   const workflowScheduleHeaderLabel = workflowScheduleSummary.runningWorkflows > 0
     ? `${workflowScheduleSummary.runningWorkflows}/${workflowScheduleSummary.scheduledWorkflows} automations · ${workflowScheduleSummary.runningSchedules}/${workflowScheduleSummary.totalSchedules} schedules`
@@ -356,19 +338,6 @@ export const ModePresetBar: React.FC = () => {
   const workflowScheduleTooltip = workflowScheduleSummary.runningWorkflows > 0
     ? `${workflowScheduleSummary.runningWorkflows} of ${workflowScheduleSummary.scheduledWorkflows} scheduled automations running now; ${workflowScheduleSummary.runningSchedules} of ${workflowScheduleSummary.totalSchedules} schedules running`
     : `${workflowCountLabel} scheduled; ${scheduleCountLabel} total`
-
-  const openTierModal = useCallback(() => {
-    const shouldRestoreAfterClose = !workspaceMinimized
-    setRestoreWorkspaceAfterTierModal(shouldRestoreAfterClose)
-    if (shouldRestoreAfterClose) setWorkspaceMinimized(true)
-    setShowTierModal(true)
-  }, [workspaceMinimized, setWorkspaceMinimized])
-
-  const closeTierModal = useCallback(() => {
-    setShowTierModal(false)
-    if (restoreWorkspaceAfterTierModal) setWorkspaceMinimized(false)
-    setRestoreWorkspaceAfterTierModal(false)
-  }, [restoreWorkspaceAfterTierModal, setWorkspaceMinimized])
 
   const openBotConnector = useCallback(() => {
     const shouldRestore = !workspaceMinimized
@@ -875,34 +844,6 @@ export const ModePresetBar: React.FC = () => {
                 <TooltipContent side="bottom">Keyboard shortcuts</TooltipContent>
               </Tooltip>
 
-              {selectedModeCategory === 'multi-agent' && !isOrganizationView && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={openTierModal}
-                        className={`relative p-1 rounded-md transition-colors ${
-                          tierLines.length > 0
-                            ? 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
-                            : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200'
-                        }`}
-                      >
-                        <SlidersHorizontal className="w-4 h-4" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {tierLines.length > 0 ? (
-                        <div className="space-y-1 text-xs">
-                          {tierLines.map((line) => (
-                            <p key={line}>{line}</p>
-                          ))}
-                        </div>
-                      ) : (
-                        <p>Configure delegation tiers (H/M/L)</p>
-                      )}
-                    </TooltipContent>
-                  </Tooltip>
-              )}
-
               {shouldShowBotConnector && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1075,11 +1016,6 @@ export const ModePresetBar: React.FC = () => {
         fixedAgentMode={editingPreset?.agentMode || (selectedModeCategory ? (getAgentModeFromCategory(selectedModeCategory) as 'multi-agent' | 'workflow') : undefined)}
         agentMode={agentMode}
         onDeleteWorkflow={handleDeleteWorkflow}
-      />
-
-      <DelegationTierConfigModal
-        isOpen={showTierModal}
-        onClose={closeTierModal}
       />
 
       <BotConnectorModal

--- a/frontend/src/components/WorkspaceTopBarControls.tsx
+++ b/frontend/src/components/WorkspaceTopBarControls.tsx
@@ -2,6 +2,7 @@ import { TooltipProvider } from './ui/tooltip'
 import ThemeToggle from './topbar/ThemeToggle'
 import { WorkspaceConnectionSwitcher } from './WorkspaceConnectionSwitcher'
 import LlmModalHost from './topbar/LlmModalHost'
+import LlmTriggerButton from './topbar/LlmTriggerButton'
 import McpControl from './topbar/McpControl'
 import SkillsControl from './topbar/SkillsControl'
 import SecretsControl from './topbar/SecretsControl'
@@ -17,10 +18,11 @@ import AccountControl from './topbar/AccountControl'
 export default function WorkspaceTopBarControls() {
   return (
     <TooltipProvider delayDuration={400}>
-      {/* LlmModalHost renders the LLM modals once (no visible UI); the trigger
-          icon lives in the per-mode headers as <LlmTriggerButton>. */}
+      {/* LlmModalHost renders the LLM modals once (no visible UI); the global
+          Models trigger lives here in the top bar as <LlmTriggerButton>. */}
       <LlmModalHost />
       <div className="flex items-center gap-1.5">
+        <LlmTriggerButton />
         <McpControl />
         <SkillsControl />
         <SecretsControl />

--- a/frontend/src/components/topbar/LlmModalHost.tsx
+++ b/frontend/src/components/topbar/LlmModalHost.tsx
@@ -6,10 +6,11 @@ import { useLlmOnboarding } from './useLlmOnboarding'
 /**
  * LlmModalHost renders the LLM configuration modals (full config, first-run
  * discovery, delegation tiers) and runs their auto-open effects via
- * useLlmOnboarding. Mount it EXACTLY ONCE (in the global top bar). The visible
- * trigger lives in the per-mode headers as <LlmTriggerButton>, which opens these
- * modals through the shared LLM store — so the trigger can appear in several
- * headers while the modal still renders only once.
+ * useLlmOnboarding. Mount it EXACTLY ONCE (in the global top bar). The triggers
+ * open these modals through the shared LLM store (showLLMModal / showTierModal):
+ * the global Models trigger lives in the top bar as <LlmTriggerButton>, and the
+ * CoS delegation-tier trigger lives in the Chief of Staff heading (ChatTabs) —
+ * both drive the single modal instance rendered here.
  */
 export default function LlmModalHost() {
   const {

--- a/frontend/src/components/topbar/LlmTriggerButton.tsx
+++ b/frontend/src/components/topbar/LlmTriggerButton.tsx
@@ -9,9 +9,8 @@ type LlmTriggerButtonProps = {
 /**
  * LlmTriggerButton opens the LLM configuration modal (rendered once by
  * LlmModalHost) via the shared LLM store. It's stateless, so it can be mounted
- * in multiple per-mode headers (Chief of Staff / workflow) without duplicating
- * the modal. Models config is per-context, so it lives in the mode heading
- * rather than the global top bar.
+ * anywhere without duplicating the modal. The global "Models" config is a
+ * workspace-wide control, so it lives in the global top bar.
  */
 export default function LlmTriggerButton({ className }: LlmTriggerButtonProps) {
   const setShowLLMModal = useLLMStore(s => s.setShowLLMModal)

--- a/frontend/src/components/topbar/useLlmOnboarding.ts
+++ b/frontend/src/components/topbar/useLlmOnboarding.ts
@@ -21,6 +21,8 @@ export function useLlmOnboarding() {
   const {
     showLLMModal,
     setShowLLMModal,
+    showTierModal,
+    setShowTierModal,
     delegationTierConfig,
     savedLLMs,
     defaultsLoaded,
@@ -35,7 +37,6 @@ export function useLlmOnboarding() {
   const showDelegationTiersDialog = useCommandDialogStore(state => state.showDelegationTiers)
   const closeDialog = useCommandDialogStore(state => state.closeDialog)
 
-  const [showTierModal, setShowTierModal] = useState(false)
   const [showLLMDiscoveryModal, setShowLLMDiscoveryModal] = useState(false)
   const [releaseWalkthroughAfterLLMModalClose, setReleaseWalkthroughAfterLLMModalClose] = useState(false)
 
@@ -74,7 +75,7 @@ export function useLlmOnboarding() {
     }
   }, [releaseWalkthroughAfterLLMModalClose, setShowLLMModal])
 
-  const closeTierModal = useCallback(() => setShowTierModal(false), [])
+  const closeTierModal = useCallback(() => setShowTierModal(false), [setShowTierModal])
 
   // Auto-open delegation tier modal when triggered from multi-agent mode entry
   useEffect(() => {
@@ -82,7 +83,7 @@ export function useLlmOnboarding() {
       setShowTierModal(true)
       closeDialog('delegationTiers')
     }
-  }, [showDelegationTiersDialog, selectedModeCategory, closeDialog])
+  }, [showDelegationTiersDialog, selectedModeCategory, closeDialog, setShowTierModal])
 
   // First-run LLM setup: if no model is configured yet, prefer discovery over
   // the advanced tier configuration modal.
@@ -123,7 +124,7 @@ export function useLlmOnboarding() {
     if (!hasTiers) {
       setShowTierModal(true)
     }
-  }, [selectedModeCategory, delegationTierConfig, hasConfiguredLLM, openLLMDiscoveryModal])
+  }, [selectedModeCategory, delegationTierConfig, hasConfiguredLLM, openLLMDiscoveryModal, setShowTierModal])
 
   return {
     llmCount,

--- a/frontend/src/components/workflow/WorkflowChatTabs.tsx
+++ b/frontend/src/components/workflow/WorkflowChatTabs.tsx
@@ -9,7 +9,6 @@ import { useWorkflowStore } from '../../stores/useWorkflowStore'
 import { useGlobalPresetStore } from '../../stores/useGlobalPresetStore'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { TreeViewAlphaDialog, shouldShowTreeViewAlphaWarning } from '../TreeViewAlphaDialog'
-import LlmTriggerButton from '../topbar/LlmTriggerButton'
 
 // ---------------------------------------------------------------------------
 // WorkflowTabItem — per-tab component with narrow store subscriptions
@@ -361,10 +360,6 @@ export const WorkflowChatTabs: React.FC<WorkflowChatTabsProps> = ({ onNewChat, e
             <span className="hidden sm:inline">New Chat</span>
           </button>
         )}
-
-        {/* Models / LLM config — lives in the mode heading since the model is
-            per-context (opens the globally-mounted LLM modal via the store). */}
-        <LlmTriggerButton className="ml-0.5 inline-flex h-7 shrink-0 items-center rounded-md px-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100" />
 
         {/* Layout Mode — tree vs terminal, sits right after New Chat */}
         <div

--- a/frontend/src/stores/useLLMStore.ts
+++ b/frontend/src/stores/useLLMStore.ts
@@ -260,7 +260,8 @@ interface LLMState extends StoreActions {
 
   // Modal state
   showLLMModal: boolean
-  
+  showTierModal: boolean
+
   // Available LLMs for selection
   availableLLMs: LLMOption[]
   modelMetadataCatalog: ModelMetadata[]
@@ -316,6 +317,7 @@ interface LLMState extends StoreActions {
   setElevenlabsConfig: (config: ExtendedLLMConfiguration) => void
   setDeepgramConfig: (config: ExtendedLLMConfiguration) => void
   setShowLLMModal: (show: boolean) => void
+  setShowTierModal: (show: boolean) => void
   loadDefaultsFromBackend: () => Promise<void>
   
   // Library management
@@ -494,7 +496,8 @@ export const useLLMStore = create<LLMState>()(
 
         // Modal state
         showLLMModal: false,
-        
+        showTierModal: false,
+
         availableLLMs: [],
         modelMetadataCatalog: [],
         isLoadingLLMs: false,
@@ -639,6 +642,10 @@ export const useLLMStore = create<LLMState>()(
 
         setShowLLMModal: (show) => {
           set({ showLLMModal: show })
+        },
+
+        setShowTierModal: (show) => {
+          set({ showTierModal: show })
         },
 
         setDelegationTierConfig: (config) => {


### PR DESCRIPTION
Global LLM Models config back in the top bar; the CoS-specific delegation-tier (H/M/L) config moved into the Chief-of-Staff heading's right cluster (next to Org Pulse). Tier-modal state consolidated into the store → one modal instance, no double. Workflow heading gets no tier icon. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)