### PR TITLE
Terminal stability + Org Pulse + layout + resume fixes

### DIFF
--- a/agent_go/cmd/server/builtin_schedules.go
+++ b/agent_go/cmd/server/builtin_schedules.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Built-in schedules are defined in Go and run for every user unless the user
@@ -105,6 +106,21 @@ func IsDefaultBuiltinSchedule(scheduleID string) bool {
 
 func IsSlashManagedBuiltinSchedule(scheduleID string) bool {
 	return scheduleID == builtinOrgPulseID
+}
+
+// IsOrgPulseSchedule reports whether a multi-agent schedule IS the Org Pulse —
+// either the canonical built-in (builtin-org-pulse) or a user-created duplicate.
+// /pulse-setup is supposed to enable/override builtin-org-pulse, but an agent can
+// instead materialize Org Pulse under a fresh id via create_multiagent_schedule
+// (the on-disk shape we actually observe). Such a duplicate is still what the
+// scheduler runs, so the effective "Org Pulse is on" state must account for it.
+// We recognize duplicates by their highly specific Org Pulse signature.
+func IsOrgPulseSchedule(sched WorkflowSchedule) bool {
+	if sched.ID == builtinOrgPulseID {
+		return true
+	}
+	hay := strings.ToLower(sched.Name + "\n" + sched.Description + "\n" + sched.Query)
+	return strings.Contains(hay, "org pulse") || strings.Contains(hay, "org-pulse")
 }
 
 // MergeBuiltinSchedules appends built-in schedules that the user has not

--- a/agent_go/cmd/server/chat_history_persistence.go
+++ b/agent_go/cmd/server/chat_history_persistence.go
@@ -191,14 +191,17 @@ func (api *StreamingAPI) captureChatHistoryTerminalSnapshots(sessionID string, r
 		candidates = append(candidates, snapshot)
 	}
 	if len(candidates) == 0 && api.terminalStore != nil {
-		for _, snapshot := range api.terminalStore.List(sessionID) {
-			if strings.TrimSpace(snapshot.Content) == "" || !chatHistoryTerminalSnapshotIsTmux(snapshot) {
-				continue
-			}
-			prepared, ok := prepareChatHistoryTerminalSnapshot(snapshot)
-			if ok {
-				candidates = append(candidates, prepared)
-			}
+		stored := api.terminalStore.List(sessionID)
+		// Prefer tmux-backed panes (workflow coding-agent steps run over a tmux
+		// transport, so their snapshots are recapturable on restore). When no
+		// tmux pane exists — e.g. a multi-agent / Chief-of-Staff chat whose
+		// coding agent streams over a non-tmux transport (stream-json), so the
+		// terminal events carry no tmux_session — fall back to any terminal
+		// pane. Without this fallback the last capture is dropped at save time
+		// and the restored terminal pane comes up empty after a server restart.
+		candidates = collectChatHistoryTerminalSnapshots(stored, true)
+		if len(candidates) == 0 {
+			candidates = collectChatHistoryTerminalSnapshots(stored, false)
 		}
 	}
 	if len(candidates) == 0 {
@@ -214,6 +217,26 @@ func (api *StreamingAPI) captureChatHistoryTerminalSnapshots(sessionID string, r
 	})
 	if len(candidates) > maxChatHistoryTerminalSnapshots {
 		candidates = candidates[:maxChatHistoryTerminalSnapshots]
+	}
+	return candidates
+}
+
+// collectChatHistoryTerminalSnapshots prepares persistable terminal snapshots
+// from the in-memory store list. When tmuxOnly is set it keeps only
+// tmux-backed panes (the workflow coding-agent path); otherwise it keeps any
+// non-empty terminal pane (the multi-agent non-tmux fallback).
+func collectChatHistoryTerminalSnapshots(stored []terminals.Snapshot, tmuxOnly bool) []terminals.Snapshot {
+	candidates := make([]terminals.Snapshot, 0, len(stored))
+	for _, snapshot := range stored {
+		if strings.TrimSpace(snapshot.Content) == "" {
+			continue
+		}
+		if tmuxOnly && !chatHistoryTerminalSnapshotIsTmux(snapshot) {
+			continue
+		}
+		if prepared, ok := prepareChatHistoryTerminalSnapshot(snapshot); ok {
+			candidates = append(candidates, prepared)
+		}
 	}
 	return candidates
 }
@@ -1617,9 +1640,11 @@ func chatHistoryTerminalSnapshotFromUIEvent(sessionID string, runtime *ChatHisto
 		"claude_code_interactive_session",
 		"gemini_interactive_session",
 	)
-	if tmuxSession == "" {
-		return terminals.Snapshot{}, false
-	}
+	// A tmux_session is no longer required: multi-agent / Chief-of-Staff chats
+	// stream their coding-agent terminal over a non-tmux transport, so those
+	// terminal events carry no tmux_session. Reconstruct them anyway (keyed by
+	// session) so the last capture is restorable from ui_events on sessions
+	// saved before terminal_snapshots persisted non-tmux panes.
 
 	content := event.Data.Content
 	chunkIndex := 0
@@ -1666,15 +1691,20 @@ func chatHistoryTerminalSnapshotFromUIEvent(sessionID string, runtime *ChatHisto
 		Scope:         "main_agent",
 		WorkflowPath:  workflowPath,
 		StepID:        "main_agent:" + sessionID,
-		StepTransport: "tmux",
 		TmuxSession:   tmuxSession,
 		Content:       content,
-		ContentSource: "tmux_capture",
 		ChunkIndex:    chunkIndex,
 		Active:        false,
 		State:         "stale",
 		CreatedAt:     updatedAt,
 		UpdatedAt:     updatedAt,
+	}
+	// Only stamp tmux transport/source when the event actually came from a tmux
+	// pane. Non-tmux multi-agent terminals leave these empty so a restored
+	// static snapshot isn't treated as live-tmux-recapturable.
+	if tmuxSession != "" {
+		snapshot.StepTransport = "tmux"
+		snapshot.ContentSource = "tmux_capture"
 	}
 	if snapshot.ExecutionID == "" {
 		snapshot.ExecutionID = "main:" + sessionID

--- a/agent_go/cmd/server/chat_history_persistence_test.go
+++ b/agent_go/cmd/server/chat_history_persistence_test.go
@@ -14,8 +14,66 @@ import (
 	"mcp-agent-builder-go/agent_go/pkg/workspace"
 
 	mcpagent "github.com/manishiitg/mcpagent/agent"
+	agentevents "github.com/manishiitg/mcpagent/events"
 	"github.com/manishiitg/multi-llm-provider-go/llmtypes"
 )
+
+// TestCaptureChatHistoryTerminalSnapshotsPersistsNonTmuxMultiAgentPane covers the
+// multi-agent / Chief-of-Staff case: the coding agent streams its terminal over
+// a non-tmux transport, so the store snapshot has no tmux_session. Persistence
+// must still capture it so the pane can be restored after a server restart.
+func TestCaptureChatHistoryTerminalSnapshotsPersistsNonTmuxMultiAgentPane(t *testing.T) {
+	store := terminals.NewStore()
+	api := &StreamingAPI{terminalStore: store}
+	sessionID := "chat-non-tmux-multiagent"
+
+	now := time.Now()
+	store.HandleEvent(sessionID, internalevents.Event{
+		Type:          "streaming_chunk",
+		Timestamp:     now,
+		SessionID:     sessionID,
+		ExecutionKind: "main_agent",
+		Data: &agentevents.AgentEvent{
+			Type:      agentevents.StreamingChunk,
+			Timestamp: now,
+			SessionID: sessionID,
+			Data: &agentevents.StreamingChunkEvent{
+				BaseEventData: agentevents.BaseEventData{
+					Timestamp: now,
+					SessionID: sessionID,
+					Metadata: map[string]interface{}{
+						"kind":           "terminal",
+						"provider":       "claude-code",
+						"execution_kind": "main_agent",
+						"scope":          "main_agent",
+						// Intentionally no tmux_session / step_transport — the
+						// non-tmux transport the bug was reported against.
+					},
+				},
+				Content:    "\x1b[32mchief of staff output\x1b[0m\n",
+				ChunkIndex: 0,
+			},
+		},
+	})
+
+	// Sanity: the live store snapshot is non-tmux (the condition the old
+	// persist filter dropped).
+	stored := store.List(sessionID)
+	if len(stored) != 1 {
+		t.Fatalf("store snapshot count = %d, want 1", len(stored))
+	}
+	if chatHistoryTerminalSnapshotIsTmux(stored[0]) {
+		t.Fatalf("expected non-tmux store snapshot, got transport=%q source=%q tmux=%q", stored[0].StepTransport, stored[0].ContentSource, stored[0].TmuxSession)
+	}
+
+	snapshots := api.captureChatHistoryTerminalSnapshots(sessionID, nil)
+	if len(snapshots) != 1 {
+		t.Fatalf("persisted snapshot count = %d, want 1 (non-tmux multi-agent pane must persist)", len(snapshots))
+	}
+	if !strings.Contains(snapshots[0].Content, "chief of staff output") {
+		t.Fatalf("persisted snapshot content = %q, want chief of staff output", snapshots[0].Content)
+	}
+}
 
 func TestCleanChatHistoryForPersistenceRemovesRestoredConversationContext(t *testing.T) {
 	originalText := "check what we did here\n\nPrevious workflow-builder conversation file: Workflow/instagram/builder/conversation/2026-05-14/session-old-conversation.json\nThis hidden context should not persist."

--- a/agent_go/cmd/server/scheduler_routes.go
+++ b/agent_go/cmd/server/scheduler_routes.go
@@ -165,6 +165,53 @@ func buildMultiAgentJobResponse(userID string, sched WorkflowSchedule, state Sch
 	}
 }
 
+// buildMultiAgentJobResponsesWithOrgPulse builds job responses for a user's
+// merged multi-agent schedules, applying the effective Org Pulse enabled state.
+//
+// The Org Pulse pill (and the scheduler's own intent) treats Org Pulse as a
+// single logical thing keyed by builtin-org-pulse. But /pulse-setup can leave
+// Org Pulse enabled under a different id (a user-created duplicate) instead of a
+// same-id builtin override. When that happens the canonical builtin-org-pulse
+// entry stays at its disabled default, so the pill — which reads that id — shows
+// OFF even though the scheduler is actually running Org Pulse. Here we detect any
+// enabled Org Pulse schedule and surface its effective ON state (plus run info)
+// on the canonical builtin-org-pulse job so the pill matches reality.
+func buildMultiAgentJobResponsesWithOrgPulse(svc *SchedulerService, userID string, merged []WorkflowSchedule, enabledFilter string) []ScheduledJobResponse {
+	orgPulseOn := false
+	var orgPulseRun ScheduleRuntimeState
+	for _, sched := range merged {
+		if sched.Enabled && sched.ID != builtinOrgPulseID && IsOrgPulseSchedule(sched) {
+			orgPulseOn = true
+			orgPulseRun = svc.GetRuntimeState(sched.ID)
+		}
+	}
+
+	var out []ScheduledJobResponse
+	for _, sched := range merged {
+		state := svc.GetRuntimeState(sched.ID)
+		resp := buildMultiAgentJobResponse(userID, sched, state)
+		if resp.ID == builtinOrgPulseID && !resp.Enabled && orgPulseOn {
+			resp.Enabled = true
+			if resp.LastRunAt == nil {
+				resp.LastRunAt = orgPulseRun.LastRunAt
+			}
+			if resp.NextRunAt == nil {
+				resp.NextRunAt = orgPulseRun.NextRunAt
+			}
+		}
+		// Filter on the EFFECTIVE enabled state so the canonical Org Pulse job is
+		// not dropped from an enabled-only listing when it is on via a duplicate.
+		if enabledFilter != "" {
+			wantEnabled := enabledFilter == "true" || enabledFilter == "1"
+			if resp.Enabled != wantEnabled {
+				continue
+			}
+		}
+		out = append(out, resp)
+	}
+	return out
+}
+
 func validateScheduleRequest(scheduleType string, cronExpr string, calendarItems []CalendarScheduleItem) error {
 	switch scheduleType {
 	case "cron":
@@ -399,31 +446,13 @@ func listScheduledJobsHandler(svc *SchedulerService) http.HandlerFunc {
 			if userIDFilter != "" {
 				f, _, fErr := ReadMultiAgentSchedules(r.Context(), userIDFilter)
 				if fErr == nil {
-					for _, sched := range MergeBuiltinSchedules(f.Schedules) {
-						if enabledFilter != "" {
-							wantEnabled := enabledFilter == "true" || enabledFilter == "1"
-							if sched.Enabled != wantEnabled {
-								continue
-							}
-						}
-						state := svc.GetRuntimeState(sched.ID)
-						allJobs = append(allJobs, buildMultiAgentJobResponse(userIDFilter, sched, state))
-					}
+					allJobs = append(allJobs, buildMultiAgentJobResponsesWithOrgPulse(svc, userIDFilter, MergeBuiltinSchedules(f.Schedules), enabledFilter)...)
 				}
 			} else {
 				maScheds, maErr := DiscoverMultiAgentSchedules(r.Context())
 				if maErr == nil {
 					for _, ma := range maScheds {
-						for _, sched := range MergeBuiltinSchedules(ma.ScheduleFile.Schedules) {
-							if enabledFilter != "" {
-								wantEnabled := enabledFilter == "true" || enabledFilter == "1"
-								if sched.Enabled != wantEnabled {
-									continue
-								}
-							}
-							state := svc.GetRuntimeState(sched.ID)
-							allJobs = append(allJobs, buildMultiAgentJobResponse(ma.UserID, sched, state))
-						}
+						allJobs = append(allJobs, buildMultiAgentJobResponsesWithOrgPulse(svc, ma.UserID, MergeBuiltinSchedules(ma.ScheduleFile.Schedules), enabledFilter)...)
 					}
 				}
 			}

--- a/agent_go/cmd/server/scheduler_routes_test.go
+++ b/agent_go/cmd/server/scheduler_routes_test.go
@@ -63,6 +63,62 @@ func TestListScheduledJobsIncludesDefaultBuiltinsWithoutScheduleFile(t *testing.
 	}
 }
 
+func TestListScheduledJobsReflectsOrgPulseEnabledViaDuplicate(t *testing.T) {
+	// /pulse-setup can leave Org Pulse enabled under a user-created duplicate id
+	// (via create_multiagent_schedule) instead of a same-id builtin override.
+	// The canonical builtin-org-pulse job must still report Enabled=true so the
+	// Org Pulse pill matches what the scheduler actually runs.
+	scheduleFile := `{
+  "schedules": [
+    {
+      "id": "c8261d3e-f999-4260-a58b-98ff28aa5d1e",
+      "name": "Daily Org Pulse",
+      "description": "Daily sweep of all workflows.",
+      "schedule_type": "cron",
+      "cron_expression": "0 9 * * *",
+      "timezone": "Asia/Kolkata",
+      "enabled": true,
+      "mode": "multi-agent",
+      "query": "Perform the Daily Org Pulse sweep."
+    }
+  ]
+}`
+	api := &mockWorkspaceAPI{files: map[string]string{
+		multiAgentSchedulesPath(GetDefaultUserID()): scheduleFile,
+	}}
+	server := httptest.NewServer(api)
+	defer server.Close()
+	t.Setenv("WORKSPACE_API_URL", server.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/scheduler/jobs?mode=multi-agent", nil)
+	rec := httptest.NewRecorder()
+	listScheduledJobsHandler(NewSchedulerService(nil)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Jobs []ScheduledJobResponse `json:"jobs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v\n%s", err, rec.Body.String())
+	}
+
+	var found bool
+	for _, job := range resp.Jobs {
+		if job.ID == builtinOrgPulseID {
+			found = true
+			if !job.Enabled {
+				t.Fatal("builtin-org-pulse should report Enabled=true when an enabled Org Pulse duplicate exists")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("builtin-org-pulse was not listed: %+v", resp.Jobs)
+	}
+}
+
 func TestEnableBuiltinOrgPulseRequiresPersistedOverride(t *testing.T) {
 	api := &mockWorkspaceAPI{files: map[string]string{}}
 	server := httptest.NewServer(api)

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -5338,8 +5338,27 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 			}
 			if restoredNativeCodingResume {
 				if restoredRuntimeUsesLaunchableTerminalTransport(restoredRuntime) {
-					if _, err := underlyingAgent.StartCodingAgentTransportSession(agentCtx); err != nil {
+					if handle, err := underlyingAgent.StartCodingAgentTransportSession(agentCtx); err != nil {
 						logfWithContext(queryLogCtx, "[CHAT_HISTORY] Failed to prelaunch restored coding-agent transport session: %v", err)
+					} else if handle != nil && strings.TrimSpace(handle.TmuxSession) != "" {
+						// FIX B: After a server restart the original tmux is dead, so the
+						// restore path published a STATIC snapshot (Active:false, empty
+						// TmuxSession). The prelaunch above just started a NEW live tmux
+						// session via --resume, so the new tmux session id is only now
+						// known. Register it on the terminal store under the canonical
+						// main-agent terminalID — the same registration a fresh chat and
+						// the attach-existing restore tier use — so the snapshot the
+						// frontend reads (GET /api/terminals) flips to Active:true with
+						// the live tmux_session. Without this the frontend skips /resize
+						// (no tmux_session → tmux stays 120, text overflow + spinner
+						// geometry) and the append-only pipe recorder never engages
+						// (it needs snapshot.Active), so content=history churns the xterm.
+						newTmuxSession := strings.TrimSpace(handle.TmuxSession)
+						if _, started, reason := api.materializeRestoredTmuxTerminal(agentCtx, sessionID, restoredRuntime, newTmuxSession); started {
+							logfWithContext(queryLogCtx, "[CHAT_HISTORY] Registered relaunched restored coding-agent tmux as live session=%s tmux=%s", sessionID, newTmuxSession)
+						} else if reason != "" {
+							logfWithContext(queryLogCtx, "[CHAT_HISTORY] Could not register relaunched restored tmux session=%s tmux=%s reason=%s", sessionID, newTmuxSession, reason)
+						}
 					}
 				}
 				cleanedChatQuery := cleanChatHistoryQuery(chatQuery)

--- a/agent_go/cmd/server/terminal_pipe_recorder.go
+++ b/agent_go/cmd/server/terminal_pipe_recorder.go
@@ -137,6 +137,20 @@ func (r *terminalPipeRecorder) markStarted(tmuxSession string, err error) {
 	}
 }
 
+// disableTerminalPaneStatusLine turns off the tmux status bar for a mirrored
+// session so the PANE height equals the WINDOW height (== the xterm grid).
+// resize-window -y sets the WINDOW height; with the default status bar on, the
+// pane (the CLI's PTY) is one row shorter, so an inline TUI's bottom-anchored
+// live-region repaint drifts a row per tick and its spinner/progress frames pile
+// up. No tmux client is attached to these piped sessions, so the bar never shows
+// in the mirror anyway — turning it off is a pure win that hands the CLI the row.
+func disableTerminalPaneStatusLine(ctx context.Context, tmuxSession string) {
+	if strings.TrimSpace(tmuxSession) == "" {
+		return
+	}
+	_ = runTerminalTmuxCommand(ctx, "", "set-option", "-t", tmuxSession, "status", "off")
+}
+
 // start attaches the tmux pipe-pane recorder for a session. seedHistory is kept
 // for call-site compatibility but no longer selects a text seed: the log is now
 // seeded with a screen-mode-aware control prologue (see below) regardless.
@@ -169,6 +183,10 @@ func (r *terminalPipeRecorder) start(ctx context.Context, rec *terminalPipeRecor
 	// frame arrives as the CLI's OWN bytes on the clean prologue slate — rather
 	// than waiting for the next incidental redraw, which could otherwise leave an
 	// alt-screen pane blank until the next activity.
+	// Drop the status bar first (pane height == window height == xterm rows) so the
+	// repaint below re-renders the CLI at the corrected height; otherwise an inline
+	// TUI's spinner stacks (see disableTerminalPaneStatusLine).
+	disableTerminalPaneStatusLine(ctx, rec.tmuxSession)
 	forceTerminalPaneRepaint(ctx, rec.tmuxSession)
 	return nil
 }
@@ -196,6 +214,7 @@ func (r *terminalPipeRecorder) ResetForResize(ctx context.Context, tmuxSession s
 		log.Printf("Terminal pipe recorder resize reset failed for %s: %v", tmuxSession, err)
 		return
 	}
+	disableTerminalPaneStatusLine(ctx, tmuxSession)
 	forceTerminalPaneRepaint(ctx, tmuxSession)
 }
 

--- a/agent_go/cmd/server/terminal_pipe_recorder.go
+++ b/agent_go/cmd/server/terminal_pipe_recorder.go
@@ -137,36 +137,161 @@ func (r *terminalPipeRecorder) markStarted(tmuxSession string, err error) {
 	}
 }
 
+// start attaches the tmux pipe-pane recorder for a session. seedHistory is kept
+// for call-site compatibility but no longer selects a text seed: the log is now
+// seeded with a screen-mode-aware control prologue (see below) regardless.
 func (r *terminalPipeRecorder) start(ctx context.Context, rec *terminalPipeRecording, seedHistory bool) error {
+	_ = seedHistory
 	if rec == nil {
 		return fmt.Errorf("terminal recording is required")
 	}
 	if err := os.MkdirAll(filepath.Dir(rec.path), 0o700); err != nil {
 		return err
 	}
-	var seed string
-	var err error
-	if seedHistory {
-		seed, err = captureTerminalPaneLines(ctx, rec.tmuxSession, terminalDefaultRefreshLines)
-	} else {
-		seed, err = captureTerminalVisiblePane(ctx, rec.tmuxSession)
-	}
-	if err == nil && strings.TrimSpace(seed) != "" {
-		if writeErr := os.WriteFile(rec.path, []byte(strings.TrimRight(seed, "\n")+"\n"), 0o600); writeErr != nil {
-			return writeErr
-		}
-	} else if _, statErr := os.Stat(rec.path); os.IsNotExist(statErr) {
-		file, createErr := os.OpenFile(rec.path, os.O_CREATE|os.O_WRONLY, 0o600)
-		if createErr != nil {
-			return createErr
-		}
-		_ = file.Close()
+	// Seed the pipe log with a clean, screen-mode-aware control prologue instead
+	// of a flattened capture-pane TEXT snapshot. pipe-pane attaches AFTER a TUI
+	// has already entered the alternate screen, so the byte stream carries partial
+	// in-place absolute-cursor redraws but no alt-screen-enter and no initial
+	// clear. The old text seed (rendered text, no control codes, bare \n) pre-
+	// filled the xterm's NORMAL buffer with cells the CLI never re-addresses, so
+	// its in-place redraws left stale fragments behind — the "litter". The
+	// prologue gives xterm a clean slate in the SAME mode the pane is really in;
+	// the CLI's own bytes then paint onto it.
+	prologue := terminalPipeRecorderPrologue(ctx, rec.tmuxSession)
+	if err := os.WriteFile(rec.path, []byte(prologue), 0o600); err != nil {
+		return err
 	}
 	command := "cat >> " + shellSingleQuote(rec.path)
 	if err := runTerminalTmuxCommand(ctx, "", "pipe-pane", "-t", rec.tmuxSession, command); err != nil {
 		return fmt.Errorf("start tmux pipe-pane recorder: %w", err)
 	}
+	// Now that pipe-pane is attached, force one full repaint so a complete first
+	// frame arrives as the CLI's OWN bytes on the clean prologue slate — rather
+	// than waiting for the next incidental redraw, which could otherwise leave an
+	// alt-screen pane blank until the next activity.
+	forceTerminalPaneRepaint(ctx, rec.tmuxSession)
 	return nil
+}
+
+// ResetForResize truncates the pipe log on a geometry change and re-seeds it with
+// a fresh, screen-mode-aware prologue, then forces a repaint. Without this the
+// log would still hold frames captured at the OLD width; replayed concatenated
+// with the new width's frames they land at the wrong rows and pile up as litter.
+// Call it AFTER tmux has resized the window so the forced repaint is captured at
+// the new geometry. No-op when the session has no live recording.
+func (r *terminalPipeRecorder) ResetForResize(ctx context.Context, tmuxSession string) {
+	if r == nil {
+		return
+	}
+	tmuxSession = strings.TrimSpace(tmuxSession)
+	if tmuxSession == "" {
+		return
+	}
+	rec, ok := r.recording(tmuxSession)
+	if !ok || rec == nil {
+		return
+	}
+	prologue := terminalPipeRecorderPrologue(ctx, tmuxSession)
+	if err := os.WriteFile(rec.path, []byte(prologue), 0o600); err != nil {
+		log.Printf("Terminal pipe recorder resize reset failed for %s: %v", tmuxSession, err)
+		return
+	}
+	forceTerminalPaneRepaint(ctx, tmuxSession)
+}
+
+const (
+	// terminalPipeAltScreenPrologue enters the alternate screen, clears it and
+	// homes the cursor — the clean slate a full-screen TUI (claudecode, codex,
+	// gemini, cursor, pi) needs before its absolute-cursor redraws make sense.
+	terminalPipeAltScreenPrologue = "\x1b[?1049h\x1b[2J\x1b[H"
+	// terminalPipeNormalScreenPrologue is a full terminal reset (RIS) for a
+	// normal-buffer / line-based command. It clears the emulator WITHOUT entering
+	// the alternate screen, so a plain CLI is never wrongly trapped on an alt
+	// buffer. It is also the safe fallback when the screen mode is unknown.
+	terminalPipeNormalScreenPrologue = "\x1bc"
+)
+
+// terminalPipeRecorderPrologue returns the control prologue to seed the pipe log
+// with, matched to the pane's REAL screen mode. Forcing the alternate screen on a
+// normal-buffer CLI (or vice versa) is exactly the failure we must avoid, so when
+// the state cannot be determined we fall back to the safest option (RIS) rather
+// than guessing alt-screen.
+func terminalPipeRecorderPrologue(ctx context.Context, tmuxSession string) string {
+	if altOn, ok := terminalPaneAlternateScreenOn(ctx, tmuxSession); ok && altOn {
+		return terminalPipeAltScreenPrologue
+	}
+	return terminalPipeNormalScreenPrologue
+}
+
+// terminalPaneAlternateScreenOn reports whether the tmux pane is currently
+// showing the alternate screen (#{alternate_on} == 1). The second return value is
+// false when tmux could not be queried or returned an unexpected value, signalling
+// callers to use the safe fallback prologue.
+func terminalPaneAlternateScreenOn(ctx context.Context, tmuxSession string) (bool, bool) {
+	tmuxSession = strings.TrimSpace(tmuxSession)
+	if tmuxSession == "" {
+		return false, false
+	}
+	out, err := runTerminalTmuxOutputCommand(ctx, "display-message", "-p", "-t", tmuxSession, "#{alternate_on}")
+	if err != nil {
+		return false, false
+	}
+	switch strings.TrimSpace(out) {
+	case "1":
+		return true, true
+	case "0":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// forceTerminalPaneRepaint nudges a full-screen TUI into emitting a fresh, full
+// frame by briefly toggling the tmux window height by one row and restoring it. A
+// redraw is driven by SIGWINCH, which tmux only raises on an ACTUAL size change,
+// so a same-size resize is a no-op; toggling one row guarantees the signal. The
+// WIDTH is left untouched so a normal-buffer CLI's line wrapping is never
+// reflowed (and line-based shells simply ignore the SIGWINCH). The repaint lands
+// in the pipe log as the CLI's own bytes, painting the clean prologue slate.
+// Best-effort: any failure is ignored because the prologue already left a usable
+// clean screen.
+func forceTerminalPaneRepaint(ctx context.Context, tmuxSession string) {
+	tmuxSession = strings.TrimSpace(tmuxSession)
+	if tmuxSession == "" {
+		return
+	}
+	width, height, ok := terminalWindowSize(ctx, tmuxSession)
+	if !ok || width <= 0 || height <= 1 {
+		return
+	}
+	if err := runTerminalTmuxCommand(ctx, "", "resize-window", "-t", tmuxSession, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height-1)); err != nil {
+		return
+	}
+	_ = runTerminalTmuxCommand(ctx, "", "resize-window", "-t", tmuxSession, "-x", strconv.Itoa(width), "-y", strconv.Itoa(height))
+}
+
+// terminalWindowSize returns the tmux WINDOW dimensions. We deliberately read the
+// window (not the pane, whose height excludes any status line) so the height
+// toggle in forceTerminalPaneRepaint restores the exact original geometry.
+func terminalWindowSize(ctx context.Context, tmuxSession string) (int, int, bool) {
+	tmuxSession = strings.TrimSpace(tmuxSession)
+	if tmuxSession == "" {
+		return 0, 0, false
+	}
+	out, err := runTerminalTmuxOutputCommand(ctx, "display-message", "-p", "-t", tmuxSession, "#{window_width}\t#{window_height}")
+	if err != nil {
+		return 0, 0, false
+	}
+	parts := strings.Split(strings.TrimSpace(out), "\t")
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	width, errW := strconv.Atoi(strings.TrimSpace(parts[0]))
+	height, errH := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if errW != nil || errH != nil {
+		return 0, 0, false
+	}
+	return width, height, true
 }
 
 func (r *terminalPipeRecorder) Content(ctx context.Context, snapshot terminals.Snapshot, seedHistory bool) (string, terminalPaneCaptureStats, bool, error) {

--- a/agent_go/cmd/server/terminal_pipe_recorder_e2e_test.go
+++ b/agent_go/cmd/server/terminal_pipe_recorder_e2e_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -32,9 +34,6 @@ func TestTerminalPipeRecorderHTTPE2EPreservesAnsiAndAppends(t *testing.T) {
 		_ = runTerminalTmuxCommand(cleanupCtx, "", "kill-session", "-t", sessionName)
 	})
 
-	sendTmuxLiteralCommand(t, ctx, sessionName, "printf '\\033[31mred-start\\033[0m\\n'; printf '\\033[33mspinner-frame-1\\033[0m\\n'; printf 'MCP_API_TOKEN=super-secret\\nMCP_AUTH=Authorization: Bearer bearer-secret\\nSECRET_FOO=hidden-secret\\n'")
-	waitForTmuxCapture(t, ctx, sessionName, "red-start")
-
 	store := terminals.NewStore()
 	api := &StreamingAPI{
 		terminalStore: store,
@@ -48,7 +47,23 @@ func TestTerminalPipeRecorderHTTPE2EPreservesAnsiAndAppends(t *testing.T) {
 	terminalID := sessionID + ":" + ownerID
 	store.HandleEvent(sessionID, terminalRouteChunkEvent(sessionID, ownerID, sessionName, "seed pane", 1))
 
-	first := getTerminalHistoryDetail(t, api, terminalID)
+	// Boot the recorder FIRST so pipe-pane is attached before we emit output. The
+	// seed is now a clean control prologue (no flattened text snapshot), so only
+	// bytes the CLI writes AFTER pipe-pane attaches appear in the stream. /bin/sh
+	// is a normal-buffer command, so the prologue is RIS (no alternate screen).
+	boot := getTerminalHistoryDetail(t, api, terminalID)
+	if boot.ContentSource != "tmux_pipe" {
+		t.Fatalf("boot content_source = %q, want tmux_pipe", boot.ContentSource)
+	}
+	if !strings.Contains(boot.Content, terminalPipeNormalScreenPrologue) {
+		t.Fatalf("boot content should begin with the normal-screen prologue (RIS), got:\n%q", boot.Content)
+	}
+	if strings.Contains(boot.Content, terminalPipeAltScreenPrologue) {
+		t.Fatalf("normal-buffer /bin/sh must NOT be seeded with the alternate-screen prologue, got:\n%q", boot.Content)
+	}
+
+	sendTmuxLiteralCommand(t, ctx, sessionName, "printf '\\033[31mred-start\\033[0m\\n'; printf '\\033[33mspinner-frame-1\\033[0m\\n'; printf 'MCP_API_TOKEN=super-secret\\nMCP_AUTH=Authorization: Bearer bearer-secret\\nSECRET_FOO=hidden-secret\\n'")
+	first := waitForTerminalDetail(t, api, terminalID, "red-start")
 	if first.ContentSource != "tmux_pipe" {
 		t.Fatalf("content_source = %q, want tmux_pipe", first.ContentSource)
 	}
@@ -115,19 +130,6 @@ func sendTmuxLiteralCommand(t *testing.T, ctx context.Context, sessionName, comm
 	}
 }
 
-func waitForTmuxCapture(t *testing.T, ctx context.Context, sessionName, needle string) {
-	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		content, err := runTerminalTmuxOutputCommand(ctx, "capture-pane", "-p", "-e", "-t", sessionName)
-		if err == nil && strings.Contains(content, needle) {
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for tmux capture to contain %q", needle)
-}
-
 func waitForTerminalDetail(t *testing.T, api *StreamingAPI, terminalID, needle string) terminals.Snapshot {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
@@ -172,4 +174,112 @@ func getTerminalHistoryDetailWithHeader(t *testing.T, api *StreamingAPI, termina
 		t.Fatalf("decode terminal detail: %v", err)
 	}
 	return snapshot, rec.Header().Get("X-Runloop-Terminal-Content-Source")
+}
+
+// TestTerminalPipeRecorderPrologueMatchesScreenMode verifies the seed prologue is
+// chosen from the pane's real alternate-screen state, and that an unknown state
+// falls back to the safe normal-screen reset (never forcing the alternate screen).
+func TestTerminalPipeRecorderPrologueMatchesScreenMode(t *testing.T) {
+	cases := []struct {
+		name        string
+		alternateOn string
+		queryErr    bool
+		want        string
+	}{
+		{name: "alt-screen TUI", alternateOn: "1", want: terminalPipeAltScreenPrologue},
+		{name: "normal buffer", alternateOn: "0", want: terminalPipeNormalScreenPrologue},
+		{name: "unknown value falls back to RIS", alternateOn: "garbage", want: terminalPipeNormalScreenPrologue},
+		{name: "query error falls back to RIS", queryErr: true, want: terminalPipeNormalScreenPrologue},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldRunOutput := runTerminalTmuxOutputCommand
+			runTerminalTmuxOutputCommand = func(ctx context.Context, args ...string) (string, error) {
+				if tc.queryErr {
+					return "", context.DeadlineExceeded
+				}
+				return tc.alternateOn, nil
+			}
+			defer func() { runTerminalTmuxOutputCommand = oldRunOutput }()
+
+			got := terminalPipeRecorderPrologue(context.Background(), "mlp-some-session")
+			if got != tc.want {
+				t.Fatalf("prologue = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTerminalPipeRecorderResetForResizeTruncatesAndReseeds verifies a geometry
+// change truncates the old-width frames out of the pipe log and re-seeds a fresh
+// mode-aware prologue so the frontend never replays mismatched-width frames.
+func TestTerminalPipeRecorderResetForResizeTruncatesAndReseeds(t *testing.T) {
+	tmuxSession := "mlp-claude-resize-reset"
+	dir := t.TempDir()
+	path := filepath.Join(dir, terminalPipeRecorderFileName(tmuxSession))
+	oldFrames := "\x1b[?1049h\x1b[2J\x1b[Hold-width frame one\x1b[2;1Hold-width frame two"
+	if err := os.WriteFile(path, []byte(oldFrames), 0o600); err != nil {
+		t.Fatalf("seed old pipe log: %v", err)
+	}
+
+	recorder := &terminalPipeRecorder{
+		root: dir,
+		sessions: map[string]*terminalPipeRecording{
+			tmuxSession: {tmuxSession: tmuxSession, path: path, started: true},
+		},
+	}
+
+	oldRunOutput := runTerminalTmuxOutputCommand
+	runTerminalTmuxOutputCommand = func(ctx context.Context, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "#{alternate_on}"):
+			return "1", nil
+		case strings.Contains(joined, "#{window_width}"):
+			return "120\t40", nil
+		default:
+			return "", nil
+		}
+	}
+	oldRun := runTerminalTmuxCommand
+	runTerminalTmuxCommand = func(ctx context.Context, stdin string, args ...string) error { return nil }
+	defer func() {
+		runTerminalTmuxOutputCommand = oldRunOutput
+		runTerminalTmuxCommand = oldRun
+	}()
+
+	recorder.ResetForResize(context.Background(), tmuxSession)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pipe log after reset: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "old-width frame") {
+		t.Fatalf("reset must truncate old-width frames, got:\n%q", got)
+	}
+	if got != terminalPipeAltScreenPrologue {
+		t.Fatalf("reset must re-seed the alternate-screen prologue, got:\n%q", got)
+	}
+}
+
+// TestTerminalPipeRecorderResetForResizeIgnoresUnknownSession verifies the reset
+// is a safe no-op when no live recording exists for the session.
+func TestTerminalPipeRecorderResetForResizeIgnoresUnknownSession(t *testing.T) {
+	recorder := &terminalPipeRecorder{
+		root:     t.TempDir(),
+		sessions: make(map[string]*terminalPipeRecording),
+	}
+	called := false
+	oldRunOutput := runTerminalTmuxOutputCommand
+	runTerminalTmuxOutputCommand = func(ctx context.Context, args ...string) (string, error) {
+		called = true
+		return "0", nil
+	}
+	defer func() { runTerminalTmuxOutputCommand = oldRunOutput }()
+
+	recorder.ResetForResize(context.Background(), "mlp-missing-session")
+	if called {
+		t.Fatalf("ResetForResize must not query tmux for an unknown session")
+	}
 }

--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -729,6 +729,12 @@ func (api *StreamingAPI) handleResizeTerminal(w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
+	// [SPINNER_DEBUG] requested-vs-actual geometry — diagnoses live-region (spinner)
+	// stacking from an xterm/tmux size mismatch. Remove after the spinner fix.
+	if out, qerr := runTerminalTmuxOutputCommand(ctx, "display-message", "-p", "-t", snapshot.TmuxSession,
+		"win=#{window_width}x#{window_height} pane=#{pane_width}x#{pane_height} alt=#{alternate_on}"); qerr == nil {
+		log.Printf("[SPINNER_DEBUG] resize session=%s requested=%dx%d %s", snapshot.TmuxSession, req.Cols, req.Rows, strings.TrimSpace(out))
+	}
 	// The pane was resized: the pipe recording still holds frames captured at the
 	// OLD geometry. Truncate it and re-seed a screen-mode-aware prologue, then
 	// force a fresh full repaint, so the frontend never replays old-width frames

--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -667,6 +667,11 @@ func (api *StreamingAPI) resizeLiveTerminalWindowsForSession(ctx context.Context
 			}
 			continue
 		}
+		// Geometry changed: drop the pipe recording's old-width frames and re-seed
+		// a clean prologue so the live stream never replays mismatched-width frames.
+		if api.terminalPipeRecorder != nil {
+			api.terminalPipeRecorder.ResetForResize(resizeCtx, snapshot.TmuxSession)
+		}
 		resized++
 	}
 	return resized
@@ -724,6 +729,13 @@ func (api *StreamingAPI) handleResizeTerminal(w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
+	// The pane was resized: the pipe recording still holds frames captured at the
+	// OLD geometry. Truncate it and re-seed a screen-mode-aware prologue, then
+	// force a fresh full repaint, so the frontend never replays old-width frames
+	// concatenated with new-width frames (the resize-time litter).
+	if api.terminalPipeRecorder != nil {
+		api.terminalPipeRecorder.ResetForResize(ctx, snapshot.TmuxSession)
+	}
 	_ = json.NewEncoder(w).Encode(terminalActionResponse{OK: true, Terminal: api.enrichTerminalSnapshot(r.Context(), newTerminalPlanTypeResolver(r.Context()), snapshot)})
 }
 
@@ -762,11 +774,6 @@ func pasteTerminalText(ctx context.Context, tmuxSession, text string) error {
 
 func captureTerminalPane(ctx context.Context, tmuxSession string) (string, error) {
 	return captureTerminalPaneLines(ctx, tmuxSession, terminalDefaultRefreshLines)
-}
-
-func captureTerminalVisiblePane(ctx context.Context, tmuxSession string) (string, error) {
-	content, _, err := captureTerminalVisiblePaneWithStats(ctx, tmuxSession)
-	return content, err
 }
 
 func captureTerminalPaneLines(ctx context.Context, tmuxSession string, lines int) (string, error) {

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -337,6 +337,18 @@ func (s *Store) UpsertStaticSnapshot(sessionID string, snapshot Snapshot) (Snaps
 		ownerID = "main:" + sessionID
 	}
 	terminalID := terminalIDFor(sessionID, ownerID)
+	// Never clobber a LIVE tmux terminal with the static buffer. Once a resumed
+	// session's transport has been materialized under this canonical terminalID
+	// (Active + a real TmuxSession), a late static re-publish — the frontend's
+	// restore-terminal POST races the /api/query re-launch that materializes the
+	// live pane — must NOT reset it back to Active:false / TmuxSession:"". Doing so
+	// strips the tmux_session the frontend needs to fire /resize, so tmux geometry
+	// never matches the xterm and pi-cli's full-screen redraws append instead of
+	// overwrite (duplicated status bar / stacked "Working..."). The live snapshot
+	// already shows current content, so the static buffer adds nothing — keep live.
+	if existing, ok := s.byID[terminalID]; ok && existing.Active && strings.TrimSpace(existing.TmuxSession) != "" {
+		return existing, true
+	}
 	snapshot.TerminalID = terminalID
 	snapshot.SessionID = sessionID
 	snapshot.OwnerID = ownerID

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -529,6 +529,79 @@ func TestStoreDoesNotArchiveMainAgentTmuxTurnOnContinuation(t *testing.T) {
 	}
 }
 
+// TestUpsertStaticSnapshotDoesNotClobberLiveTmuxTerminal guards the resume race:
+// the frontend's restore-terminal POST (which publishes the static buffer) can
+// land AFTER /api/query has materialized the live tmux pane under the same
+// canonical main-agent terminalID. The static publish must not reset the live
+// terminal back to Active:false / TmuxSession:"" — that strips the tmux_session
+// the frontend needs to fire /resize.
+func TestUpsertStaticSnapshotDoesNotClobberLiveTmuxTerminal(t *testing.T) {
+	store := NewStore()
+	now := time.Now()
+
+	// Materialize the live tmux terminal (what /api/query's re-launch does).
+	store.HandleEvent("session-1", terminalEventWithMetadata(
+		"main:session-1",
+		"live pane content\n❯",
+		0,
+		map[string]interface{}{
+			"tmux_session":   "mlp-pi-cli-resumed-123",
+			"execution_kind": "main_agent",
+		},
+		now,
+	))
+
+	live := store.List("session-1")
+	if len(live) != 1 || !live[0].Active || live[0].TmuxSession != "mlp-pi-cli-resumed-123" {
+		t.Fatalf("expected one live tmux terminal, got %#v", live)
+	}
+	canonicalID := live[0].TerminalID
+
+	// A late static re-publish for the SAME canonical terminal must be ignored.
+	stored, ok := store.UpsertStaticSnapshot("session-1", Snapshot{
+		Content:       "stale persisted buffer",
+		ExecutionKind: "main_agent",
+	})
+	if !ok {
+		t.Fatalf("UpsertStaticSnapshot returned ok=false")
+	}
+	if stored.TerminalID != canonicalID {
+		t.Fatalf("static upsert targeted %q, want canonical %q", stored.TerminalID, canonicalID)
+	}
+	if !stored.Active || stored.TmuxSession != "mlp-pi-cli-resumed-123" {
+		t.Fatalf("live terminal was clobbered by static publish: active=%v tmux=%q content=%q",
+			stored.Active, stored.TmuxSession, stored.Content)
+	}
+	if stored.Content != "live pane content\n❯" {
+		t.Fatalf("live content overwritten by static buffer: %q", stored.Content)
+	}
+
+	after := store.List("session-1")
+	if len(after) != 1 || !after[0].Active || after[0].TmuxSession != "mlp-pi-cli-resumed-123" {
+		t.Fatalf("expected the live tmux terminal preserved, got %#v", after)
+	}
+}
+
+// TestUpsertStaticSnapshotPublishesWhenNoLiveTerminal confirms the guard is
+// scoped: with no live tmux terminal present (the normal first-restore case),
+// the static snapshot still publishes.
+func TestUpsertStaticSnapshotPublishesWhenNoLiveTerminal(t *testing.T) {
+	store := NewStore()
+	stored, ok := store.UpsertStaticSnapshot("session-1", Snapshot{
+		Content:       "restored buffer\n❯",
+		ExecutionKind: "main_agent",
+	})
+	if !ok {
+		t.Fatalf("UpsertStaticSnapshot returned ok=false")
+	}
+	if stored.Active || strings.TrimSpace(stored.TmuxSession) != "" {
+		t.Fatalf("static snapshot should be inactive with no tmux, got active=%v tmux=%q", stored.Active, stored.TmuxSession)
+	}
+	if stored.Content != "restored buffer\n❯" {
+		t.Fatalf("static content = %q", stored.Content)
+	}
+}
+
 func TestStoreKeepsArchivedTurnWhenRestartReusesTmuxSession(t *testing.T) {
 	store := NewStore()
 	now := time.Now()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,7 +66,8 @@
         "tailwindcss-animate": "^1.0.7",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.1",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2625,6 +2626,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -2884,6 +2896,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3289,6 +3308,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@welldone-software/why-did-you-render": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-10.0.1.tgz",
@@ -3490,6 +3622,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -3731,6 +3873,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4705,6 +4857,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4990,6 +5149,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5004,6 +5173,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -7324,6 +7503,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/option": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
@@ -8384,6 +8577,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8419,10 +8619,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -8629,6 +8843,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -8678,6 +8899,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9142,6 +9373,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -9204,6 +9538,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
     "types:events": "node scripts/generate-event-types.mjs",
     "types:events-bridge": "node scripts/generate-event-types.mjs",
     "types:generate": "node scripts/generate-event-types.mjs",
@@ -73,6 +74,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "./contexts/ThemeContext.tsx";
 import { UpdateProgressToast } from "./components/UpdateProgressToast";
 import Workspace from "./components/Workspace.tsx";
 import { MemoryPanel, OrgGoalsPanel, OrgPulsePanel } from "./components/org/OrgHtmlPanels";
-import { ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT, getOrgHtmlPreviewDevice, type OrgHtmlPreviewDevice } from "./components/org/orgHtmlPreview";
+import { ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT, getOrgHtmlPreviewDevice, setOrgHtmlPreviewDevice as persistOrgHtmlPreviewDevice, type OrgHtmlPreviewDevice } from "./components/org/orgHtmlPreview";
 import ChatArea, { type ChatAreaRef } from "./components/ChatArea.tsx";
 import { MarkdownRenderer, MermaidDiagram } from "./components/ui/MarkdownRenderer";
 import { CsvRenderer } from "./components/ui/CsvRenderer";
@@ -25,7 +25,7 @@ import { isValidJSON } from "./utils/event-helpers";
 import { prepareDomForPdfExport } from "./utils/pdfExport";
 import { convertToSlackMarkdown } from "./utils/slackMarkdown";
 import { isDiffFilePath, looksLikeDiffContent } from "./utils/diff";
-import { Edit, Save, X, Loader2, Download, Link, Github, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { Edit, Save, X, Loader2, Download, Link, Github, PanelRightClose, PanelRightOpen, Smartphone, Laptop } from "lucide-react";
 import { WorkflowLayout } from "./components/workflow";
 import { WorkflowsOverviewPage } from "./components/WorkflowsOverviewPage";
 import { ModePresetBar } from "./components/ModePresetBar";
@@ -235,7 +235,7 @@ function App() {
   useEffect(() => {
     const handler = (event: Event) => {
       const preference = (event as CustomEvent).detail?.preference
-      if (preference === 'mobile' || preference === 'tablet' || preference === 'desktop') {
+      if (preference === 'mobile' || preference === 'desktop') {
         setOrgHtmlPreviewDevice(preference)
       }
     }
@@ -1440,16 +1440,15 @@ function App() {
   }, [setWorkspaceMinimizedForLayout])
 
   // Responsive split mirroring WorkflowLayout's splitGridCols, keyed off the
-  // device tier (OrgHtmlPreviewDevice = 'mobile' | 'tablet' | 'desktop'; the UI
-  // labels 'desktop' as "Laptop"). Chat is grid col 1, org content is grid col 2.
-  //   'desktop' (UI "Laptop", default) → chat = 360px rail, org content fills
-  //   'tablet' → chat fills, org content = 880px (tablet preview)
-  //   'mobile' → chat fills, org content = 480px (phone preview)
-  // The chat rail stays visible in all three tiers.
+  // device tier (OrgHtmlPreviewDevice = 'mobile' | 'desktop'; the UI labels
+  // 'desktop' as "Laptop"). Chat is grid col 1, org content is grid col 2.
+  //   'mobile' (default) → chat fills (1fr), org content = 480px panel on the right
+  //   'desktop' (UI "Laptop") → chat/terminal column is hidden; org content fills
+  //     the full width as a single grid column.
+  const isMultiAgentLaptopFull = orgHtmlPreviewDevice === 'desktop'
   const multiAgentSplitGridCols =
-    orgHtmlPreviewDevice === 'mobile' ? 'md:grid-cols-[minmax(0,1fr)_480px]'
-      : orgHtmlPreviewDevice === 'tablet' ? 'md:grid-cols-[minmax(0,1fr)_880px]'
-        : 'md:grid-cols-[360px_minmax(0,1fr)]'
+    isMultiAgentLaptopFull ? 'md:grid-cols-[minmax(0,1fr)]'
+      : 'md:grid-cols-[minmax(0,1fr)_480px]'
   const layoutWorkspaceMinimized =
     showWorkflowsOverview
       ? true
@@ -1459,38 +1458,67 @@ function App() {
   const toggleMultiAgentPanelMinimize = useCallback(() => {
     setWorkspaceMinimized(!layoutWorkspaceMinimized)
   }, [layoutWorkspaceMinimized, setWorkspaceMinimized])
+  // Device-preview toggle (Mobile / Laptop). Lives alongside the panel tabs so it
+  // renders in EVERY right-panel view header (Pulse/Goals/Memory/Files) — critical
+  // because Laptop hides the chat/terminal column, so this toggle is the only way
+  // back to Mobile to interact with the agent. Persists + broadcasts the choice;
+  // App's own listener mirrors it into local state.
+  const multiAgentDeviceToggle = (
+    <div className="inline-flex flex-none items-center gap-0.5 rounded-lg border border-border bg-muted/70 p-0.5 shadow-sm backdrop-blur-sm">
+      {([
+        { mode: 'mobile' as const, Icon: Smartphone, label: 'Mobile' },
+        { mode: 'desktop' as const, Icon: Laptop, label: 'Laptop' },
+      ]).map(({ mode, Icon: DeviceIcon, label }) => (
+        <button
+          key={mode}
+          type="button"
+          onClick={() => persistOrgHtmlPreviewDevice(mode)}
+          title={`${label} layout`}
+          aria-label={`${label} layout`}
+          className={`inline-flex h-6 w-6 items-center justify-center rounded transition-colors ${
+            orgHtmlPreviewDevice === mode ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <DeviceIcon className="h-3.5 w-3.5" />
+        </button>
+      ))}
+    </div>
+  )
   const multiAgentPanelTabs = (
-    <div className="inline-flex min-w-0 flex-none items-center gap-0.5 rounded-lg border border-border bg-muted/70 p-0.5 shadow-sm backdrop-blur-sm">
-      <button
-        type="button"
-        onClick={() => setMultiAgentRightPanelView('org-pulse')}
-        title="Org Pulse"
-        aria-label="Org Pulse"
-        className={multiAgentPanelTabClass(multiAgentRightPanelView === 'org-pulse')}
-      >
-        Pulse
-      </button>
-      <button
-        type="button"
-        onClick={() => setMultiAgentRightPanelView('org-goals')}
-        className={multiAgentPanelTabClass(multiAgentRightPanelView === 'org-goals')}
-      >
-        Goals
-      </button>
-      <button
-        type="button"
-        onClick={() => setMultiAgentRightPanelView('memory')}
-        className={multiAgentPanelTabClass(multiAgentRightPanelView === 'memory')}
-      >
-        Memory
-      </button>
-      <button
-        type="button"
-        onClick={() => setMultiAgentRightPanelView('files')}
-        className={multiAgentPanelTabClass(multiAgentRightPanelView === 'files')}
-      >
-        Files
-      </button>
+    <div className="inline-flex min-w-0 flex-none items-center gap-1">
+      <div className="inline-flex min-w-0 flex-none items-center gap-0.5 rounded-lg border border-border bg-muted/70 p-0.5 shadow-sm backdrop-blur-sm">
+        <button
+          type="button"
+          onClick={() => setMultiAgentRightPanelView('org-pulse')}
+          title="Org Pulse"
+          aria-label="Org Pulse"
+          className={multiAgentPanelTabClass(multiAgentRightPanelView === 'org-pulse')}
+        >
+          Pulse
+        </button>
+        <button
+          type="button"
+          onClick={() => setMultiAgentRightPanelView('org-goals')}
+          className={multiAgentPanelTabClass(multiAgentRightPanelView === 'org-goals')}
+        >
+          Goals
+        </button>
+        <button
+          type="button"
+          onClick={() => setMultiAgentRightPanelView('memory')}
+          className={multiAgentPanelTabClass(multiAgentRightPanelView === 'memory')}
+        >
+          Memory
+        </button>
+        <button
+          type="button"
+          onClick={() => setMultiAgentRightPanelView('files')}
+          className={multiAgentPanelTabClass(multiAgentRightPanelView === 'files')}
+        >
+          Files
+        </button>
+      </div>
+      {multiAgentDeviceToggle}
     </div>
   )
   const multiAgentPanelCloseButton = (
@@ -1585,12 +1613,16 @@ function App() {
                       }`}
                     >
                       {/* Chat rail = grid col 1, mirroring the workflow. Minimized →
-                          flexes to fill the width; otherwise it's the col-1 rail. */}
+                          flexes to fill the width; Laptop → hidden entirely so the
+                          org content takes the full width; otherwise it's the col-1
+                          rail. */}
                       <div
                         className={`flex min-w-0 flex-col overflow-hidden bg-background ${
                           layoutWorkspaceMinimized
                             ? 'flex-1'
-                            : 'w-full border-b border-gray-200 dark:border-gray-700 md:col-start-1 md:border-b-0 md:border-r'
+                            : isMultiAgentLaptopFull
+                              ? 'hidden'
+                              : 'w-full border-b border-gray-200 dark:border-gray-700 md:col-start-1 md:border-b-0 md:border-r'
                         }`}
                       >
                         <ChatAreaWithObserverId
@@ -1601,7 +1633,7 @@ function App() {
                       </div>
                       {!layoutWorkspaceMinimized && (
                         <div
-                          className="flex min-w-0 flex-1 flex-col overflow-hidden bg-background md:col-start-2"
+                          className={`flex min-w-0 flex-1 flex-col overflow-hidden bg-background ${isMultiAgentLaptopFull ? 'md:col-start-1' : 'md:col-start-2'}`}
                         >
                           {multiAgentRightPanelView === 'files' && (
                             <div className="flex flex-wrap items-center justify-between gap-1 border-b border-border bg-muted/40 px-2 py-2">

--- a/frontend/src/commands/builtin-commands.tsx
+++ b/frontend/src/commands/builtin-commands.tsx
@@ -337,8 +337,9 @@ Also ask whether I want to set up org-level backup and publish:
 Call get_reference_doc(kind="org-pulse") and follow it for what Daily Org Pulse should do. Before writing or changing pulse/org-pulse.html, also call get_reference_doc(kind="backup-strategy") and confirm org backup status in pulse/backup.json and pulse/backup/status.json, then call get_reference_doc(kind="org-html") and use its Org Pulse skeleton.
 Read pulse/goals.html if it exists, and read pulse/org-pulse.html if it exists.
 Read pulse/backup.json, pulse/backup/status.json, pulse/publish.json, and pulse/publish/status.json if they exist.
-Check the built-in Org Pulse schedule (builtin-org-pulse): whether it is enabled, its cron, timezone, and last/next run state.
-Before editing any multi-agent schedule file directly, call get_reference_doc(kind="schedule-management"). Prefer enabling/updating builtin-org-pulse; do not create a duplicate Org Pulse schedule.
+First call list_multiagent_schedules and find the existing Org Pulse schedule — the built-in builtin-org-pulse AND any other schedule that is really an Org Pulse (its name/description/query mentions "Org Pulse"). Report whether it is enabled, its cron, timezone, and last/next run state.
+To enable or configure Daily Org Pulse, ALWAYS call update_multiagent_schedule on builtin-org-pulse (this owns/materializes the built-in). NEVER call create_multiagent_schedule for Org Pulse — a freshly-minted UUID schedule becomes a duplicate that the Org Pulse pill and the scheduler can disagree about. If a duplicate non-builtin Org Pulse schedule already exists, consolidate: enable builtin-org-pulse and disable (or delete) the duplicate so exactly one Org Pulse schedule remains.
+Before editing any multi-agent schedule file directly, call get_reference_doc(kind="schedule-management").
 
 If pulse/goals.html is missing or has no measurable goals, explain that Daily Org Pulse can only measure org progress after goals exist. Ask whether I want to run /org-setup first or enable a workflow-health-only pulse temporarily. Do not create goals from this command unless I explicitly ask.
 

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -503,6 +503,12 @@ interface ChatAreaProps {
   // chat sits in the narrow rail; labeled tabs when it fills the pane (org panel
   // minimized). The panel always renders in fill mode so it scrolls in both.
   previousChatsCompact?: boolean
+  // Workflow landing previous-chats panel. WorkflowLayout owns the panel + its
+  // resume handler (so the workflow-scoped history logic isn't duplicated here)
+  // and passes the rendered node only when a fresh automation chat should show
+  // the list. When present, ChatArea renders it as the primary surface (mirroring
+  // the multi-agent landing panel) and suppresses its own workflow empty states.
+  workflowPreviousChatsPanel?: React.ReactNode
 }
 
 // Ref interface for ChatArea component
@@ -522,7 +528,7 @@ let globalHasRestored = false
 
 // Inner component for chat area
 const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAreaRef>) => {
-  const { onNewChat, hideHeader = false, hideInput = false, compact = false, hidePhaseChatEmptyState = false, suppressTerminalPane = false, tabId, previousChatsCompact = false } = props
+  const { onNewChat, hideHeader = false, hideInput = false, compact = false, hidePhaseChatEmptyState = false, suppressTerminalPane = false, tabId, previousChatsCompact = false, workflowPreviousChatsPanel } = props
   // null means "inactive — don't subscribe to any tab or run any effects"
   const isInactive = tabId === null
 
@@ -2978,7 +2984,12 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
 
   const shouldRenderTerminalPane = activeEventViewMode === 'terminal' && !showNormalPreviousChatsPanel
   const shouldRenderEventDisplay = activeEventViewMode !== 'terminal' && !showNormalPreviousChatsPanel
-  const shouldUseFullHeightContent = shouldRenderTerminalPane || showNormalPreviousChatsPanel
+  // Workflow landing panel: WorkflowLayout passes the rendered node only when a
+  // fresh automation chat should show the previous-chats list. When present we
+  // make it the primary surface (mirrors the multi-agent landing panel) and
+  // suppress the workflow empty states / terminal / event display below it.
+  const showWorkflowPreviousChatsPanel = selectedModeCategory === 'workflow' && !!workflowPreviousChatsPanel
+  const shouldUseFullHeightContent = shouldRenderTerminalPane || showNormalPreviousChatsPanel || showWorkflowPreviousChatsPanel
 
   return (
     <div className="flex flex-col h-full min-w-0" data-testid="chat-area-container">
@@ -3079,21 +3090,26 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
                 <p className="text-sm text-gray-500 dark:text-gray-400">Restoring previous session...</p>
               </div>
             )}
+            {/* Previous automation chats — primary landing surface on a fresh chat
+                (mirrors the multi-agent landing panel). WorkflowLayout supplies the
+                node + resume handler so the workflow-scoped history logic lives in
+                one place. */}
+            {showWorkflowPreviousChatsPanel && workflowPreviousChatsPanel}
             {/* Empty State - Show when no events and not in historical session.
                 Skipped in Terminal view mode so the workflow ModeEmptyState
                 does not cover the TerminalCenter pane. */}
-            {displayEvents.length === 0 && !isStreaming && !isRestoringWorkflowSessions && !isChatCompatiblePhase(activeTab?.metadata?.phaseId) && activeEventViewMode !== 'terminal' && (
+            {!showWorkflowPreviousChatsPanel && displayEvents.length === 0 && !isStreaming && !isRestoringWorkflowSessions && !isChatCompatiblePhase(activeTab?.metadata?.phaseId) && activeEventViewMode !== 'terminal' && (
               <ModeEmptyState modeCategory={selectedModeCategory} />
             )}
             {/* Phase Chat Help - Show only before the workflow-builder conversation starts */}
-            {!hidePhaseChatEmptyState && displayEvents.length === 0 && activeEventViewMode !== 'terminal' && !isRestoringWorkflowSessions && !showWorkflowsOverview && !activeTab?.metadata?.isOrganizationAssistant && !activeTab?.isStreaming && isChatCompatiblePhase(activeTab?.metadata?.phaseId) && (
+            {!showWorkflowPreviousChatsPanel && !hidePhaseChatEmptyState && displayEvents.length === 0 && activeEventViewMode !== 'terminal' && !isRestoringWorkflowSessions && !showWorkflowsOverview && !activeTab?.metadata?.isOrganizationAssistant && !activeTab?.isStreaming && isChatCompatiblePhase(activeTab?.metadata?.phaseId) && (
               <PhaseChatEmptyState phaseId={activeTab!.metadata!.phaseId!} compact={compact} />
             )}
 
-            {activeTab?.sessionId && activeEventViewMode === 'terminal' && (
+            {!showWorkflowPreviousChatsPanel && activeTab?.sessionId && activeEventViewMode === 'terminal' && (
               <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
             )}
-            {activeTab?.sessionId && activeEventViewMode !== 'terminal' && (
+            {!showWorkflowPreviousChatsPanel && activeTab?.sessionId && activeEventViewMode !== 'terminal' && (
               <EventDisplay events={displayEvents} executionTree={sessionExecutionTree} onFeedbackSubmitted={handleFeedbackSubmitted} onSendMessage={submitQueryWithQuery} compact={compact} sessionId={activeTab.sessionId} tabId={targetTabId || undefined} />
             )}
           </WorkflowModeHandler>

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -3013,7 +3013,7 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
           around the fixed-height terminal box. */}
       <div ref={chatContentRef} className={`flex-1 ${shouldUseFullHeightContent ? 'overflow-hidden' : 'overflow-y-auto'} overflow-x-hidden min-w-0 relative overscroll-y-none ${compact ? 'text-sm' : ''}`} style={{ scrollBehavior: 'auto' }}>
         
-        <div className={`min-w-0 ${shouldUseFullHeightContent ? 'flex h-full flex-col' : 'min-h-full'} ${shouldRenderTerminalPane ? '' : (compact ? 'px-2 pb-2' : 'px-4 pb-4')}`}>
+        <div className={`min-w-0 ${shouldUseFullHeightContent ? 'flex h-full flex-col' : 'min-h-full'} ${shouldRenderTerminalPane ? '' : (compact ? 'px-2 pb-2' : 'px-3 pb-4')}`}>
           {/* Loading indicator for historical events */}
           {isLoadingHistory && (
             <div className={`flex items-center justify-center ${compact ? 'py-4' : 'py-8'}`}>

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -3013,6 +3013,32 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
     isReadOnlyRunView,
   })
 
+  // Keep the bottom "Resuming coding session" indicator in sync with the surface
+  // (both modes). A native/terminal resume that settles onto the previous-chats
+  // list (landing) yielded nothing live, so its restore markers are stale: clear
+  // them so the indicator disappears and typing starts a fresh chat instead of
+  // silently resuming a chat you're no longer viewing. (File-fallback resumes —
+  // NativeResume false — stay: their attached file context still drives the next
+  // turn. Read-only run views never reach landing, so they're untouched.)
+  const activeChatSurface = selectedModeCategory === 'workflow' ? workflowSurface : multiAgentSurface
+  useEffect(() => {
+    if (activeChatSurface !== 'landing') return
+    const tabId = activeTab?.tabId
+    const cfg = activeTab?.config
+    if (!tabId || cfg?.restoredConversationNativeResume !== true) return
+    const restoredPath = cfg.restoredConversationPath?.trim()
+    if (!restoredPath) return
+    useChatStore.getState().setTabConfig(tabId, {
+      restoredConversationPath: undefined,
+      restoredConversationSummary: undefined,
+      restoredConversationTitle: undefined,
+      restoredConversationWorkshopModeLabel: undefined,
+      restoredConversationRuntimeLabel: undefined,
+      restoredConversationNativeResume: undefined,
+      fileContext: (cfg.fileContext || []).filter(item => item.path !== restoredPath),
+    })
+  }, [activeChatSurface, activeTab?.tabId, activeTab?.config])
+
   // Multi-agent landing surface = the previous-chats panel (mirrors the old
   // showNormalPreviousChatsPanel).
   const showNormalPreviousChatsPanel = selectedModeCategory === 'multi-agent' && multiAgentSurface === 'landing'

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -50,8 +50,17 @@ const STALE_STREAMING_RECOVERY_GRACE_MS = 10000
 // before isRestoringChatSessions flips true; a freshly-resumed chat streams its
 // first turn shortly after). The previous-chats list stays hidden during this
 // window so a NON-empty resumed chat doesn't flash the list before its first
-// event arrives; once it elapses still-empty, the list is revealed.
-const RESUME_SETTLE_MS = 2500
+// event/terminal arrives; once it elapses still-empty, the list is revealed.
+//
+// CRITICAL: this MUST outlast the useSessionTerminals presence probe so the list
+// never flashes mid-resume. That probe (src/hooks/useSessionTerminals.ts) polls
+// every 3000ms and the restored static snapshot only lands after the async
+// restore-terminal POST, so the terminal is typically detected on the 2nd–3rd
+// poll (~3–6s). A 2500ms settle expired BEFORE the probe's second poll → the
+// resolver fell to 'landing' and the user had to click Resume 2–3 times. 10000ms
+// gives the probe ~4 polls to confirm the terminal (→ 'active') before the settle
+// can ever fall through to 'landing' (only a genuinely dead/empty resume does).
+const RESUME_SETTLE_MS = 10000
 const STREAMING_EVENT_TYPES = new Set(['streaming_start', 'streaming_chunk', 'streaming_end'])
 
 type RuntimeEventScope = {
@@ -895,15 +904,19 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
   // isRestoringChatSessions flips true) so a NON-empty resumed chat doesn't flash
   // the list before its first event settles.
   const [resumeSettling, setResumeSettling] = useState(false)
+  // Use the ACTIVE TAB's streaming flag, not the global state.isStreaming, which
+  // lingers true after New Chat from a running conversation (a cross-tab signal,
+  // not session-scoped) and would wrongly clear the settle / force 'active'.
+  const activeTabStreaming = !!activeTab?.isStreaming
   useEffect(() => {
-    if (!activeTabHasRestoredConversation || hasConversationContent || isStreaming) {
+    if (!activeTabHasRestoredConversation || hasConversationContent || activeTabStreaming) {
       setResumeSettling(false)
       return
     }
     setResumeSettling(true)
     const timer = window.setTimeout(() => setResumeSettling(false), RESUME_SETTLE_MS)
     return () => window.clearTimeout(timer)
-  }, [activeTabHasRestoredConversation, hasConversationContent, isStreaming, activeSessionId])
+  }, [activeTabHasRestoredConversation, hasConversationContent, activeTabStreaming, activeSessionId])
   // A tab observing a specific scheduled/bot run is a read-only view of THAT
   // run, never a fresh chat. The chat-surface resolver keeps such tabs in
   // restoring (while events load) or active (once present) and never lets them
@@ -2996,20 +3009,32 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
   // multi-agent and workflow render branches (see ./resolveChatSurface). The two
   // branches derive `hasContent` differently (mirroring today's behavior):
   // multi-agent keys off conversation events, workflow off any display event.
+  // isStreaming below is the ACTIVE TAB's flag (activeTabStreaming), NOT the
+  // global state.isStreaming. The global flag is a cross-tab signal that lingers
+  // true after New Chat from a running conversation (resetTabChat rotates the
+  // sessionId + clears the per-tab flag but does not reset the global one), which
+  // wrongly kept a fresh New-Chat tab on 'active' (empty terminal) instead of
+  // 'landing'. Reading the per-tab flag scopes "is streaming" to THIS session.
   const multiAgentSurface = resolveChatSurface({
     isRestoring: isRestoringChatSessions,
     resumeSettling,
     hasContent: hasConversationContent,
-    isStreaming,
+    isStreaming: activeTabStreaming,
     hasRestoredLiveContent,
     isReadOnlyRunView,
   })
+  // Workflow shares the resume-pending signals (resumeSettling + the terminal/
+  // execution-tree probe) so a coding-agent/terminal resume in the workflow pane
+  // stays 'restoring' until its terminal is confirmed — then 'active' — instead of
+  // flashing the previous-chats list on the first Resume click. Both inputs are
+  // false/gated whenever there's no restoredConversationPath, so a FRESH workflow
+  // chat is unaffected (still resolves to 'landing').
   const workflowSurface = resolveChatSurface({
     isRestoring: isRestoringWorkflowSessions,
-    resumeSettling: false,
+    resumeSettling,
     hasContent: displayEvents.length > 0,
-    isStreaming: isStreaming || !!activeTab?.isStreaming,
-    hasRestoredLiveContent: false,
+    isStreaming: activeTabStreaming,
+    hasRestoredLiveContent,
     isReadOnlyRunView,
   })
 

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -16,6 +16,7 @@ import { useAppStore, useLLMStore, useMCPStore, useChatStore, useGlobalPresetSto
 import { useModeStore, type ModeCategory } from '../stores/useModeStore'
 import { ModeEmptyState } from './ModeEmptyState'
 import { PreviousChatHistoryPanel } from './PreviousChatHistoryPanel'
+import { resolveChatSurface } from './resolveChatSurface'
 import { PresetSelectionOverlay } from './PresetSelectionOverlay'
 import { ModeSwitchDialog } from './ui/ModeSwitchDialog'
 import { normalizeEventViewMode, type ChatTab } from '../stores/useChatStore'
@@ -26,6 +27,7 @@ import { summarizeEventForDebug } from '../utils/eventOrdering'
 import { secretsApi } from '../api/secrets'
 import { useSecretsStore } from '../stores'
 import { useSessionExecutionTree } from '../hooks/useSessionExecutionTree'
+import { useSessionTerminals } from '../hooks/useSessionTerminals'
 import { useResumePreviousChat } from '../hooks/useResumePreviousChat'
 import { requestTerminalRefreshBurst } from '../utils/terminalRefresh'
 import {
@@ -854,7 +856,6 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
   
   // State for session restoration loading
   const [isRestoringChatSessions, setIsRestoringChatSessions] = useState(false)
-  const [hasPreviousNormalChats, setHasPreviousNormalChats] = useState(false)
   // Workflow-mode restore flag is owned by WorkflowLayout via useChatStore so we can show
   // an in-panel spinner here while reconnectWorkflowTabs() is replaying events.
   const isRestoringWorkflowSessions = useChatStore(state => state.isRestoringWorkflowSessions)
@@ -875,6 +876,21 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
       sessionExecutionTree.summary.completed_count +
       sessionExecutionTree.summary.failed_count +
       sessionExecutionTree.summary.canceled_count) > 0
+  // A native/terminal resume reattaches a live terminal but produces NO
+  // execution-tree nodes, so restoredSessionHasExecutionContent alone can't see
+  // it — without this probe the surface would flip from the restored terminal to
+  // the previous-chats landing once the settle window elapsed. Probe the same
+  // terminal list that decides TerminalCenter's "No terminals yet" empty state;
+  // a present terminal means the resumed tab's surface is the terminal pane.
+  const { data: sessionTerminals } = useSessionTerminals(
+    activeSessionId,
+    !!activeSessionId && activeTabHasRestoredConversation,
+  )
+  const restoredSessionHasTerminal =
+    activeTabHasRestoredConversation && (sessionTerminals?.terminals?.length ?? 0) > 0
+  // Any recognized "this resumed tab is live" signal: execution-tree activity OR
+  // a live terminal pane. Feeds the resolver's active-over-landing decision.
+  const hasRestoredLiveContent = restoredSessionHasExecutionContent || restoredSessionHasTerminal
   // Bridge the brief load gap for event-based resumes (and page-load restore before
   // isRestoringChatSessions flips true) so a NON-empty resumed chat doesn't flash
   // the list before its first event settles.
@@ -888,18 +904,12 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
     const timer = window.setTimeout(() => setResumeSettling(false), RESUME_SETTLE_MS)
     return () => window.clearTimeout(timer)
   }, [activeTabHasRestoredConversation, hasConversationContent, isStreaming, activeSessionId])
-  const showNormalPreviousChatsPanel = selectedModeCategory === 'multi-agent' &&
-    !hasConversationContent &&
-    !isStreaming &&
-    !isRestoringChatSessions &&
-    !resumeSettling &&
-    !restoredSessionHasExecutionContent
-
-  useEffect(() => {
-    if (!showNormalPreviousChatsPanel) {
-      setHasPreviousNormalChats(false)
-    }
-  }, [showNormalPreviousChatsPanel])
+  // A tab observing a specific scheduled/bot run is a read-only view of THAT
+  // run, never a fresh chat. The chat-surface resolver keeps such tabs in
+  // restoring (while events load) or active (once present) and never lets them
+  // bounce to the previous-chats landing panel (the "schedule-bounce" fix).
+  const isReadOnlyRunView =
+    !!activeTab?.metadata?.isScheduledRun || !!activeTab?.metadata?.isBotRun
 
   // Resume a previous chat from the landing "Previous chats" panel. The same
   // resume path is used anywhere else that needs to restore a multi-agent chat.
@@ -2982,13 +2992,39 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
     currentWorkflowPhase
   }), [handleNewChat, resetChatState, refreshWorkflowPresets, submitQueryWithQuery, displayEvents, isStreaming, currentWorkflowPhase])
 
-  const shouldRenderTerminalPane = activeEventViewMode === 'terminal' && !showNormalPreviousChatsPanel
-  const shouldRenderEventDisplay = activeEventViewMode !== 'terminal' && !showNormalPreviousChatsPanel
+  // Single source of truth for "which surface shows" — shared by BOTH the
+  // multi-agent and workflow render branches (see ./resolveChatSurface). The two
+  // branches derive `hasContent` differently (mirroring today's behavior):
+  // multi-agent keys off conversation events, workflow off any display event.
+  const multiAgentSurface = resolveChatSurface({
+    isRestoring: isRestoringChatSessions,
+    resumeSettling,
+    hasContent: hasConversationContent,
+    isStreaming,
+    hasRestoredLiveContent,
+    isReadOnlyRunView,
+  })
+  const workflowSurface = resolveChatSurface({
+    isRestoring: isRestoringWorkflowSessions,
+    resumeSettling: false,
+    hasContent: displayEvents.length > 0,
+    isStreaming: isStreaming || !!activeTab?.isStreaming,
+    hasRestoredLiveContent: false,
+    isReadOnlyRunView,
+  })
+
+  // Multi-agent landing surface = the previous-chats panel (mirrors the old
+  // showNormalPreviousChatsPanel).
+  const showNormalPreviousChatsPanel = selectedModeCategory === 'multi-agent' && multiAgentSurface === 'landing'
   // Workflow landing panel: WorkflowLayout passes the rendered node only when a
   // fresh automation chat should show the previous-chats list. When present we
   // make it the primary surface (mirrors the multi-agent landing panel) and
   // suppress the workflow empty states / terminal / event display below it.
   const showWorkflowPreviousChatsPanel = selectedModeCategory === 'workflow' && !!workflowPreviousChatsPanel
+  // Layout: the terminal pane is full-height unless the multi-agent landing list
+  // is covering it; the two landing panels are also full-height. (Preserves the
+  // original shouldRenderTerminalPane / shouldUseFullHeightContent formulas.)
+  const shouldRenderTerminalPane = activeEventViewMode === 'terminal' && !showNormalPreviousChatsPanel
   const shouldUseFullHeightContent = shouldRenderTerminalPane || showNormalPreviousChatsPanel || showWorkflowPreviousChatsPanel
 
   return (
@@ -3083,68 +3119,83 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
             onPresetCleared={handleWorkflowPresetCleared}
             onWorkflowPhaseChange={setCurrentWorkflowPhase}
           >
-            {/* Restoring Sessions Loading Indicator - shown while reconnectWorkflowTabs replays events */}
-            {isRestoringWorkflowSessions && displayEvents.length === 0 && !isStreaming && (
+            {/* restoring — reconnectWorkflowTabs is replaying events. */}
+            {workflowSurface === 'restoring' && (
               <div className="flex flex-col items-center justify-center py-12 gap-3">
                 <div className="w-6 h-6 border-2 border-gray-300 dark:border-gray-600 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin"></div>
                 <p className="text-sm text-gray-500 dark:text-gray-400">Restoring previous session...</p>
               </div>
             )}
-            {/* Previous automation chats — primary landing surface on a fresh chat
-                (mirrors the multi-agent landing panel). WorkflowLayout supplies the
-                node + resume handler so the workflow-scoped history logic lives in
-                one place. */}
-            {showWorkflowPreviousChatsPanel && workflowPreviousChatsPanel}
-            {/* Empty State - Show when no events and not in historical session.
-                Skipped in Terminal view mode so the workflow ModeEmptyState
-                does not cover the TerminalCenter pane. */}
-            {!showWorkflowPreviousChatsPanel && displayEvents.length === 0 && !isStreaming && !isRestoringWorkflowSessions && !isChatCompatiblePhase(activeTab?.metadata?.phaseId) && activeEventViewMode !== 'terminal' && (
-              <ModeEmptyState modeCategory={selectedModeCategory} />
-            )}
-            {/* Phase Chat Help - Show only before the workflow-builder conversation starts */}
-            {!showWorkflowPreviousChatsPanel && !hidePhaseChatEmptyState && displayEvents.length === 0 && activeEventViewMode !== 'terminal' && !isRestoringWorkflowSessions && !showWorkflowsOverview && !activeTab?.metadata?.isOrganizationAssistant && !activeTab?.isStreaming && isChatCompatiblePhase(activeTab?.metadata?.phaseId) && (
-              <PhaseChatEmptyState phaseId={activeTab!.metadata!.phaseId!} compact={compact} />
+
+            {/* active — terminal-or-events by the view toggle. */}
+            {workflowSurface === 'active' && activeTab?.sessionId && (
+              activeEventViewMode === 'terminal' ? (
+                <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
+              ) : (
+                <EventDisplay events={displayEvents} executionTree={sessionExecutionTree} onFeedbackSubmitted={handleFeedbackSubmitted} onSendMessage={submitQueryWithQuery} compact={compact} sessionId={activeTab.sessionId} tabId={targetTabId || undefined} />
+              )
             )}
 
-            {!showWorkflowPreviousChatsPanel && activeTab?.sessionId && activeEventViewMode === 'terminal' && (
-              <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
-            )}
-            {!showWorkflowPreviousChatsPanel && activeTab?.sessionId && activeEventViewMode !== 'terminal' && (
-              <EventDisplay events={displayEvents} executionTree={sessionExecutionTree} onFeedbackSubmitted={handleFeedbackSubmitted} onSendMessage={submitQueryWithQuery} compact={compact} sessionId={activeTab.sessionId} tabId={targetTabId || undefined} />
+            {/* landing — fresh automation chat. Prefer the previous-chats panel
+                (WorkflowLayout supplies the node + resume handler so the
+                workflow-scoped history logic lives in one place). With no panel,
+                fall back to the workflow empty states — in terminal view mode the
+                TerminalCenter owns its surface (empty states are suppressed there,
+                same as before) so it isn't covered by an empty state. */}
+            {workflowSurface === 'landing' && (
+              showWorkflowPreviousChatsPanel ? (
+                workflowPreviousChatsPanel
+              ) : activeEventViewMode === 'terminal' ? (
+                activeTab?.sessionId && (
+                  <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
+                )
+              ) : (
+                <>
+                  {/* Empty State for non-chat phases. */}
+                  {!isChatCompatiblePhase(activeTab?.metadata?.phaseId) && (
+                    <ModeEmptyState modeCategory={selectedModeCategory} />
+                  )}
+                  {/* Phase Chat Help — shown only before the workflow-builder
+                      conversation starts, on chat-compatible phases. */}
+                  {!hidePhaseChatEmptyState && !showWorkflowsOverview && !activeTab?.metadata?.isOrganizationAssistant && isChatCompatiblePhase(activeTab?.metadata?.phaseId) && (
+                    <PhaseChatEmptyState phaseId={activeTab!.metadata!.phaseId!} compact={compact} />
+                  )}
+                </>
+              )
             )}
           </WorkflowModeHandler>
         ) : (
           <>
-            {/* Restoring Sessions Loading Indicator */}
-            {isRestoringChatSessions && displayEvents.length === 0 && !isStreaming && (
+            {/* restoring — a previous multi-agent session is loading/replaying. */}
+            {multiAgentSurface === 'restoring' && (
               <div className="flex flex-col items-center justify-center py-12 gap-3">
                 <div className="w-6 h-6 border-2 border-gray-300 dark:border-gray-600 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin"></div>
                 <p className="text-sm text-gray-500 dark:text-gray-400">Restoring previous session...</p>
               </div>
             )}
-            {showNormalPreviousChatsPanel && (
+
+            {/* landing — fresh chat / New Chat. The panel renders the list OR its
+                own "No previous chats yet." empty, so it subsumes the old
+                standalone ModeEmptyState case for multi-agent. */}
+            {multiAgentSurface === 'landing' && (
               <PreviousChatHistoryPanel
                 activeSessionId={hasConversationContent ? activeTab?.sessionId ?? undefined : undefined}
                 title="Previous chats"
                 actionLabel="Resume"
                 emptyText="No previous chats yet."
-                onHasChatsChange={setHasPreviousNormalChats}
                 onSelectSession={handleResumePreviousChat}
                 fill
                 compact={previousChatsCompact}
               />
             )}
-            {/* Empty State - Show when no events and not in historical session.
-                Skipped in Terminal mode (same reason as workflow branch). */}
-            {!showNormalPreviousChatsPanel && !hasConversationContent && !isStreaming && !isRestoringChatSessions && !hasPreviousNormalChats && activeEventViewMode !== 'terminal' && (
-              <ModeEmptyState modeCategory={selectedModeCategory} />
-            )}
 
-            {activeTab?.sessionId && shouldRenderTerminalPane && (
-              <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
-            )}
-            {activeTab?.sessionId && shouldRenderEventDisplay && (
-              <EventDisplay events={displayEvents} executionTree={sessionExecutionTree} onFeedbackSubmitted={handleFeedbackSubmitted} onSendMessage={submitQueryWithQuery} compact={compact} sessionId={activeTab.sessionId} tabId={targetTabId || undefined} />
+            {/* active — terminal-or-events by the view toggle. */}
+            {multiAgentSurface === 'active' && activeTab?.sessionId && (
+              activeEventViewMode === 'terminal' ? (
+                <TerminalCenter currentSessionId={activeTab.sessionId} compact={false} hasConversationActivity={!suppressTerminalPane && (hasConversationContent || isStreaming || !!activeTab?.isStreaming)} />
+              ) : (
+                <EventDisplay events={displayEvents} executionTree={sessionExecutionTree} onFeedbackSubmitted={handleFeedbackSubmitted} onSendMessage={submitQueryWithQuery} compact={compact} sessionId={activeTab.sessionId} tabId={targetTabId || undefined} />
+              )
             )}
           </>
         )}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -255,6 +255,7 @@ import LLMConfigurationModal from './LLMConfigurationModal'
 import type { PlannerFile, LLMProvider, ChatHistorySession, TerminalSnapshot } from '../services/api-types'
 import type { LLMOption } from '../types/llm'
 import { useAppStore, useMCPStore, useLLMStore, useChatStore } from '../stores'
+import { normalizeEventViewMode } from '../stores/useChatStore'
 import { useCapabilitiesStore } from '../stores/useCapabilitiesStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useCommandDialogStore } from '../stores/useCommandDialogStore'
@@ -655,6 +656,17 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
   )
   const isOrganizationAssistant = !!activeTab?.metadata?.isOrganizationAssistant
   const isOrganizationContext = isOrganizationAssistant || showWorkflowsOverview
+  // When the live-terminal pane is the active surface (multi-agent + workflow
+  // phase chats, terminal view), reserve a stable height for the textarea so its
+  // per-keystroke height thrash (the height='auto'→scrollHeight measure, plus the
+  // 40→100px auto-grow) is absorbed INSIDE a fixed-height container and never
+  // changes the ChatInput's outer height. ChatInput is the flex sibling of the
+  // flex-1 terminal, so an invariant ChatInput height keeps the terminal
+  // container's height invariant too — no ResizeObserver→fit→onResize→/resize
+  // churn (and no backend tmux resize-window / ResetForResize) from typing.
+  const terminalPaneActive =
+    (isMultiAgentMode || isWorkflowPhaseChat) &&
+    normalizeEventViewMode(activeTab?.viewMode) === 'terminal'
   
   // Memoize tabConfig to prevent unnecessary re-renders
   const tabConfig = useMemo(() => activeTab?.config, [activeTab?.config])
@@ -1638,12 +1650,25 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
   const adjustTextareaHeight = useCallback(() => {
     if (textareaRef.current) {
       const textarea = textareaRef.current
+      // Fast path: the box is already at the 2-line floor and the content fits
+      // (no vertical overflow). There is nothing to grow or shrink, so DON'T flip
+      // height to 'auto' — that forced reflow is what jitters the flex column and
+      // fires the terminal's ResizeObserver on every keystroke, even a single
+      // character that needs no growth at all.
+      if (textarea.style.height === '40px' && textarea.scrollHeight <= textarea.clientHeight) {
+        return
+      }
       // Reset height to auto to get correct scrollHeight
       textarea.style.height = 'auto'
       // Calculate new height (min 40px for 2 lines, max 100px)
       // scrollHeight includes padding, so we get the exact content height
       const newHeight = Math.min(Math.max(textarea.scrollHeight, 40), 100)
-      textarea.style.height = `${newHeight}px`
+      const newHeightPx = `${newHeight}px`
+      // Only write when it actually changes so an unchanged height never leaves a
+      // pending style mutation / extra layout pass.
+      if (textarea.style.height !== newHeightPx) {
+        textarea.style.height = newHeightPx
+      }
     }
   }, [])
 
@@ -3682,7 +3707,13 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                 </button>
               </div>
             )}
-            {/* Show text input */}
+            {/* Show text input. In terminal-pane mode the textarea lives inside a
+                fixed 100px box (its max height) and is bottom-anchored, so it
+                grows UPWARD within that reserved space; the box height never
+                changes, so the textarea's height thrash cannot reach the terminal
+                container (see terminalPaneActive). The small headroom above the
+                textarea when the message is short shrinks as it grows. */}
+            <div className={terminalPaneActive ? 'flex h-[100px] flex-col justify-end' : undefined}>
             <Textarea
               data-tour="chat-input-box"
               ref={textareaRef}
@@ -3706,6 +3737,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
               disabled={keyboardMode ? false : inputDisabled}
               data-testid="chat-input-textarea"
             />
+            </div>
             {isDraggingFiles && (
               <div className="text-[11px] text-blue-600 dark:text-blue-400 px-1">
                 Drop files to upload and attach to this chat

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -255,7 +255,6 @@ import LLMConfigurationModal from './LLMConfigurationModal'
 import type { PlannerFile, LLMProvider, ChatHistorySession, TerminalSnapshot } from '../services/api-types'
 import type { LLMOption } from '../types/llm'
 import { useAppStore, useMCPStore, useLLMStore, useChatStore } from '../stores'
-import { normalizeEventViewMode } from '../stores/useChatStore'
 import { useCapabilitiesStore } from '../stores/useCapabilitiesStore'
 import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useCommandDialogStore } from '../stores/useCommandDialogStore'
@@ -656,18 +655,6 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
   )
   const isOrganizationAssistant = !!activeTab?.metadata?.isOrganizationAssistant
   const isOrganizationContext = isOrganizationAssistant || showWorkflowsOverview
-  // When the live-terminal pane is the active surface (multi-agent + workflow
-  // phase chats, terminal view), reserve a stable height for the textarea so its
-  // per-keystroke height thrash (the height='auto'→scrollHeight measure, plus the
-  // 40→100px auto-grow) is absorbed INSIDE a fixed-height container and never
-  // changes the ChatInput's outer height. ChatInput is the flex sibling of the
-  // flex-1 terminal, so an invariant ChatInput height keeps the terminal
-  // container's height invariant too — no ResizeObserver→fit→onResize→/resize
-  // churn (and no backend tmux resize-window / ResetForResize) from typing.
-  const terminalPaneActive =
-    (isMultiAgentMode || isWorkflowPhaseChat) &&
-    normalizeEventViewMode(activeTab?.viewMode) === 'terminal'
-  
   // Memoize tabConfig to prevent unnecessary re-renders
   const tabConfig = useMemo(() => activeTab?.config, [activeTab?.config])
 
@@ -3707,13 +3694,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
                 </button>
               </div>
             )}
-            {/* Show text input. In terminal-pane mode the textarea lives inside a
-                fixed 100px box (its max height) and is bottom-anchored, so it
-                grows UPWARD within that reserved space; the box height never
-                changes, so the textarea's height thrash cannot reach the terminal
-                container (see terminalPaneActive). The small headroom above the
-                textarea when the message is short shrinks as it grows. */}
-            <div className={terminalPaneActive ? 'flex h-[100px] flex-col justify-end' : undefined}>
+            {/* Show text input — compact and auto-growing (no reserved dead
+                space). adjustTextareaHeight's early-return guard prevents the
+                per-keystroke height='auto' reflow that would otherwise resize the
+                terminal on single-line typing; only a real wrap grows it. */}
+            <div>
             <Textarea
               data-tour="chat-input-box"
               ref={textareaRef}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -3421,6 +3421,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
       ? 'text-blue-600 dark:text-blue-300'
       : 'text-emerald-600 dark:text-emerald-300'
 
+  // The multi-agent (Chief of Staff) chat pane aligns its left inset with the
+  // "Chief of Staff" heading (ChatTabs header, px-3); workflow mode keeps the
+  // wider px-4 so its toolbar layout is unchanged.
+  const inputPadX = isMultiAgentMode ? 'px-3' : 'px-4'
+
   // For view-only (restored) tabs, show a minimal indicator instead of the full input form
   if (isViewOnly) {
     const isScheduledRun = activeTab?.metadata?.isScheduledRun
@@ -3428,7 +3433,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     const jobName = activeTab?.metadata?.scheduledJobName
     const botPlatform = activeTab?.metadata?.botPlatform
     return (
-      <div data-tour="chat-input-area" data-testid="tour-chat-input-area" className="px-4 py-2">
+      <div data-tour="chat-input-area" data-testid="tour-chat-input-area" className={`${inputPadX} py-2`}>
         <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
           <History className="w-3.5 h-3.5" />
           <span>
@@ -3448,7 +3453,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
       <div className="space-y-2">
       {/* Pasted-text Attachments */}
       {chatPastedAttachments.length > 0 && (
-        <div className="px-4">
+        <div className={inputPadX}>
           <div className="border rounded px-1.5 py-0.5 mb-1 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-1.5 flex-wrap">
               <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
@@ -3494,7 +3499,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
 
       {/* Pending resume indicator */}
       {restoredConversationPath && (
-        <div className="px-4 border-t border-border">
+        <div className={`${inputPadX} border-t border-border`}>
           <div className="mb-1 rounded-md border border-border bg-card px-2 py-1 shadow-sm">
             <div className="flex min-w-0 items-center justify-between gap-2">
               <div className="flex min-w-0 items-center gap-1.5 text-xs text-foreground">
@@ -3535,7 +3540,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
 
       {/* File Context Display */}
       {chatFileContext.length > 0 && (
-        <div className="px-4 border-t border-gray-200 dark:border-gray-700">
+        <div className={`${inputPadX} border-t border-gray-200 dark:border-gray-700`}>
           <FileContextDisplay
             files={chatFileContext}
             onRemoveFile={removeFileFromContext}
@@ -3549,7 +3554,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
 
       {/* Workflow Context Display — same style as FileContextDisplay */}
       {(tabConfig?.workflowContext?.length ?? 0) > 0 && (
-        <div className="px-4">
+        <div className={inputPadX}>
           <div className="border rounded px-1.5 py-0.5 mb-1 bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700">
             <div className="flex items-center gap-1.5 flex-wrap">
               <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
@@ -3609,7 +3614,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
 
 
       {/* Input Form */}
-      <div data-tour="chat-input-area" data-testid="tour-chat-input-area" className="px-4 py-2">
+      <div data-tour="chat-input-area" data-testid="tour-chat-input-area" className={`${inputPadX} py-2`}>
         <form onSubmit={handleSubmit} className="space-y-2">
           <div className="space-y-1">
             {liveMessageDelivery && (

--- a/frontend/src/components/ChatTabs.tsx
+++ b/frontend/src/components/ChatTabs.tsx
@@ -362,6 +362,7 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
       </div>
 
       <div className="ml-auto flex items-center gap-1">
+        <OrgPulseControl />
         {showHeaderContent && (
           <div className="mr-1 flex items-center gap-1 border-r border-gray-200 pr-2 dark:border-gray-700">
             <ServerSelectionDropdown
@@ -479,7 +480,6 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
             )}
           </TooltipContent>
         </Tooltip>
-        <OrgPulseControl />
         <OrgBackupPublishControls onSubmitCommand={onSubmitOrgCommand} />
       </div>
 

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -1987,6 +1987,10 @@ const XtermTerminalPaneInner: React.FC<{
   const applyContentRef = useRef<((next: string) => void) | null>(null)
   const onViewportStickChangeRef = useRef(onViewportStickChange)
   const onResizeRef = useRef(onResize)
+  // contentSource is a prop; the mount effect's onResize handler closes over the
+  // INITIAL render's value (empty deps), so mirror it in a ref to normalize the
+  // carry-over repaint correctly on later resizes.
+  const contentSourceRef = useRef(contentSource)
 
   useEffect(() => {
     onViewportStickChangeRef.current = onViewportStickChange
@@ -1995,6 +1999,10 @@ const XtermTerminalPaneInner: React.FC<{
   useEffect(() => {
     onResizeRef.current = onResize
   }, [onResize])
+
+  useEffect(() => {
+    contentSourceRef.current = contentSource
+  }, [contentSource])
 
   const logXtermDebug = useCallback((phase: string, extra: Record<string, unknown> = {}) => {
     if (!terminalScrollDebugEnabled()) return
@@ -2057,13 +2065,29 @@ const XtermTerminalPaneInner: React.FC<{
     // we POST the new size and re-seed exactly once per real geometry change.
     const resizeDisposable = term.onResize(({ cols, rows }) => {
       // Re-seed on geometry change: the pipe recording still holds frames captured
-      // at the OLD pane size; replaying/appending them into the resized grid is the
-      // litter. Reset and drop our content trackers so the next content fetch
-      // rebuilds cleanly at the new geometry (resize first, rebuild on next fetch —
-      // don't render old-geometry pipe bytes after a resize).
+      // at the OLD pane size, and the pipe file is append-only — so the NEXT capture
+      // starts with the old bytes. Appending that delta (which carries tmux's own
+      // resize-redraw escapes) into the resized grid is the litter. We therefore
+      // STILL force a clean full rebuild on the next fetch by clearing lastContentRef
+      // (previousContent==='' → applyContent rebuilds with an inline RIS, never an
+      // append).
+      //
+      // The bug this avoids: clearing alone also blanked the pane until that next
+      // fetch (up to a full poll interval). When the chat input auto-grows (a few
+      // wrapped lines of typing in the narrow layout) it momentarily shrinks this
+      // flex-sibling pane mid-stream → grid change → onResize → blank. So we repaint
+      // the content we ALREADY have IMMEDIATELY (inline RIS + full write) to bridge
+      // that gap. This repaint does NOT touch lastContentRef, so the next fetch still
+      // does its clean litter-free rebuild and overwrites this bridge frame.
+      const carryOver = lastContentRef.current
       term.reset()
       lastContentRef.current = ''
       pendingContentRef.current = null
+      if (carryOver) {
+        const payload = normalizeXtermWriteContent(carryOver, contentSourceRef.current)
+        term.write('\x1bc' + payload)
+        term.scrollToBottom()
+      }
       // Drive the tmux resize from xterm's real grid so the pane matches 1:1.
       onResizeRef.current?.(cols, rows)
       logXtermDebug('resize', { cols, rows })

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, ArrowDownToLine, ArrowRightToLine, Braces, Bug, Check, ChevronDown, ChevronsLeft, ChevronsRight, ChevronUp, Copy, CornerDownLeft, CornerUpLeft, GitBranch, History, Info, Minus, Palette, Plus, Power, RefreshCw, Square, Terminal, Trash2, X } from 'lucide-react'
 import { AnsiUp } from 'ansi_up'
 import { Terminal as XTerm, type ITheme } from '@xterm/xterm'
@@ -1966,7 +1966,7 @@ const ColoredText: React.FC<{ rawText: string; className?: string }> = ({ rawTex
   return <span className={className} dangerouslySetInnerHTML={{ __html: html }} />
 }
 
-const XtermTerminalPane: React.FC<{
+const XtermTerminalPaneInner: React.FC<{
   content: string
   contentSource?: string
   className?: string
@@ -2286,6 +2286,11 @@ const XtermTerminalPane: React.FC<{
   )
 }
 
+// Memoized so a parent (TerminalCenter) re-render that leaves this pane's props
+// unchanged does NOT tear down / rewrite the live xterm. Its callback props are
+// all useCallback-stable, so re-render now tracks content/theme changes only.
+const XtermTerminalPane = memo(XtermTerminalPaneInner)
+
 function normalizeXtermWriteContent(content: string, contentSource?: string): string {
   if (contentSource === 'tmux_pipe') {
     return content
@@ -2380,7 +2385,7 @@ function formatStatusFooterCost(usd?: number): string {
   return `$${formatCost(usd)}`
 }
 
-const StructuredTerminalView: React.FC<StructuredTerminalViewProps> = ({ content, rows: structuredRows, scrollRef, onScroll, onWheel, terminal, theme }) => {
+const StructuredTerminalViewInner: React.FC<StructuredTerminalViewProps> = ({ content, rows: structuredRows, scrollRef, onScroll, onWheel, terminal, theme }) => {
   const rows = useMemo(() => {
     const normalizedRows = normalizeTerminalRows(structuredRows)
     return normalizedRows.length > 0 ? normalizedRows : parseTerminalContent(content)
@@ -2587,6 +2592,10 @@ const StructuredTerminalView: React.FC<StructuredTerminalViewProps> = ({ content
     </div>
   )
 }
+
+// Memoized for the same reason as XtermTerminalPane: a parent re-render with
+// unchanged props (callbacks are useCallback-stable) must not re-render the view.
+const StructuredTerminalView = memo(StructuredTerminalViewInner)
 
 function isSyntheticTerminal(terminal: TerminalSnapshot): boolean {
   const transport = (terminal.step_transport || '').toLowerCase()
@@ -2873,7 +2882,7 @@ function writeDismissedTerminalErrorIDs(sessionId: string | undefined, ids: Set<
   }
 }
 
-export const TerminalCenter: React.FC<TerminalCenterProps> = ({ currentSessionId, compact, hasConversationActivity = false }) => {
+const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, compact, hasConversationActivity = false }) => {
   // terminalCenterOpen was the legacy toggle gate (separate sidekick
   // panel); kept here for any callers that still pass the flag but no
   // longer affects rendering — Debug-mode mount is the only gate.
@@ -4713,3 +4722,10 @@ export const TerminalCenter: React.FC<TerminalCenterProps> = ({ currentSessionId
     </div>
   )
 }
+
+// FIX A: Memoized so typing in the chat input — which re-renders ChatArea (the
+// parent) — does NOT re-render the terminal subtree and disturb the live xterm
+// panes. Props (currentSessionId, compact, hasConversationActivity) are all
+// primitives and stable while typing, so the shallow-prop comparison short-
+// circuits the re-render.
+export const TerminalCenter = memo(TerminalCenterInner)

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -3085,6 +3085,10 @@ const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, 
   const fastPollIntervalRef = useRef<number | null>(null)
   const lastSizeHintSentRef = useRef<{ cols: number; rows: number } | null>(null)
   const lastResizeSentRef = useRef<{ terminalId: string; cols: number; rows: number } | null>(null)
+  // Latest real xterm grid (cols/rows from term.onResize), remembered even when we
+  // can't POST /resize yet (e.g. a resumed terminal whose tmux_session hasn't been
+  // materialized). Lets us push the grid the moment tmux_session appears.
+  const lastXtermGridRef = useRef<{ cols: number; rows: number } | null>(null)
   const terminalTheme = TERMINAL_THEMES[terminalColorScheme]
 
   useEffect(() => {
@@ -3912,9 +3916,29 @@ const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, 
   }, [])
 
   const handleSelectedXtermResize = useCallback((cols: number, rows: number) => {
+    // Always remember the real xterm grid, even when we can't POST yet (no
+    // tmux_session). A resumed terminal starts as the static snapshot (tmux_session
+    // === '') so this early-returns; once the live tmux is materialized the effect
+    // below replays this remembered grid (term.onResize won't re-fire on its own
+    // because the grid didn't change).
+    lastXtermGridRef.current = { cols, rows }
     if (!selectedTerminalView || !selectedTerminalView.tmux_session || isSyntheticTerminal(selectedTerminalView)) return
     sendTerminalResize(selectedTerminalView.terminal_id, cols, rows)
   }, [selectedTerminalView, sendTerminalResize])
+
+  // Resume gap closer: when a terminal's tmux_session first becomes available
+  // (static restored snapshot → live materialized tmux, same canonical
+  // terminal_id), xterm has already fitted, so term.onResize won't fire again and
+  // /resize would never be sent — tmux would keep its launch geometry and pi-cli's
+  // full-screen redraws would append instead of overwrite (duplicated frames).
+  // Proactively push the current xterm grid so the pane matches the xterm 1:1,
+  // exactly like a new chat. Idempotent: sendTerminalResize dedupes by id+cols+rows.
+  useEffect(() => {
+    if (!selectedTerminalView || !selectedTerminalView.tmux_session || isSyntheticTerminal(selectedTerminalView)) return
+    const grid = lastXtermGridRef.current
+    if (!grid) return
+    sendTerminalResize(selectedTerminalView.terminal_id, grid.cols, grid.rows)
+  }, [selectedTerminalView?.terminal_id, selectedTerminalView?.tmux_session, sendTerminalResize])
 
   // Startup/idle size hint: keep the backend's preferred tmux launch size in
   // sync with the visible TerminalCenter container, even before any terminal

--- a/frontend/src/components/org/OrgHtmlPanels.tsx
+++ b/frontend/src/components/org/OrgHtmlPanels.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Activity, Brain, Laptop, PanelRightClose, RefreshCw, Smartphone, TabletSmartphone, Target } from 'lucide-react'
+import { Activity, Brain, PanelRightClose, RefreshCw, Target } from 'lucide-react'
 import { agentApi } from '../../services/api'
 import { useAuthStore } from '../../stores/useAuthStore'
 import { useTheme } from '../../hooks/useTheme'
@@ -9,18 +9,11 @@ import {
   ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT,
   getOrgHtmlPreviewDevice,
   orgHtmlPreviewShellClass,
-  setOrgHtmlPreviewDevice,
   type OrgHtmlPreviewDevice,
 } from './orgHtmlPreview'
 
 const ORG_PULSE_LOG_PATH = 'pulse/org-pulse.html'
 const ORG_GOALS_PATH = 'pulse/goals.html'
-
-const ORG_HTML_PREVIEW_DEVICE_OPTS = [
-  { mode: 'mobile' as const, Icon: Smartphone, label: 'Mobile preview' },
-  { mode: 'tablet' as const, Icon: TabletSmartphone, label: 'Tablet preview' },
-  { mode: 'desktop' as const, Icon: Laptop, label: 'Laptop preview' },
-]
 
 function applyThemeToOrgHtml(content: string, isDark: boolean): string {
   const themeAttr = isDark ? 'dark' : 'light'
@@ -115,7 +108,7 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
     if (fixedDevice) return // locked to fixedDevice — ignore the global preview preference
     const handler = (event: Event) => {
       const preference = (event as CustomEvent).detail?.preference
-      if (preference === 'mobile' || preference === 'tablet' || preference === 'desktop') {
+      if (preference === 'mobile' || preference === 'desktop') {
         setDevice(preference)
       }
     }
@@ -126,11 +119,6 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
   const refresh = useCallback(() => {
     void load()
   }, [load])
-
-  const selectDevice = useCallback((next: OrgHtmlPreviewDevice) => {
-    setDevice(next)
-    setOrgHtmlPreviewDevice(next)
-  }, [])
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
@@ -147,24 +135,6 @@ const OrgHtmlPanel: React.FC<OrgHtmlPanelProps> = ({ title, path, loadingText, e
           )}
         </div>
         <div className="flex flex-none items-center gap-1">
-          {!fixedDevice && (
-          <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-muted/70 p-0.5 shadow-sm">
-            {ORG_HTML_PREVIEW_DEVICE_OPTS.map(({ mode, Icon: DeviceIcon, label }) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => selectDevice(mode)}
-                title={label}
-                aria-label={label}
-                className={`inline-flex h-6 w-6 items-center justify-center rounded transition-colors ${
-                  device === mode ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                <DeviceIcon className="h-3.5 w-3.5" />
-              </button>
-            ))}
-          </div>
-          )}
           <button type="button" onClick={refresh} disabled={loading} title="Refresh" aria-label="Refresh" className={toolbarIconBtnClass}>
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           </button>

--- a/frontend/src/components/org/orgHtmlPreview.ts
+++ b/frontend/src/components/org/orgHtmlPreview.ts
@@ -1,12 +1,12 @@
 export const ORG_HTML_PREVIEW_PREFERENCE_KEY = 'org_html_preview_device'
 export const ORG_HTML_PREVIEW_PREFERENCE_CHANGED_EVENT = 'org-html-preview-device-changed'
 
-export type OrgHtmlPreviewDevice = 'mobile' | 'tablet' | 'desktop'
+export type OrgHtmlPreviewDevice = 'mobile' | 'desktop'
 
 export function getOrgHtmlPreviewDevice(): OrgHtmlPreviewDevice {
   try {
     const saved = localStorage.getItem(ORG_HTML_PREVIEW_PREFERENCE_KEY)
-    return saved === 'mobile' || saved === 'tablet' || saved === 'desktop' ? saved : 'mobile'
+    return saved === 'mobile' || saved === 'desktop' ? saved : 'mobile'
   } catch {
     return 'mobile'
   }
@@ -20,7 +20,5 @@ export function setOrgHtmlPreviewDevice(device: OrgHtmlPreviewDevice) {
 export function orgHtmlPreviewShellClass(device: OrgHtmlPreviewDevice): string {
   return device === 'mobile'
     ? 'mx-auto h-full w-full max-w-[480px]'
-    : device === 'tablet'
-      ? 'mx-auto h-full w-full max-w-[880px]'
-      : 'h-full w-full'
+    : 'h-full w-full'
 }

--- a/frontend/src/components/resolveChatSurface.test.ts
+++ b/frontend/src/components/resolveChatSurface.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { resolveChatSurface, type ChatSurfaceInputs } from './resolveChatSurface'
+
+// Baseline = a fresh New Chat: nothing loading, no content, no read-only run.
+const base: ChatSurfaceInputs = {
+  isRestoring: false,
+  resumeSettling: false,
+  hasContent: false,
+  isStreaming: false,
+  hasRestoredLiveContent: false,
+  isReadOnlyRunView: false,
+}
+
+describe('resolveChatSurface', () => {
+  it('New Chat (no content, no restore) → landing', () => {
+    expect(resolveChatSurface(base)).toBe('landing')
+  })
+
+  it('active content → active', () => {
+    expect(resolveChatSurface({ ...base, hasContent: true })).toBe('active')
+  })
+
+  it('streaming → active', () => {
+    expect(resolveChatSurface({ ...base, isStreaming: true })).toBe('active')
+  })
+
+  it('isRestoring + empty → restoring', () => {
+    expect(resolveChatSurface({ ...base, isRestoring: true })).toBe('restoring')
+  })
+
+  it('resume-empty (resumeSettling) → restoring', () => {
+    expect(resolveChatSurface({ ...base, resumeSettling: true })).toBe('restoring')
+  })
+
+  it('resume-with-execution/terminal content → active', () => {
+    expect(resolveChatSurface({ ...base, hasRestoredLiveContent: true })).toBe('active')
+  })
+
+  // --- Native/terminal resume (the terminal-only resume flicker fix) ---
+  // A native/terminal resume reattaches a live terminal but leaves NO
+  // execution-tree nodes; hasRestoredLiveContent carries the terminal-presence
+  // signal so the surface stays on the terminal instead of flipping to landing.
+  it('resumed tab with a terminal (no execution tree) → active', () => {
+    expect(resolveChatSurface({ ...base, hasRestoredLiveContent: true })).toBe('active')
+  })
+
+  it('resumed tab with neither terminal nor execution content after settle → landing', () => {
+    expect(
+      resolveChatSurface({ ...base, resumeSettling: false, hasRestoredLiveContent: false }),
+    ).toBe('landing')
+  })
+
+  it('resumed tab still settling → restoring (not landing)', () => {
+    expect(resolveChatSurface({ ...base, resumeSettling: true })).toBe('restoring')
+  })
+
+  it('resumed tab still settling but terminal already present → active (not landing)', () => {
+    expect(
+      resolveChatSurface({ ...base, resumeSettling: true, hasRestoredLiveContent: true }),
+    ).toBe('active')
+  })
+
+  it('content wins over a still-set restoring flag → active', () => {
+    expect(
+      resolveChatSurface({ ...base, isRestoring: true, hasContent: true }),
+    ).toBe('active')
+  })
+
+  it('restored terminal content wins over restoring flag → active', () => {
+    expect(
+      resolveChatSurface({ ...base, isRestoring: true, hasRestoredLiveContent: true }),
+    ).toBe('active')
+  })
+
+  // --- Read-only run view (scheduled/bot run) — the "schedule-bounce" fix ---
+  it('read-only run with no events yet → restoring (never landing)', () => {
+    expect(resolveChatSurface({ ...base, isReadOnlyRunView: true })).toBe('restoring')
+  })
+
+  it('read-only run with events → active', () => {
+    expect(
+      resolveChatSurface({ ...base, isReadOnlyRunView: true, hasContent: true }),
+    ).toBe('active')
+  })
+
+  it('read-only run while streaming → active', () => {
+    expect(
+      resolveChatSurface({ ...base, isReadOnlyRunView: true, isStreaming: true }),
+    ).toBe('active')
+  })
+
+  it('a normal fresh chat still → landing (read-only off)', () => {
+    expect(resolveChatSurface({ ...base, isReadOnlyRunView: false })).toBe('landing')
+  })
+})

--- a/frontend/src/components/resolveChatSurface.test.ts
+++ b/frontend/src/components/resolveChatSurface.test.ts
@@ -92,4 +92,43 @@ describe('resolveChatSurface', () => {
   it('a normal fresh chat still → landing (read-only off)', () => {
     expect(resolveChatSurface({ ...base, isReadOnlyRunView: false })).toBe('landing')
   })
+
+  // --- Resume coherence (Resume-first-click + New-Chat-from-running-conv) ---
+  // A resume in flight (restoredConversationPath set) before its terminal/content
+  // is detected must stay 'restoring', NOT flash 'landing'. The wiring keeps
+  // resumeSettling true long enough (RESUME_SETTLE_MS) to outlast the terminal
+  // presence probe so the resumed terminal shows on the FIRST Resume click.
+  it('resume pending (terminal not yet detected, settle active) → restoring not landing', () => {
+    expect(
+      resolveChatSurface({
+        ...base,
+        resumeSettling: true,
+        hasContent: false,
+        isStreaming: false,
+        hasRestoredLiveContent: false,
+      }),
+    ).toBe('restoring')
+  })
+
+  // New Chat from a RUNNING conversation: the fresh tab has rotated its sessionId
+  // and cleared its per-tab streaming flag, so the resolver receives isStreaming
+  // false even though the PRIOR session was streaming (the global state.isStreaming
+  // must NOT be fed here). With no content/restore signals it resolves to landing.
+  it('new chat after a prior session streamed (per-tab not streaming) → landing', () => {
+    expect(
+      resolveChatSurface({
+        ...base,
+        isStreaming: false, // per-tab flag for the fresh tab, not the lingering global
+        hasContent: false,
+        hasRestoredLiveContent: false,
+        resumeSettling: false,
+      }),
+    ).toBe('landing')
+  })
+
+  // A genuinely streaming tab (its OWN per-tab flag true) stays active — the
+  // per-tab scoping fix must not regress real streaming chats.
+  it('genuinely streaming active tab (per-tab true) → active', () => {
+    expect(resolveChatSurface({ ...base, isStreaming: true })).toBe('active')
+  })
 })

--- a/frontend/src/components/resolveChatSurface.ts
+++ b/frontend/src/components/resolveChatSurface.ts
@@ -1,0 +1,93 @@
+// resolveChatSurface — the single, pure 3-state resolver for the chat-pane
+// surface. Shared by BOTH the multi-agent (Chief of Staff) and the workflow
+// render branches in ChatArea so the "which surface shows" decision lives in
+// exactly one place.
+//
+// This is intentionally pure: no React, no store access — just inputs → enum.
+// Callers derive the inputs from their own state (the multi-agent and workflow
+// branches compute `hasContent` differently, mirroring today's behavior) and
+// then map the returned surface to the concrete JSX.
+
+export type ChatSurface = 'restoring' | 'active' | 'landing'
+
+export interface ChatSurfaceInputs {
+  /**
+   * A previous session is loading/replaying its events
+   * (isRestoringChatSessions for multi-agent, isRestoringWorkflowSessions for
+   * workflow).
+   */
+  isRestoring: boolean
+  /**
+   * Brief settle window for a freshly-resumed tab so an empty resume doesn't
+   * flash the previous-chats list before its first event arrives. Feeds the
+   * `restoring` state (multi-agent only; workflow passes false).
+   */
+  resumeSettling: boolean
+  /**
+   * A live/replayed conversation has content. Multi-agent uses
+   * `hasConversationContent` (user/assistant/completion events); workflow uses
+   * `displayEvents.length > 0` (its execution events aren't always
+   * "conversation" typed). Either way: real content is present.
+   */
+  hasContent: boolean
+  /** A streaming turn is in flight. */
+  isStreaming: boolean
+  /**
+   * A resumed session whose terminal/execution tree already has content
+   * (restoredSessionHasExecutionContent and/or a restored-terminal signal).
+   * Such a tab is live even before conversation events replay.
+   */
+  hasRestoredLiveContent: boolean
+  /**
+   * The tab is viewing a specific read-only run (scheduled or bot run). Such a
+   * tab is NEVER a fresh chat, so it must never fall to `landing`: while empty
+   * it stays in `restoring` (events still loading), and once content/terminal
+   * arrives it is `active`. This fixes the "schedule-bounce" where opening a
+   * scheduled run briefly showed the previous-chats panel.
+   */
+  isReadOnlyRunView: boolean
+}
+
+/**
+ * Resolve the chat-pane surface with explicit ordered precedence:
+ *   restoring → active → landing
+ *
+ * - `restoring`: nothing to show yet, but a session is replaying, a resume is
+ *   settling, or a read-only run view is still fetching → spinner.
+ * - `active`: a live or replayed conversation, an in-flight stream, or restored
+ *   terminal/execution content → terminal-or-events (the view toggle decides
+ *   which, NOT this resolver).
+ * - `landing`: a fresh chat / New Chat with no content → previous-chats panel
+ *   (which renders its own "none yet" empty when the list is empty).
+ */
+export function resolveChatSurface(inputs: ChatSurfaceInputs): ChatSurface {
+  const {
+    isRestoring,
+    resumeSettling,
+    hasContent,
+    isStreaming,
+    hasRestoredLiveContent,
+    isReadOnlyRunView,
+  } = inputs
+
+  // Any signal that real content exists. A resumed session with terminal/
+  // execution content counts even before conversation events replay — this is
+  // why the active check (below) must win over a still-set restoring flag.
+  const hasLiveOrRestoredContent = hasContent || isStreaming || hasRestoredLiveContent
+
+  // 1) restoring — still empty, but a session is replaying, a resume is
+  //    settling, or a read-only run view is loading its events.
+  if (!hasLiveOrRestoredContent && (isRestoring || resumeSettling || isReadOnlyRunView)) {
+    return 'restoring'
+  }
+
+  // 2) active — a live or replayed conversation, an in-flight stream, or
+  //    restored terminal/execution content.
+  if (hasLiveOrRestoredContent) {
+    return 'active'
+  }
+
+  // 3) landing — fresh chat / New Chat. A read-only run view never reaches here
+  //    (empty → restoring above; with content → active above).
+  return 'landing'
+}

--- a/frontend/src/components/workflow/ReportViewer.tsx
+++ b/frontend/src/components/workflow/ReportViewer.tsx
@@ -19,7 +19,7 @@ import {
   isHtmlDocumentWidget,
 } from './reportWidgets/shared'
 import { useCompactWidgetLayout, useContainerSizeTier } from './reportWidgets/tableHelpers'
-import { BarChart3, Check, ChevronDown, Download, Laptop, Loader2, RefreshCw, Smartphone, TabletSmartphone } from 'lucide-react'
+import { BarChart3, Check, ChevronDown, Download, Loader2, RefreshCw } from 'lucide-react'
 import { agentApi, workspaceApi } from '../../services/api'
 import { useReportFilePreviewStore } from '../../stores/useReportFilePreviewStore'
 import { useChatStore } from '../../stores/useChatStore'
@@ -457,10 +457,9 @@ interface ReportViewProps {
   reviewData?: unknown
   /** Optional close/back handler; when omitted, no close button is rendered (used for canvas-mode). */
   onClose?: () => void
-  // When the report pane is chat-focused it shrinks, so the parent caps the report
-  // at a smaller tier than the user's saved device width: laptop→tablet, and the
-  // narrowest case (saved mobile) → mobile. undefined = no chat-focus override.
-  focusTier?: 'mobile' | 'tablet'
+  // When the report pane is chat-focused in Mobile it shrinks, so the parent caps
+  // the report to mobile so it fits the narrow column. undefined = no override.
+  focusTier?: 'mobile'
 }
 
 // Source content cached per workspace-relative path. `undefined` = not yet fetched;
@@ -652,14 +651,14 @@ export function ReportViewer({ workspacePath, isOpen, onClose }: ReportViewerPro
 // Inline content — renders the report plan directly without modal chrome. Used by the
 // workflow canvas when canvasViewMode === 'report'.
 function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onClose, focusTier }: ReportViewProps) {
-  // Three explicit preview widths plus 'auto'. The internal name 'desktop' is
+  // Two explicit preview widths plus 'auto'. The internal name 'desktop' is
   // surfaced as "Laptop" in the UI to match the user's mental model — laptop
   // viewports are what fill the full max-width shell. 'auto' falls back to the
   // mobilePreview prop, used when nothing has been selected yet.
-  const [previewPreference, setPreviewPreference] = useState<'auto' | 'desktop' | 'tablet' | 'mobile'>(() => {
+  const [previewPreference, setPreviewPreference] = useState<'auto' | 'desktop' | 'mobile'>(() => {
     try {
       const saved = localStorage.getItem(reportPreviewPreferenceKey(workspacePath))
-      return saved === 'desktop' || saved === 'tablet' || saved === 'mobile' ? saved : 'mobile'
+      return saved === 'desktop' || saved === 'mobile' ? saved : 'mobile'
     } catch {
       return 'mobile'
     }
@@ -669,7 +668,7 @@ function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onC
   useEffect(() => {
     try {
       const saved = localStorage.getItem(reportPreviewPreferenceKey(workspacePath))
-      setPreviewPreference(saved === 'desktop' || saved === 'tablet' || saved === 'mobile' ? saved : 'mobile')
+      setPreviewPreference(saved === 'desktop' || saved === 'mobile' ? saved : 'mobile')
     } catch {
       setPreviewPreference('mobile')
     }
@@ -816,7 +815,7 @@ function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onC
       // Only react to changes for THIS workflow (scoped per workspacePath).
       if ((detail?.scopeId ?? null) !== (workspacePath ?? null)) return
       const p = detail?.preference
-      if (p === 'mobile' || p === 'tablet' || p === 'desktop' || p === 'auto') setPreviewPreference(p)
+      if (p === 'mobile' || p === 'desktop' || p === 'auto') setPreviewPreference(p)
     }
     const onDataStale = (e: Event) => {
       const stalePath = (e as CustomEvent).detail?.workspacePath
@@ -877,24 +876,22 @@ function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onC
     }
     return false
   }, [planExists, plan, sources, hiddenWidgetKeys])
-  // Report renders at the selected device width. When the pane is chat-focused the
-  // parent passes a capped focusTier (laptop→tablet, mobile→mobile) so the report
-  // fits the narrower pane; otherwise it follows the user's saved preference.
-  // Device selection lives in the shared on-pane bar (PreviewPaneControls).
-  const previewMode: 'desktop' | 'tablet' | 'mobile' = focusTier
+  // Report renders at the selected device width. When the pane is chat-focused in
+  // Mobile the parent passes focusTier='mobile' so the report fits the narrow pane;
+  // otherwise it follows the user's saved preference. Device selection lives in the
+  // shared on-pane bar (PreviewPaneControls).
+  const previewMode: 'desktop' | 'mobile' = focusTier
     ? focusTier
-    : (previewPreference === 'mobile' || previewPreference === 'tablet' || previewPreference === 'desktop'
+    : (previewPreference === 'mobile' || previewPreference === 'desktop'
         ? previewPreference
         : 'desktop')
-  // Per-mode shell width. Mobile mimics a phone (~480px), tablet mimics an
-  // iPad-class device (~880px), laptop fills available space. Content width
-  // mirrors the shell so widget reflow tests against the right container size.
+  // Per-mode shell width. Mobile mimics a phone (~480px); laptop fills available
+  // space. Content width mirrors the shell so widget reflow tests against the
+  // right container size.
   const previewShellClassName =
     previewMode === 'mobile'
       ? 'mx-auto w-full max-w-[480px] p-1.5 transition-all duration-200'
-      : previewMode === 'tablet'
-        ? 'mx-auto w-full max-w-[880px] p-1.5 transition-all duration-200'
-        : 'mx-auto w-full max-w-full transition-all duration-200'
+      : 'mx-auto w-full max-w-full transition-all duration-200'
   // A report made only of self-contained documents (md/html) renders edge-to-edge:
   // each document owns its own width / padding / background, so we add no
   // content-width cap, no scroll padding, and no card chrome around it (avoids
@@ -918,7 +915,7 @@ function ReportViewComponent({ workspacePath, selectedRunFolder, reviewData, onC
   const htmlOnlyReport = documentWidgets != null && documentWidgets.every(isHtmlDocumentWidget)
 
   const previewContentClassName =
-    previewMode === 'mobile' || previewMode === 'tablet'
+    previewMode === 'mobile'
       ? 'w-full max-w-full'
       : htmlOnlyReport
         ? 'w-full max-w-full'

--- a/frontend/src/components/workflow/WorkflowLayout.tsx
+++ b/frontend/src/components/workflow/WorkflowLayout.tsx
@@ -37,7 +37,8 @@ const ChatAreaWithObserverId = forwardRef<ChatAreaRef, {
   compact?: boolean
   hidePhaseChatEmptyState?: boolean
   suppressTerminalPane?: boolean
-}>(({ onNewChat, hideHeader, hideInput, compact, hidePhaseChatEmptyState, suppressTerminalPane }, ref) => {
+  workflowPreviousChatsPanel?: React.ReactNode
+}>(({ onNewChat, hideHeader, hideInput, compact, hidePhaseChatEmptyState, suppressTerminalPane, workflowPreviousChatsPanel }, ref) => {
   // Prefer the active workflow tab when one is selected. The tab strip keeps
   // active workflow tabs visible even while preset metadata is catching up
   // after reload; ChatArea must use the same rule or the input area disappears.
@@ -91,6 +92,7 @@ const ChatAreaWithObserverId = forwardRef<ChatAreaRef, {
       compact={compact}
       hidePhaseChatEmptyState={hidePhaseChatEmptyState}
       suppressTerminalPane={suppressTerminalPane}
+      workflowPreviousChatsPanel={workflowPreviousChatsPanel}
       // Pass null (not undefined) when no tab matches the active workflow preset.
       // Otherwise ChatArea falls back to the global activeTabId and can briefly
       // render the previous workflow's blocking human-feedback/auth prompt.
@@ -286,7 +288,10 @@ function runningWorkflowBelongsToPreset(
 const WorkflowPreviousChatsPanel: React.FC<{
   workspacePath: string
   onHasChatsChange?: (hasChats: boolean) => void
-}> = ({ workspacePath, onHasChatsChange }) => {
+  // When true the panel fills the chat pane as the primary landing surface
+  // (mirrors the multi-agent landing panel) instead of the compact top strip.
+  primary?: boolean
+}> = ({ workspacePath, onHasChatsChange, primary = false }) => {
   const activeTabId = useChatStore(state => state.activeTabId)
   const activePresetId = useGlobalPresetStore(state => state.activePresetIds.workflow)
   const setShowChatArea = useWorkflowStore(state => state.setShowChatArea)
@@ -391,7 +396,8 @@ const WorkflowPreviousChatsPanel: React.FC<{
       emptyText="No previous automation chats yet."
       onHasChatsChange={onHasChatsChange}
       onSelectSession={handleResumePreviousChat}
-      compact
+      compact={!primary}
+      fill={primary}
     />
   )
 }
@@ -702,7 +708,6 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   const showWorkspacePane = useWorkflowStore(state => state.showWorkspacePane)
   const setShowChatArea = useWorkflowStore(state => state.setShowChatArea)
   const setShowWorkspacePane = useWorkflowStore(state => state.setShowWorkspacePane)
-  const focusedPane = useWorkflowStore(state => state.focusedPane)
   const setFocusedPane = useWorkflowStore(state => state.setFocusedPane)
   const workflowWorkspaceView = useWorkflowStore(state => state.workflowWorkspaceView)
   const setWorkflowWorkspaceView = useWorkflowStore(state => state.setWorkflowWorkspaceView)
@@ -904,10 +909,18 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
     setHasLoadedPreviousWorkflowChats(isLoaded)
   }, [])
 
-  const [reportPreviewPreference, setReportPreviewPreference] = useState<'auto' | 'desktop' | 'tablet' | 'mobile'>(() => {
+  // Show the previous-automation-chats list as the primary landing surface on a
+  // fresh builder chat (mirrors the multi-agent landing panel). We keep it up
+  // while the list is still loading, then keep it only if there are chats to
+  // resume — otherwise we fall through to the normal empty/start state so the
+  // user can just start typing.
+  const showWorkflowPreviousChatsAsPrimary =
+    showResumeHint && !!workspacePath && (!hasLoadedPreviousWorkflowChats || hasPreviousWorkflowChats)
+
+  const [reportPreviewPreference, setReportPreviewPreference] = useState<'auto' | 'desktop' | 'mobile'>(() => {
     try {
       const saved = localStorage.getItem(reportPreviewPreferenceKey(workspacePath))
-      return saved === 'desktop' || saved === 'tablet' || saved === 'mobile' ? saved : 'mobile'
+      return saved === 'desktop' || saved === 'mobile' ? saved : 'mobile'
     } catch {
       return 'mobile'
     }
@@ -942,7 +955,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
     const syncReportPreviewPreference = () => {
       try {
         const saved = localStorage.getItem(reportPreviewPreferenceKey(workspacePath))
-        setReportPreviewPreference(saved === 'desktop' || saved === 'tablet' || saved === 'mobile' ? saved : 'mobile')
+        setReportPreviewPreference(saved === 'desktop' || saved === 'mobile' ? saved : 'mobile')
       } catch {
         setReportPreviewPreference('mobile')
       }
@@ -966,22 +979,19 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   // pane stayed pinned at 50% of the screen.
   //
   //   mobile  → report 480px column, chat takes the rest (review-style)
-  //   tablet  → 50/50 split between builder/chat and the workflow view
-  //   laptop  → chat collapses to ~360px, report fills the remaining width
+  //   laptop  → chat is hidden, report fills the full width
   //   default → 50/50 split (no preview pref, or running in non-report views)
   const isPreviewableWorkspaceCanvas =
     !isFilesWorkspace &&
     showChatArea &&
     workspacePaneVisible &&
     (canvasViewMode === 'report' || canvasViewMode === 'flow')
-  const previewPaneTier: 'mobile' | 'tablet' | 'laptop' | null = isPreviewableWorkspaceCanvas
+  const previewPaneTier: 'mobile' | 'laptop' | null = isPreviewableWorkspaceCanvas
     ? reportPreviewPreference === 'mobile'
       ? 'mobile'
-      : reportPreviewPreference === 'tablet'
-        ? 'tablet'
-        : reportPreviewPreference === 'desktop'
-          ? 'laptop'
-          : null
+      : reportPreviewPreference === 'desktop'
+        ? 'laptop'
+        : null
     : null
   // Backward-compat alias kept for downstream readers — mobile pane behaviour
   // is unchanged.
@@ -993,31 +1003,19 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
     workspacePaneVisible && isWorkspaceViewActive
       ? 'hidden md:flex'
       : 'flex'
-  // The device selection (mobile/tablet/laptop) drives BOTH the outer pane width
-  // and the inner content width, together:
-  //   laptop → report fills, chat ~360px rail (the report column flexes)
-  //   tablet → report pane 880px, chat fills the rest
-  //   mobile → report pane 480px, chat fills the rest
-  // Clicking into chat caps the report at tablet so chat gets room without
-  // shrinking the report all the way to mobile: laptop→tablet, tablet stays
-  // tablet, mobile stays mobile. Report is always grid col 2, chat is col 1.
+  // The device selection (mobile/laptop) drives the outer pane width:
+  //   mobile → report pane 480px, chat fills the rest (chat is col 1, report col 2)
+  //   laptop → chat is hidden; the report fills the full width (see laptopHidesChat)
   const previewDevice = usePreviewDevice(workspacePath)
-  // Focusing chat shrinks the report column, so cap the report at tablet while
-  // typing: laptop→tablet (not all the way to mobile), tablet stays tablet, and a
-  // saved mobile width stays mobile. Unfocused, the report uses its own device tier.
-  const effectiveTier: 'mobile' | 'tablet' | 'laptop' =
-    focusedPane === 'chat'
-      ? (previewDevice === 'mobile' ? 'mobile' : 'tablet')
-      : previewDevice === 'mobile' ? 'mobile' : previewDevice === 'tablet' ? 'tablet' : 'laptop'
+  const effectiveTier: 'mobile' | 'laptop' =
+    previewDevice === 'mobile' ? 'mobile' : 'laptop'
   // Laptop ('desktop' device) hides the chat pane entirely for both report and
-  // plan — the workspace canvas takes the full width. (Use the raw device choice,
-  // not effectiveTier, so it holds regardless of the focus-cap.)
+  // plan — the workspace canvas takes the full width.
   const laptopHidesChat = !isFilesWorkspace && previewDevice === 'desktop' && showChatArea && workspacePaneVisible
   const splitGridCols = isFilesWorkspace
     ? 'md:grid-cols-[minmax(0,1fr)_384px]'
     : effectiveTier === 'mobile' ? 'md:grid-cols-[minmax(0,1fr)_480px]'
-    : effectiveTier === 'tablet' ? 'md:grid-cols-[minmax(0,1fr)_880px]'
-    : 'md:grid-cols-[360px_minmax(0,1fr)]'
+    : 'md:grid-cols-[minmax(0,1fr)]'
   // Animate the GRID TRACK widths on the container so the chat↔report resize
   // glides — the panes just follow their grid column instead of fighting it with
   // per-tier explicit widths. (grid-template-columns animation is supported by
@@ -2223,14 +2221,10 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
               </div>
             )}
 
-            {showResumeHint && workspacePath && (
-              <div className="shrink-0">
-                <WorkflowPreviousChatsPanel
-                  workspacePath={workspacePath}
-                  onHasChatsChange={handleHasPreviousWorkflowChatsChange}
-                />
-              </div>
-            )}
+            {/* The previous-automation-chats list now renders inside ChatArea's
+                content area (workflowPreviousChatsPanel below) so it fills the
+                pane above the chat input, mirroring the multi-agent landing
+                panel — instead of a compact strip stacked on top of the chat. */}
 
             <div className="min-h-0 flex-1 overflow-hidden">
               <ChatAreaWithObserverId
@@ -2239,8 +2233,15 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
                 hideHeader
                 hideInput
                 compact
-                hidePhaseChatEmptyState={showResumeHint && (!hasLoadedPreviousWorkflowChats || hasPreviousWorkflowChats)}
-                suppressTerminalPane={showResumeHint && (!hasLoadedPreviousWorkflowChats || hasPreviousWorkflowChats)}
+                hidePhaseChatEmptyState={showWorkflowPreviousChatsAsPrimary}
+                suppressTerminalPane={showWorkflowPreviousChatsAsPrimary}
+                workflowPreviousChatsPanel={showWorkflowPreviousChatsAsPrimary && workspacePath ? (
+                  <WorkflowPreviousChatsPanel
+                    primary
+                    workspacePath={workspacePath}
+                    onHasChatsChange={handleHasPreviousWorkflowChatsChange}
+                  />
+                ) : undefined}
               />
             </div>
           </div>

--- a/frontend/src/components/workflow/canvas/WorkflowCanvas.tsx
+++ b/frontend/src/components/workflow/canvas/WorkflowCanvas.tsx
@@ -10,7 +10,7 @@ import {
   type NodeChange,
   type OnNodeDrag
 } from '@xyflow/react'
-import { Braces, Download, FileText, GitBranch, Laptop, ListOrdered, Loader2, PanelRightClose, RefreshCw, Route, Settings, SlidersHorizontal, Smartphone, TabletSmartphone, X } from 'lucide-react'
+import { Braces, Download, FileText, GitBranch, Laptop, ListOrdered, Loader2, PanelRightClose, RefreshCw, Route, Settings, SlidersHorizontal, Smartphone, X } from 'lucide-react'
 import '@xyflow/react/dist/style.css'
 
 import { useModeStore } from '../../../stores/useModeStore'
@@ -101,7 +101,6 @@ function enforceWorkflowHeaderClearance(nodes: WorkflowNode[]): WorkflowNode[] {
 
 import type { ExecutionOptions } from '../../../services/api-types'
 
-type WorkflowPreviewMode = 'desktop' | 'tablet' | 'mobile'
 type WorkflowImageExportFormat = 'svg' | 'png' | 'jpeg'
 
 function isHorizontalWorkflowLayout(direction: 'LR' | 'TB'): boolean {
@@ -138,10 +137,9 @@ export const WORKFLOW_REPORT_REFRESH_EVENT = 'workflow-report-refresh-requested'
 
 const PREVIEW_DEVICE_OPTS = [
   { mode: 'mobile' as const, Icon: Smartphone, label: 'Mobile preview' },
-  { mode: 'tablet' as const, Icon: TabletSmartphone, label: 'Tablet preview' },
   { mode: 'desktop' as const, Icon: Laptop, label: 'Laptop preview' },
 ]
-type PreviewDevice = 'mobile' | 'tablet' | 'desktop'
+type PreviewDevice = 'mobile' | 'desktop'
 
 // Shared device-width preference, synced across the on-pane bar, the report
 // shell, and the plan/flow shell via REPORT_PREVIEW_PREFERENCE_CHANGED_EVENT.
@@ -151,7 +149,7 @@ export function usePreviewDevice(scopeId?: string | null): PreviewDevice {
   const read = (): PreviewDevice => {
     try {
       const v = localStorage.getItem(reportPreviewPreferenceKey(scopeId))
-      return v === 'mobile' || v === 'tablet' || v === 'desktop' ? v : 'mobile'
+      return v === 'mobile' || v === 'desktop' ? v : 'mobile'
     } catch { return 'mobile' }
   }
   const [pref, setPref] = React.useState<PreviewDevice>(read)
@@ -162,7 +160,7 @@ export function usePreviewDevice(scopeId?: string | null): PreviewDevice {
       const detail = (e as CustomEvent).detail
       if ((detail?.scopeId ?? null) !== (scopeId ?? null)) return
       const p = detail?.preference
-      if (p === 'mobile' || p === 'tablet' || p === 'desktop') setPref(p)
+      if (p === 'mobile' || p === 'desktop') setPref(p)
     }
     window.addEventListener(REPORT_PREVIEW_PREFERENCE_CHANGED_EVENT, handler)
     return () => window.removeEventListener(REPORT_PREVIEW_PREFERENCE_CHANGED_EVENT, handler)
@@ -178,9 +176,7 @@ function setPreviewDevice(mode: PreviewDevice, scopeId?: string | null) {
 export function previewDeviceShellClass(device: PreviewDevice): string {
   return device === 'mobile'
     ? 'mx-auto w-full max-w-[480px]'
-    : device === 'tablet'
-      ? 'mx-auto w-full max-w-[880px]'
-      : 'w-full'
+    : 'w-full'
 }
 
 function PreviewPaneControls({ hasPlan, onExportPlan, onRefreshPlan, scopeId }: { hasPlan: boolean; onExportPlan?: () => void; onRefreshPlan?: () => void; scopeId?: string | null }) {
@@ -383,15 +379,13 @@ const WorkflowReportCanvasInner = forwardRef<WorkflowCanvasRef, WorkflowCanvasPr
   const selectedRunFolder = useWorkflowStore(state => state.selectedRunFolder)
   const canvasViewMode = useWorkflowStore(state => state.canvasViewMode)
   const paneMode = viewMode || canvasViewMode
-  // Report renders mobile-framed when chat is focused AND the report pane actually
-  // collapses to the narrow 480px column (desktop/mobile). An explicit Tablet choice
-  // keeps its 880px frame even while chat is focused.
+  // In Mobile the report sits in a narrow 480px column; when chat is focused we
+  // keep the report mobile-framed so it fits. In Laptop the chat is hidden, so
+  // there's no chat-focus case to cap for.
   const reportPreviewDevice = usePreviewDevice(workspacePath)
-  // When chat is focused the report pane shrinks, so cap the report at tablet
-  // (laptop→tablet); a saved mobile width stays mobile; tablet stays tablet.
-  const reportFocusTier: 'mobile' | 'tablet' | undefined =
-    useWorkflowStore(state => state.focusedPane === 'chat')
-      ? (reportPreviewDevice === 'mobile' ? 'mobile' : 'tablet')
+  const reportFocusTier: 'mobile' | undefined =
+    useWorkflowStore(state => state.focusedPane === 'chat' && reportPreviewDevice === 'mobile')
+      ? 'mobile'
       : undefined
   const planData = usePlanData(workspacePath)
   const plan = planData.plan
@@ -1529,11 +1523,11 @@ const WorkflowCanvasInner = forwardRef<WorkflowCanvasRef, WorkflowCanvasProps>((
   const selectedRunFolder = useWorkflowStore(state => state.selectedRunFolder)
   // Device-width preview also constrains the plan/flow pane (centered shell).
   const previewDevice = usePreviewDevice(workspacePath)
-  // When chat is focused the report pane shrinks, so cap the report at tablet
-  // (laptop→tablet); a saved mobile width stays mobile; tablet stays tablet.
-  const reportFocusTier: 'mobile' | 'tablet' | undefined =
-    useWorkflowStore(state => state.focusedPane === 'chat')
-      ? (previewDevice === 'mobile' ? 'mobile' : 'tablet')
+  // In Mobile, a chat-focused report stays mobile-framed to fit its narrow column;
+  // in Laptop the chat is hidden so there's no chat-focus case to cap for.
+  const reportFocusTier: 'mobile' | undefined =
+    useWorkflowStore(state => state.focusedPane === 'chat' && previewDevice === 'mobile')
+      ? 'mobile'
       : undefined
   // Changing the device width resizes the flow pane; re-fit the diagram after the
   // CSS width transition (~300ms) so it recenters into the new width.

--- a/frontend/src/hooks/useSessionTerminals.ts
+++ b/frontend/src/hooks/useSessionTerminals.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { agentApi } from '../services/api'
+import type { ListTerminalsResponse } from '../services/api-types'
+
+/**
+ * Terminal-presence probe for a session. Used by ChatArea's chat-surface
+ * resolver to detect a restored/native-resume tab whose surface is a live
+ * terminal (which leaves NO execution-tree nodes) so it stays on the terminal
+ * instead of bouncing to the previous-chats landing. Content is fetched as
+ * 'none' — we only need presence, not scrollback.
+ */
+export function useSessionTerminals(sessionId?: string | null, enabled: boolean = true) {
+  return useQuery<ListTerminalsResponse>({
+    queryKey: ['session-terminals-presence', sessionId],
+    queryFn: () => agentApi.listTerminals(sessionId!, 'none'),
+    enabled: enabled && !!sessionId,
+    refetchInterval: (query) => {
+      // A resume reattaches its terminal asynchronously — keep polling until one
+      // appears, then stop (presence is all the resolver needs).
+      const data = query.state.data
+      if (data && (data.terminals?.length ?? 0) > 0) return false
+      return 3000
+    },
+    staleTime: 1000,
+    retry: false,
+  })
+}


### PR DESCRIPTION
15 commits:
- Terminal: persist non-tmux snapshots (restore after restart); screen-mode-aware seed (kills streaming litter); tmux status-off (spinner stops stacking); non-blanking resize; typing no longer resizes/churns the terminal; resumed sessions reliably engage the live tmux (resize/recorder) — no duplicated-frame churn.
- Resolver: single 3-state chat-surface resolver (restoring|active|landing) — fixes schedule-bounce, resume flicker; New Chat shows previous-chats list (both modes); New Chat from a running conv lands on the list; resume shows the terminal on first click.
- Org Pulse: pill first + reflects any enabled Org Pulse (no UUID dependency).
- Layout: CoS pane flush-left; 2 device tiers (Mobile/Laptop).

Note: temporary [SPINNER_DEBUG] resize log still in (to be stripped in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)