### PR TITLE
Blank-on-resume fix + pure input routing + live-attach design (v1.25.75)

### DIFF
--- a/agent_go/cmd/server/coding_agent_modes_test.go
+++ b/agent_go/cmd/server/coding_agent_modes_test.go
@@ -320,6 +320,97 @@ func TestCanSteerSessionRequiresActiveForegroundTurn(t *testing.T) {
 	}
 }
 
+// Single-entry routing: a /api/query message for a BUSY coding-agent session must
+// be steered into the running turn (Status live_input_delivered) instead of
+// starting a second streaming turn, and recorded so it persists in the timeline.
+func TestTryDeliverQueryAsLiveInputBusyCodingAgent(t *testing.T) {
+	store := internalevents.NewEventStore(10)
+	defer store.Stop()
+
+	sessionID := "busy-coding-session"
+	runningAgent := &mcpagent.Agent{ModelID: "claude-sonnet-4-6"}
+	runningAgent.SetProvider(llm.ProviderClaudeCode)
+	api := &StreamingAPI{
+		eventStore:       store,
+		runningAgents:    map[string]*mcpagent.Agent{sessionID: runningAgent},
+		runningAgentsMux: sync.RWMutex{},
+		agentCancelFuncs: map[string]context.CancelFunc{sessionID: func() {}}, // active foreground turn → busy
+		agentCancelMux:   sync.RWMutex{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/query", nil)
+	req.Header.Set("X-Session-ID", sessionID)
+	rr := httptest.NewRecorder()
+
+	if !api.tryDeliverQueryAsLiveInput(rr, req, sessionID, "steer me into the running turn", "query_test_busy") {
+		t.Fatalf("tryDeliverQueryAsLiveInput = false for a busy coding-agent session; want true (steer, not new turn). body=%s", rr.Body.String())
+	}
+	var resp QueryResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != queryStatusLiveInputDelivered {
+		t.Fatalf("status = %q, want %q", resp.Status, queryStatusLiveInputDelivered)
+	}
+	if resp.DeliveryStatus == "" {
+		t.Fatal("delivery_status empty; want a live-input delivery status")
+	}
+	if got := len(store.GetAllEventsRaw(sessionID)); got != 1 {
+		t.Fatalf("recorded %d events, want 1 (the steered user message)", got)
+	}
+}
+
+// Single-entry routing: an IDLE coding-agent session must fall through (return
+// false) so handleQuery starts a new turn + materializes the terminal.
+func TestTryDeliverQueryAsLiveInputIdleFallsThrough(t *testing.T) {
+	store := internalevents.NewEventStore(10)
+	defer store.Stop()
+
+	sessionID := "idle-coding-session"
+	runningAgent := &mcpagent.Agent{ModelID: "claude-sonnet-4-6"}
+	runningAgent.SetProvider(llm.ProviderClaudeCode)
+	api := &StreamingAPI{
+		eventStore:       store,
+		runningAgents:    map[string]*mcpagent.Agent{sessionID: runningAgent},
+		runningAgentsMux: sync.RWMutex{},
+		agentCancelFuncs: map[string]context.CancelFunc{}, // no active turn, no busy pane → idle
+		agentCancelMux:   sync.RWMutex{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/query", nil)
+	rr := httptest.NewRecorder()
+	if api.tryDeliverQueryAsLiveInput(rr, req, sessionID, "first message", "query_test_idle") {
+		t.Fatal("tryDeliverQueryAsLiveInput = true for an idle session; want false so handleQuery starts a new turn + materializes")
+	}
+	if got := len(store.GetAllEventsRaw(sessionID)); got != 0 {
+		t.Fatalf("idle fall-through recorded %d events, want 0", got)
+	}
+}
+
+// API/LLM unchanged: even when busy, a non-coding (API) agent must NOT be
+// short-circuited — those keep their frontend steer-vs-queue path.
+func TestTryDeliverQueryAsLiveInputSkipsNonCodingAgent(t *testing.T) {
+	store := internalevents.NewEventStore(10)
+	defer store.Stop()
+
+	sessionID := "busy-llm-session"
+	runningAgent := &mcpagent.Agent{ModelID: "gpt-5"}
+	runningAgent.SetProvider(llm.ProviderOpenAI)
+	api := &StreamingAPI{
+		eventStore:       store,
+		runningAgents:    map[string]*mcpagent.Agent{sessionID: runningAgent},
+		runningAgentsMux: sync.RWMutex{},
+		agentCancelFuncs: map[string]context.CancelFunc{sessionID: func() {}}, // busy
+		agentCancelMux:   sync.RWMutex{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/query", nil)
+	rr := httptest.NewRecorder()
+	if api.tryDeliverQueryAsLiveInput(rr, req, sessionID, "llm message", "query_test_llm") {
+		t.Fatal("tryDeliverQueryAsLiveInput = true for an API/LLM agent; want false (API/LLM routing unchanged)")
+	}
+}
+
 func TestIdleCompletionDoesNotCompleteStaleBusyTurn(t *testing.T) {
 	sessionID := "stale-busy-session"
 	api := &StreamingAPI{

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -5354,6 +5354,32 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
+			// Materialize guard: a tmux-transport coding-agent turn must ALWAYS have a
+			// live, registered terminal — regardless of whether this turn entered via
+			// /api/query or via live-input → startNextTurnFromLiveInput.
+			// seedCodingAgentRuntimeFromCurrentConversation bails (seeded=false,
+			// runtime=nil) when the in-memory agent already carries a native-resume
+			// handle, so the seed block above never adopts a restoredRuntime and the
+			// FIX B re-launch+materialize below is skipped. That's wrong once the live
+			// tmux is gone: the CLI pane exited after completing its previous turn (or
+			// was idle-reaped) and the frontend, seeing STALE liveness, routed this
+			// follow-up to live-input. The replayed turn would then run "headless" —
+			// setup + tools register, but no terminal is materialized — leaving a blank
+			// screen and an invisible agent response. Adopt the on-disk runtime and
+			// route through the SAME FIX B re-launch + materialize as an explicit
+			// Resume. Gated on a native-resume handle (it IS a coding agent mid-session)
+			// AND "no live tmux" so a genuinely live session is never disrupted by a
+			// spurious relaunch.
+			if !restoredNativeCodingResume && !modeChangedThisTurn && restoredRuntime == nil &&
+				codingAgentHasNativeResume(finalProvider, underlyingAgent) && !api.sessionHasLiveCodingTmux(sessionID) {
+				if runtime, ok, err := ReadChatHistoryRuntimeForSession(currentUserID, sessionID, workflowPhaseFolder); err != nil {
+					logfWithContext(queryLogCtx, "[CHAT_HISTORY] Materialize guard: failed to read runtime for session %s: %v", sessionID, err)
+				} else if ok && runtime != nil && restoredRuntimeUsesLaunchableTerminalTransport(runtime) {
+					restoredRuntime = runtime
+					restoredNativeCodingResume = true
+					logfWithContext(queryLogCtx, "[CHAT_HISTORY] Materialize guard: session %s tmux is gone but agent has a native-resume handle; re-launching + materializing terminal so the next turn is visible", sessionID)
+				}
+			}
 			if restoredNativeCodingResume {
 				if restoredRuntimeUsesLaunchableTerminalTransport(restoredRuntime) {
 					if handle, err := underlyingAgent.StartCodingAgentTransportSession(agentCtx); err != nil {

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -802,7 +802,20 @@ type QueryResponse struct {
 	SessionID string `json:"session_id"` // The actual session ID used for conversation history
 	Status    string `json:"status"`
 	Message   string `json:"message,omitempty"`
+	// DeliveryStatus/Provider are populated only when handleQuery short-circuits a
+	// message into an already-running coding-agent turn as live input (Status ==
+	// "live_input_delivered"). They mirror the live-input endpoint's response so the
+	// chat UI can render the same "sent to CLI" feedback without a second endpoint.
+	DeliveryStatus string `json:"delivery_status,omitempty"`
+	Provider       string `json:"provider,omitempty"`
 }
+
+// queryStatusLiveInputDelivered is the QueryResponse.Status returned when a
+// /api/query message was steered into an already-running coding-agent turn (the
+// session was busy) instead of starting a new streaming turn. This is the single
+// backend source of truth for tmux-transport CLI input: the frontend always POSTs
+// /api/query and the backend disambiguates deliver-vs-new-turn.
+const queryStatusLiveInputDelivered = "live_input_delivered"
 
 // LLMGuidanceRequest represents a request to set LLM guidance for a session
 type LLMGuidanceRequest struct {
@@ -2465,6 +2478,20 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 			return req.ExecutionOptions.WorkshopMode
 		}())
 		writeWorkflowPermissionDenied(w, "write")
+		return
+	}
+
+	// SINGLE-ENTRY ROUTING (tmux-transport coding-agent input): the frontend no
+	// longer decides live-input-vs-new-turn from (flaky, often-stale) terminal
+	// liveness — it always POSTs /api/query and the backend is the single source of
+	// truth. If the session already has a running, BUSY coding-agent turn (active
+	// foreground turn OR a busy tmux pane), steer this message into it as live input
+	// and return WITHOUT starting a second streaming turn. Otherwise (idle / exited /
+	// gone / resumed / never-launched) fall through to the normal setup + new-turn +
+	// terminal-materialize path below. Auto-notifications keep their synthetic-turn
+	// semantics and are never short-circuited. Scoped to live-input-capable coding
+	// agents so API/LLM chat is unchanged (those keep frontend steer-vs-queue).
+	if !req.IsAutoNotification && api.tryDeliverQueryAsLiveInput(w, r, sessionID, req.Query, queryID) {
 		return
 	}
 
@@ -6665,6 +6692,89 @@ func (api *StreamingAPI) handleSetLLMGuidance(w http.ResponseWriter, r *http.Req
 // handleSteerMessage is the legacy route name kept for compatibility.
 func (api *StreamingAPI) handleSteerMessage(w http.ResponseWriter, r *http.Request) {
 	api.handleLiveInputMessage(w, r)
+}
+
+// agentSupportsLiveInputDelivery reports whether the running agent is a coding
+// agent whose provider contract supports live input (tmux-transport CLIs). Only
+// these short-circuit a /api/query into the running turn; API/LLM agents fall
+// through to the normal new-turn path so their behavior is unchanged.
+func agentSupportsLiveInputDelivery(agent *mcpagent.Agent) bool {
+	if agent == nil {
+		return false
+	}
+	contract, isCodingAgent := llm.GetCodingAgentProviderContract(agent.GetProvider(), agent.ModelID)
+	return isCodingAgent && contract.SupportsLiveInput
+}
+
+// tryDeliverQueryAsLiveInput is the single-entry busy short-circuit for
+// tmux-transport coding-agent input (see handleQuery). When the session already
+// has a running, busy coding-agent turn, it steers the incoming /api/query message
+// into that turn as live input instead of starting a second streaming turn, and
+// writes a QueryResponse with Status == queryStatusLiveInputDelivered. Returns
+// true if it handled (and responded to) the request; false to let handleQuery
+// start a normal new turn (idle / exited / gone / resumed / never-launched).
+func (api *StreamingAPI) tryDeliverQueryAsLiveInput(w http.ResponseWriter, r *http.Request, sessionID, message, queryID string) bool {
+	if api == nil || strings.TrimSpace(message) == "" {
+		return false
+	}
+	// Busy == a running agent with an active foreground turn OR a busy coding tmux
+	// pane. canSteerSession encapsulates exactly that predicate (and requires a
+	// retained running agent).
+	if !api.canSteerSession(sessionID) {
+		return false
+	}
+	api.runningAgentsMux.RLock()
+	runningAgent := api.runningAgents[sessionID]
+	api.runningAgentsMux.RUnlock()
+	if !agentSupportsLiveInputDelivery(runningAgent) {
+		return false
+	}
+
+	if err := r.Context().Err(); err != nil {
+		log.Printf("[QUERY→LIVE] Request canceled before delivery for session %s: %v", sessionID, err)
+		return false
+	}
+
+	inputCtx, cancel := context.WithTimeout(r.Context(), liveCodingAgentInputTimeout)
+	defer cancel()
+	delivery, err := runningAgent.DeliverUserMessage(inputCtx, mcpagent.UserMessageDeliveryRequest{
+		SessionID: sessionID,
+		Message:   message,
+		Intent:    mcpagent.UserMessageDeliveryIntentLiveInput,
+	})
+	if err != nil {
+		// Delivery genuinely failed (e.g. the pane vanished between the busy check
+		// and the send). Don't error the request — fall back to the normal new-turn
+		// path so the message still lands (re-launch + materialize).
+		log.Printf("[QUERY→LIVE] Live delivery failed for session %s, falling back to new turn: %v", sessionID, err)
+		return false
+	}
+
+	messageID := newSteerMessageID()
+	provider := string(delivery.Provider)
+	if provider == "" {
+		provider = string(runningAgent.GetProvider())
+	}
+	deliveryStatus := string(delivery.DeliveryStatus)
+	if deliveryStatus == "" {
+		deliveryStatus = "queued_for_injection"
+	}
+	// Record the steered user message so it persists in the conversation timeline.
+	// The chat UI dedups this against its optimistic bubble by exact content, so
+	// there is no double message.
+	api.recordLiveCodingAgentUserMessage(sessionID, message, provider, messageID, deliveryStatus)
+	log.Printf("[QUERY→LIVE] Steered /api/query message into running turn for session %s status=%s: %.80s", sessionID, deliveryStatus, message)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(QueryResponse{
+		QueryID:        queryID,
+		SessionID:      sessionID,
+		Status:         queryStatusLiveInputDelivered,
+		Message:        "Delivered to running coding-agent turn",
+		DeliveryStatus: deliveryStatus,
+		Provider:       provider,
+	})
+	return true
 }
 
 // handleLiveInputMessage delivers a user message to an active coding-agent

--- a/docs/refactor/terminal_live_attach_transport.md
+++ b/docs/refactor/terminal_live_attach_transport.md
@@ -1,0 +1,133 @@
+# Design: Live-attach terminal transport (replace snapshot/replay mirror)
+
+**Status:** Design — not started. Supersedes the snapshot/replay mirror.
+**Author/driver:** terminal-stability refactor.
+**Related:** `cli_live_input_unification.md` (input routing — stays valid; this doc is the *output/render* transport).
+
+---
+
+## 1. Why (the root cause)
+
+The CLI runs inside a **detached** tmux session (`tmux new-session -d`, **no client ever attaches**). Because nothing is attached, the pane's live output is *reconstructed* for the browser **three separate times**:
+
+1. **Adapter** `capture-pane` polling (200–250ms) → `StreamChunkTypeTerminal` snapshots.
+2. **Backend** `pipe-pane` append-log + a screen-mode-aware prologue, repaint hacks, trim loop.
+3. **Frontend** delta-vs-reset heuristics (`computeXtermWrite`), 3s re-probe polling, remount-on-switch, RIS reseed on resize.
+
+Every terminal bug this cycle — litter, duplicated frames, stacked spinners, wrapped tables on resize, blank-on-resume — is a failure of that reconstruction. The fix is to **stop reconstructing** and let a real attached client + xterm render the live byte stream natively.
+
+> Empirically confirmed by the end-to-end map (see "Reconstruction eliminated" below): ~10 distinct mechanisms exist solely to compensate for the detached session.
+
+---
+
+## 2. Target architecture
+
+```
+ tmux session (created -d, as today)            ── reused: creation/lifecycle/input
+      │  PTY bytes
+      ▼
+ backend ATTACH STREAMER  (per SELECTED terminal)        ── NEW
+   pty.Start("tmux attach -t <session>")  (read-only: we read PTY master, never write its stdin)
+   resize: pty.Setsize(cols,rows)  → tmux client follows → clean redraw frame
+      │  raw terminal bytes (live, in order, at the xterm's geometry)
+      ▼
+ WebSocket (binary, 1:1)                                  ── NEW
+      ▼
+ xterm.js  (AttachAddon writes the stream; FitAddon for size; SerializeAddon/capture for reconnect)
+
+ INPUT (unchanged): chat live-input / debug keys → send-keys / paste-buffer  (xterm stays display-only)
+```
+
+**Core idea:** attach one real (read-only) tmux client per *selected* terminal, stream its PTY bytes over a WebSocket straight into xterm. xterm handles cursor motion, alt-screen, colors, spinners, wrapping natively — because it's receiving the actual terminal stream, in order, at a stable geometry. No log, no capture-poll, no delta/reset, no reseed.
+
+Input keeps the **existing** `send-keys`/`paste-buffer` path (the CLI-live-input unification). xterm remains `disableStdin` — we never write to the attach client's stdin, which also sidesteps tmux prefix-key / interactive-client concerns.
+
+---
+
+## 3. Key decision: PTY-attach (primary) vs control-mode `-CC` (fallback)
+
+| | PTY-attach (`tmux attach` in a PTY) | Control mode (`tmux -CC attach`) |
+|---|---|---|
+| Mechanism | Read the attached client's rendered PTY output | Parse a structured protocol (`%output`, `%layout-change`) |
+| Bytes to xterm | The rendered terminal stream (what we want) | `%output` per-pane (also what we want) |
+| Chrome/prefix | Tame with `status off` + single pane + **read-only** (never write its stdin) | None (protocol, not an interactive client) |
+| Resize | `pty.Setsize` → client follows | size commands in protocol |
+| Code we write | Minimal (ttyd is a near-blueprint; creack/pty does the PTY) | **A control-mode protocol parser** (no mature Go lib; iTerm2 is GPL → design-only) |
+| OSS leverage | High (ttyd, GoTTY, creack/pty — all MIT) | Low (write our own parser) |
+
+**Decision: PTY-attach is primary.** With our **single-viewer / single-pane** constraint and read-only attach, the usual reasons to prefer control mode (chrome, prefix, multi-pane, multi-client size negotiation) don't apply, and PTY-attach has far more MIT OSS to lean on. **Control-mode stays the documented fallback** if read-only PTY-attach taming proves leaky on some tmux version.
+
+---
+
+## 4. Constraints / assumptions (locked with product owner)
+
+1. **Single viewer per terminal** → 1 attach client ↔ 1 WebSocket ↔ 1 xterm. No fanout, no multi-client size negotiation.
+2. **xterm grid is the authoritative size.** The attach client / `pty.Setsize` simply match it.
+3. **Live stream renders; `capture-pane` (or xterm `SerializeAddon`) is used only for (re)connect backfill** — never for live rendering.
+4. **Platforms:** macOS + Linux first-class. **Windows via WSL2** (= the Linux path; tmux already required, so no new dependency). **Native Windows out of scope** — blocker is tmux (no native equivalent), not the PTY. Use a **portable PTY lib** (e.g. `aymanbagabas/go-pty`: creack/pty on Unix, ConPTY on Windows) so the PTY layer keeps ConPTY optionality cheaply.
+5. **Attach only the SELECTED terminal.** A chat/session can have several terminals (`main:<session>`, `workflow-step:<…>`), each its own tmux session. Only the focused one gets a live attach+WS; the rail/others stay low-freq `capture-pane` thumbnails/metadata. Switch → detach old, attach new.
+6. **Minimum tmux version** pinned + checked at startup (control-mode/attach behavior varies by version; we already cope with version variance today).
+
+---
+
+## 5. OSS leverage (all MIT unless noted)
+
+- **ttyd (MIT)** — near-blueprint for PTY→WS→xterm (incl. readonly); borrow its WS message framing (input/resize/output). Not drop-in (no session/cost/workflow integration).
+- **creack/pty / aymanbagabas/go-pty (MIT)** — Go PTY primitive; `pty.Start`, `Setsize`. go-pty for the portability hedge.
+- **xterm addons (MIT)** — **AttachAddon** (wire xterm ⇄ WS), **FitAddon** (size, already used), **SerializeAddon** (snapshot xterm buffer for reconnect).
+- **GoTTY (MIT)** — Go-specific reference for the WS↔PTY relay; documents tmux for shared sessions.
+- **WebSocket lib** — `coder/websocket` or `gorilla/websocket`.
+- **iTerm2 (GPL-2)** — gold-standard *design* reference for control-mode (fallback). Study, **do not copy**.
+- **node-pty / WeTTY** — conceptual only (Node).
+
+---
+
+## 6. Phased migration (feature-flagged, parallel to the current transport)
+
+The current snapshot/replay transport stays the **default** until the new one is proven. Flag: `RUNLOOP_TERMINAL_LIVE_ATTACH` (off by default).
+
+- **Phase 0 — Spike (throwaway):** stand up ttyd-style PoC: `pty.Start("tmux attach -t <existing session>")` → WS → a bare xterm. Confirm clean render of a live pi-cli and codex pane, resize via `Setsize`, on macOS + Linux. Validates the core assumption before touching product code.
+- **Phase 1 — Backend attach streamer + WS endpoint (behind flag):** per-selected-terminal attach streamer (portable-pty), read-only; `GET/WS /api/terminals/{id}/stream`; lifecycle (open on select, close on deselect/disconnect); `pty.Setsize` on resize; reconnect backfill via `capture-pane` seed then live. Reuse `tmuxsize`, session registry, `tmuxexec`.
+- **Phase 2 — Frontend xterm over WS (behind flag):** xterm + AttachAddon bound to the WS; FitAddon → `Setsize`; reconnect → SerializeAddon/capture seed. Keep `disableStdin`. Behind the flag, side-by-side with the existing polling path.
+- **Phase 3 — Input + selection + rail:** confirm existing `send-keys`/`paste-buffer` input works unchanged with an attached session; switch = detach/attach; rail thumbnails via low-freq capture.
+- **Phase 4 — Verify all cases** (flag on, internal): new chat (pi-cli + codex), resume, busy steer, idle follow-up, completed→new turn, terminal switch, server restart/reconnect, workflow-step terminals, resize/wide-table. macOS + Linux + WSL.
+- **Phase 5 — Flip default + soak.**
+- **Phase 6 — Delete the old transport:** remove `terminal_pipe_recorder.go`, adapter capture-poll streaming, `terminalReplay.ts` + `applyContent` delta/reset, the 3s re-probe + dual-source merge + `ResetForResize`/repaint hacks, `[SPINNER_DEBUG]`.
+
+Each phase ships independently; the flag means a regression can't reach users mid-build.
+
+---
+
+## 7. What gets replaced vs reused (from the end-to-end map)
+
+**Replace / delete:**
+- `agent_go/cmd/server/terminal_pipe_recorder.go` (entire byte-mirror: prologue, pipe-pane, `forceTerminalPaneRepaint`, trim, `ResetForResize`).
+- Adapter snapshot streaming + capture-poll bodies: `streamCodex/PiTerminalSnapshot`, `captureCodex/PiPaneForDisplay`, the `waitFor…` capture loops (snapshot portions only).
+- `frontend/src/components/terminalReplay.ts` + `applyContent` delta/reset branches; the 3s re-probe + rail/detail polling; dual-source merge (`terminal_routes.go` detail `:218-259`); resize reseed/repaint.
+- `[SPINNER_DEBUG]` / `inspectTerminalPaneRuntimeStats` geometry diagnostics.
+
+**Reuse (transport-agnostic):**
+- tmux **session creation/lifecycle** (`startCodex/PiTmuxSession`, `remain-on-exit`, kill, owner→tmux registry). `window-size manual` likely flips to client-driven.
+- `coding_agent_contract.go` capability registry + `coding_agent_live_input.go` dispatch (add a transport flag).
+- **Input path** (`send-keys`/`paste-buffer`, `/input`, `/key`, `tmuxKeyName`).
+- `internal/terminals/store.go` Snapshot model + `terminal_id` keying (`main:`/`workflow-step:`) + `Active/State/Status` + `SessionHasBusyCodingTmux` + live-input routing.
+- `internal/tmuxsize`, `tmuxexec`, `tmuxlaunch`.
+- xterm shell in `TerminalCenter.tsx` (FitAddon, `key={terminal_id}` remount, theme) — fed by the stream instead of polls.
+- `services/api.ts` `resize`/`size-hint`/`input`/`key`; `useSessionTerminals` presence (useful at connect).
+
+---
+
+## 8. Risks / open questions
+
+1. **Read-only PTY-attach leakage:** does a never-written-to `tmux attach` render 100% cleanly with `status off` + single pane on all target tmux versions? (Phase 0 answers this; control-mode is the fallback.)
+2. **Reconnect backfill fidelity:** capture-pane vs xterm SerializeAddon for restoring the exact pre-disconnect screen, then seamless resume of the live stream without a doubled frame.
+3. **tmux version variance** across brew (macOS) / distro (Linux) / WSL — pin a minimum + startup check.
+4. **WS lifecycle** under the existing auth/session model (the app's API auth, session ownership).
+5. **Selection churn cost:** attach/detach on every terminal switch — ensure it's cheap (it is: attach is fast; rail stays capture-based).
+6. **Workflow-step terminals** that complete/exit (`remain-on-exit`) — attach to a dead-but-retained pane shows the final frame; confirm that's the desired read-only behavior.
+
+---
+
+## 9. Recommended stack (summary)
+
+`go-pty` (portable PTY) + read-only `tmux attach` per selected terminal + `coder/websocket` + xterm `AttachAddon`/`FitAddon`/`SerializeAddon`; ttyd as the blueprint; control-mode `-CC` as the documented fallback. Phased behind `RUNLOOP_TERMINAL_LIVE_ATTACH`, current transport stays default until Phase 5.

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -2798,6 +2798,26 @@ const ChatAreaInner = forwardRef((props: ChatAreaProps, ref: ForwardedRef<ChatAr
             logger.error('ChatArea', 'Failed to refresh active sessions cache:', error)
             connectAfterRefresh()
           })
+      } else if (response.status === 'live_input_delivered') {
+        // Single-entry routing (tmux-transport CLI): the backend steered this
+        // message into the already-running coding-agent turn instead of starting a
+        // new one. Keep the turn streaming — the optimistic user bubble already shows
+        // the message (the backend-recorded echo is deduped by exact content), and
+        // the running turn's SSE carries the agent output until its completion event
+        // clears the spinner. Do NOT resetStreamingState here (that would stop the
+        // spinner mid-turn).
+        const sid = response.session_id || tabSessionId
+        chatStore.setTabStreaming(currentTab.tabId, true)
+        chatStore.setTabCompleted(currentTab.tabId, false)
+        requestTerminalRefreshBurst()
+        if (sid && !useChatStore.getState().sseConnections[sid]) {
+          connectSSE(
+            sid,
+            (msg: SSEEventMessage) => handleSSEMessage(msg, sid),
+            (msg: SSEStatusMessage) => handleSSEStatus(msg, sid),
+            () => handleSSEFallback(sid)
+          )
+        }
       } else {
         console.log('[WF_DEBUG] ERROR: Backend non-started response', { status: response.status, message: response.message, response })
         logger.error('ChatArea', 'Backend error:', response)

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -260,7 +260,6 @@ import { useWorkspaceStore } from '../stores/useWorkspaceStore'
 import { useCommandDialogStore } from '../stores/useCommandDialogStore'
 import { usePresetApplication, useGlobalPresetStore } from '../stores/useGlobalPresetStore'
 import { useModeStore } from '../stores/useModeStore'
-import { useSessionTerminals } from '../hooks/useSessionTerminals'
 import { agentApi, getApiBaseUrl } from '../services/api'
 import { skillsApi } from '../api/skills'
 import type { Skill } from '../types/skills'
@@ -1808,25 +1807,6 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     [supportsLiveCodingAgentInput, tabSessionId]
   )
 
-  // TMUX-TRANSPORT LIVENESS (RCA single-fork model, docs/refactor/
-  // cli_live_input_unification.md). For a CLI coding-agent session, routing is
-  // decided by whether the tmux pane is LIVE — NOT by isStreaming (which is UI-only
-  // for these). We poll the session's terminal presence continuously (keepPolling)
-  // so a pane that goes idle or exits is reflected. A pane is live when some
-  // terminal for this session is Active with a non-empty tmux_session. Only enabled
-  // for tmux-transport sessions; API/LLM sessions never poll this.
-  const { data: sessionTerminalsForRouting } = useSessionTerminals(
-    tabSessionId,
-    routeLiveInputToCLI,
-    true,
-  )
-  const tmuxPaneLive = useMemo(
-    () => (sessionTerminalsForRouting?.terminals || []).some(
-      (t) => t.active && !!(t.tmux_session && t.tmux_session.trim()),
-    ),
-    [sessionTerminalsForRouting],
-  )
-
   // Ref for debounced file removal check
   const fileRemovalTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -1849,70 +1829,6 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
       setTabConfig(activeTabId, { inputText: '', pastedAttachments: [] })
     }
   }, [activeTabId, setTabConfig])
-
-  const sendLiveCodingAgentMessage = useCallback(async (msg: string): Promise<boolean> => {
-    const trimmed = msg.trim()
-    // NOTE: deliberately NOT gated on isStreaming — for a tmux-transport CLI the
-    // live pane accepts input between turns too (pi-cli idle → send-keys, CLI takes
-    // it natively). Callers only invoke this when the tmux pane is live (tmuxPaneLive).
-    if (!trimmed || !supportsLiveCodingAgentInput || !tabSessionId) return false
-
-    clearInputState()
-    setLiveMessageDelivery({
-      status: 'sending',
-      message: trimmed,
-      provider: effectiveProviderForSteer || undefined,
-    })
-    requestTerminalRefreshBurst()
-    try {
-      const response = await agentApi.sendLiveInput(tabSessionId, msg)
-      requestTerminalRefreshBurst()
-      setLiveMessageDelivery({
-        status: response.delivery_status || 'sent_to_cli',
-        message: trimmed,
-        provider: response.provider || effectiveProviderForSteer || undefined,
-      })
-      scheduleLiveMessageDeliveryClear()
-    } catch (err) {
-      const status = getHttpErrorStatus(err)
-      if (isLiveCodingSessionGoneStatus(status)) {
-        // RCA unification (docs/refactor/cli_live_input_unification.md §3/§4): for a
-        // CLI coding agent the tmux session being "gone" is NOT a failure and NOT a
-        // "queue locally + toast" case — there is simply no live turn to inject into,
-        // so this message should START THE NEXT TURN. The backend's live-input
-        // endpoint already does this server-side (startNextTurnFromLiveInput); this is
-        // the client mirror for the rare 404/409 race where it couldn't template one.
-        // Route straight to onSubmit (a fresh /api/query turn) with the SAME message —
-        // no local steer queue, no "the live coding-agent turn has ended" toast.
-        if (activeTabId) {
-          useChatStore.getState().setTabCanSteer(activeTabId, false)
-        }
-        setLiveMessageDelivery(null)
-        onSubmit(trimmed)
-      } else if (isLikelyBackendUnavailableError(err)) {
-        queueStreamingMessage(trimmed)
-        setLiveMessageDelivery({
-          status: 'failed',
-          message: trimmed,
-          provider: effectiveProviderForSteer || undefined,
-          detail: 'Backend unavailable',
-        })
-        scheduleLiveMessageDeliveryClear()
-        addToast('Backend is unavailable. Your message is still saved.', 'error')
-      } else {
-        queueStreamingMessage(trimmed)
-        setLiveMessageDelivery({
-          status: 'failed',
-          message: trimmed,
-          provider: effectiveProviderForSteer || undefined,
-          detail: err instanceof Error ? err.message : 'Unknown error',
-        })
-        scheduleLiveMessageDeliveryClear()
-        addToast('Failed to send to coding agent — message queued.', 'warning')
-      }
-    }
-    return true
-  }, [activeTabId, addToast, clearInputState, effectiveProviderForSteer, onSubmit, queueStreamingMessage, scheduleLiveMessageDeliveryClear, supportsLiveCodingAgentInput, tabSessionId])
 
   // Route ESC to the tmux pane when a live coding-agent CLI is running.
   // Returns true if the key was delivered to the CLI; false (or thrown) means
@@ -2641,12 +2557,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     const queueAwareOnSubmit = (query: string) => {
       const trimmed = query?.trim()
       if (!trimmed) return
-      // tmux-transport (CLI): route on tmux liveness, never isStreaming.
+      // tmux-transport (CLI): SINGLE-ENTRY routing — always /api/query. The backend
+      // disambiguates busy (steer into the running turn) vs idle/gone (new turn +
+      // materialize). The frontend no longer inspects terminal liveness.
       if (routeLiveInputToCLI) {
-        if (tmuxPaneLive) {
-          void sendLiveCodingAgentMessage(trimmed)
-          return
-        }
         onSubmit(trimmed)
         return
       }
@@ -2684,7 +2598,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
       workshopMode: effectiveModes.workshopMode,
       workflowPhaseId
     }
-  }, [activeTabId, tabSessionId, tabConfig, isSummarizing, isStreaming, routeLiveInputToCLI, tmuxPaneLive, sendLiveCodingAgentMessage, onSubmit, openDialog, openResumeDialog, setTabConfig, addToast, handleSummarize, handleCompact, getEffectiveWorkflowModes, workflowPhaseId])
+  }, [activeTabId, tabSessionId, tabConfig, isSummarizing, isStreaming, routeLiveInputToCLI, onSubmit, openDialog, openResumeDialog, setTabConfig, addToast, handleSummarize, handleCompact, getEffectiveWorkflowModes, workflowPhaseId])
 
   const getCommandValidationError = useCallback((cmd: CommandDefinition, beforeSlash: string) => {
     if (!cmd.validate) return null
@@ -2747,14 +2661,13 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
   // routeSubmit is the single send-routing decision shared by Enter (handleKeyDown)
   // and the Send button (handleSubmit).
   //
-  // TMUX-TRANSPORT (CLI coding agent) — RCA single-fork model: route purely on
-  // tmux-session LIVENESS, never isStreaming.
-  //   - live pane  → live-input (the backend delivers/steers when busy and starts
-  //                  the next turn when idle; the CLI owns live-vs-queue natively).
-  //   - not live   → /api/query (onSubmit) for FULL setup: a never-launched, gone,
-  //                  exited, or resumed session must launch / re-launch with --resume
-  //                  + tools + system prompt + secrets, which startNextTurnFromLiveInput
-  //                  does NOT replicate (it needs a prior recorded query).
+  // TMUX-TRANSPORT (CLI coding agent) — SINGLE-ENTRY routing: the frontend no longer
+  // inspects terminal liveness (which was flaky/stale and mis-routed resumes). It
+  // ALWAYS submits to /api/query (onSubmit) and the BACKEND is the single source of
+  // truth: it steers into the running turn when the session is busy, and starts a
+  // new turn (with --resume + tools + system prompt + secrets + terminal
+  // materialize) when idle / exited / gone / resumed / never-launched. isStreaming is
+  // UI-only (spinner/Stop) for these providers.
   //
   // NON-tmux (API/LLM): isStreaming-based steer-vs-queue, unchanged.
   const routeSubmit = useCallback((query: string) => {
@@ -2762,10 +2675,6 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     if (!trimmed) return
 
     if (routeLiveInputToCLI) {
-      if (tmuxPaneLive) {
-        void sendLiveCodingAgentMessage(query)
-        return
-      }
       if (hasSubmitTarget) {
         if (justSubmittedRef.current) return
         justSubmittedRef.current = true
@@ -2792,7 +2701,7 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
       const reason = getSubmitBlockReason()
       if (reason) addToast(reason, 'info')
     }
-  }, [routeLiveInputToCLI, tmuxPaneLive, hasSubmitTarget, sendLiveCodingAgentMessage, clearInputState, onSubmit, getSubmitBlockReason, addToast, canSubmitImmediately, canSubmit, isStreaming, queueStreamingMessage])
+  }, [routeLiveInputToCLI, hasSubmitTarget, clearInputState, onSubmit, getSubmitBlockReason, addToast, canSubmitImmediately, canSubmit, isStreaming, queueStreamingMessage])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Keyboard passthrough: every keystroke goes to the main agent terminal.

--- a/frontend/src/hooks/useSessionTerminals.ts
+++ b/frontend/src/hooks/useSessionTerminals.ts
@@ -8,22 +8,13 @@ import type { ListTerminalsResponse } from '../services/api-types'
  * terminal (which leaves NO execution-tree nodes) so it stays on the terminal
  * instead of bouncing to the previous-chats landing. Content is fetched as
  * 'none' — we only need presence, not scrollback.
- *
- * keepPolling: by default the probe stops once any terminal appears (presence is
- * all the resolver needs). ChatInput's tmux-transport routing instead needs the
- * CURRENT liveness (a pane can later go idle or exit), so it passes keepPolling
- * to keep refreshing the `active`/`tmux_session` fields. Consumers share one
- * query by key, so the continuous poll simply gives every consumer fresher data.
  */
-export function useSessionTerminals(sessionId?: string | null, enabled: boolean = true, keepPolling: boolean = false) {
+export function useSessionTerminals(sessionId?: string | null, enabled: boolean = true) {
   return useQuery<ListTerminalsResponse>({
     queryKey: ['session-terminals-presence', sessionId],
     queryFn: () => agentApi.listTerminals(sessionId!, 'none'),
     enabled: enabled && !!sessionId,
     refetchInterval: (query) => {
-      // Routing needs current liveness — keep polling so a pane that goes idle or
-      // exits is reflected, not just first-appearance presence.
-      if (keepPolling) return 3000
       // A resume reattaches its terminal asynchronously — keep polling until one
       // appears, then stop (presence is all the resolver needs).
       const data = query.state.data

--- a/frontend/src/services/api-types.ts
+++ b/frontend/src/services/api-types.ts
@@ -190,10 +190,17 @@ export interface CustomTierModel {
 
 export interface AgentQueryResponse {
   query_id: string
+  // 'started' | 'workflow_started' | 'live_input_delivered' | error states.
+  // 'live_input_delivered' means the backend steered this message into an
+  // already-running coding-agent turn instead of starting a new one (single-entry
+  // routing for tmux-transport CLIs).
   status: string
   message?: string
   sse_endpoint?: string
   session_id?: string
+  // Populated only when status === 'live_input_delivered'.
+  delivery_status?: 'sent_to_cli' | 'queued_for_injection' | 'next_turn_started'
+  provider?: string
 }
 
 // LLM Defaults Configuration Response


### PR DESCRIPTION
Since v1.25.74:
- Fix blank-on-resume: a coding-agent turn now ALWAYS materializes its terminal (re-launch + register) when there's no live pane — regardless of /api/query vs live-input entry (77a45f00).
- Codex 'message won't submit after completion' fix (completed pane not 'busy').
- Pure input routing: frontend stops deciding on flaky cached liveness; backend /api/query is the single source of truth (steer-if-busy / new-turn+materialize otherwise). isStreaming is UI-only for tmux CLI. API/LLM steer-vs-queue unchanged (f7851985).
- Design doc for the live-attach terminal transport (docs/refactor/terminal_live_attach_transport.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)