### PR TITLE
fix: CoS heading always 'Chief of Staff' (no first-message title)

### DIFF
--- a/frontend/src/components/ChatTabs.tsx
+++ b/frontend/src/components/ChatTabs.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Plus, ArrowDown, ListTree, Terminal, Globe, DollarSign, CalendarClock, SlidersHorizontal } from 'lucide-react'
 import { normalizeEventViewMode, useChatStore, type ChatTab } from '../stores/useChatStore'
-import type { PollingEvent } from '../services/api-types'
 import { useAppStore } from '../stores/useAppStore'
 import { OrgPulseControl } from './OrgPulseControl'
 import { OrgBackupPublishControls } from './org/OrgBackupPublishControls'
@@ -28,36 +27,10 @@ interface ChatTabsProps {
 
 const DEDICATED_MCP_SERVERS = new Set(['playwright'])
 
-// Mirror of ChatArea's user-message helpers so the header can derive the active
-// conversation's title from its first real user message (kept local to avoid a
-// cross-component import cycle).
-const AUTO_NOTIFICATION_PREFIX = '[AUTO-NOTIFICATION]'
-const RESTORED_CONVERSATION_CONTEXT_MARKER = '\n\nPrevious workflow-builder conversation file:'
-
-function getUserMessageContent(event: PollingEvent): string {
-  const agentEvent = event.data as Record<string, unknown> | undefined
-  const innerData = agentEvent?.data as Record<string, unknown> | undefined
-  const content = innerData?.content ?? agentEvent?.content
-  return typeof content === 'string' ? content : ''
-}
-
-function getDisplaySafeUserMessageContent(content: string): string {
-  const markerIndex = content.indexOf(RESTORED_CONVERSATION_CONTEXT_MARKER)
-  return (markerIndex >= 0 ? content.slice(0, markerIndex) : content).trim()
-}
-
 // Compact model id for the delegation-tier summary tooltip (mirrors ModePresetBar).
 function shortModelName(modelId: string): string {
   const name = modelId.split('/').pop() || modelId
   return name.length > 18 ? `${name.slice(0, 18)}…` : name
-}
-
-// Short, single-line title from a user message — matches chatHistorySessionTitle's
-// whitespace-collapse + length-cap style (default 80 chars).
-function deriveConversationTitle(text: string, maxLength = 80): string {
-  const normalized = text.replace(/\s+/g, ' ').trim()
-  if (!normalized) return ''
-  return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}...` : normalized
 }
 
 // Multi-agent chat is single-tab: this bar is a slim header for the one chat
@@ -102,23 +75,6 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
   )
   const activeTab = activeTabId ? chatTabs[activeTabId] : undefined
   const showAutoScrollControl = activeViewMode === 'tree'
-
-  // Reactively follow the active conversation's events so the header title can be
-  // derived from the first real user message as the conversation starts.
-  const activeSessionId = activeTab?.sessionId
-  const activeSessionEvents = useChatStore(state =>
-    activeSessionId ? state.tabEvents[activeSessionId] : undefined
-  )
-  const activeConversationTitle = useMemo(() => {
-    if (!activeSessionEvents) return ''
-    for (const event of activeSessionEvents) {
-      if (event.type !== 'user_message') continue
-      const content = getDisplaySafeUserMessageContent(getUserMessageContent(event))
-      if (!content || content.startsWith(AUTO_NOTIFICATION_PREFIX)) continue
-      return deriveConversationTitle(content)
-    }
-    return ''
-  }, [activeSessionEvents])
 
   const isHiddenOrganizationTab = useCallback((tab: ChatTab) => {
     // Only hide tabs explicitly marked as org assistant via metadata.
@@ -320,11 +276,10 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
   const showHeaderContent =
     !!activeTab && activeTab.metadata?.mode === 'multi-agent' && !isHiddenOrganizationTab(activeTab)
   // The multi-agent chat is the user's "chief of staff" (single-tab — this is a
-  // header label, not a tab switcher). Priority: resumed conversation's title →
-  // the active conversation's first-user-message title → the chief-of-staff label.
-  const chatTitle = (showHeaderContent
-    ? (activeTab?.config?.restoredConversationTitle?.trim() || activeConversationTitle)
-    : '') || 'Chief of Staff'
+  // header label, not a tab switcher). Always the chief-of-staff label: deriving
+  // the title from the (often long, raw) first user message made a resumed chat
+  // show a messy message at the top, which read like a fresh terminal start.
+  const chatTitle = 'Chief of Staff'
 
   return (
     <>


### PR DESCRIPTION
On resume the heading showed the chat's long first user message as its title, which read like a fresh terminal start. Reverted to the plain 'Chief of Staff' label and removed the now-dead title machinery. tsc 0 errors.