### PR TITLE
Unify runtime state and preserve terminal continuity

### DIFF
--- a/agent_go/cmd/server/background_agents.go
+++ b/agent_go/cmd/server/background_agents.go
@@ -756,6 +756,7 @@ func (api *StreamingAPI) setSessionBusy(sessionID string, busy bool) {
 	}
 	api.sessionBusy[sessionID] = busy
 	api.sessionBusyMu.Unlock()
+	api.observeRuntimeSnapshot(sessionID, nil)
 }
 
 func (api *StreamingAPI) hasActiveTurnCancel(sessionID string) bool {

--- a/agent_go/cmd/server/coding_agent_modes_test.go
+++ b/agent_go/cmd/server/coding_agent_modes_test.go
@@ -199,8 +199,8 @@ func TestProviderProfileOverridesStaleExplicitChatLLM(t *testing.T) {
 	if !applied {
 		t.Fatal("provider profile did not override the stale explicit chat LLM")
 	}
-	if gotProvider != "codex-cli" || gotModel != "gpt-5.6-terra" {
-		t.Fatalf("resolved chat LLM = %s/%s, want codex-cli/gpt-5.6-terra", gotProvider, gotModel)
+	if gotProvider != "codex-cli" || gotModel != "gpt-5.6-sol" {
+		t.Fatalf("resolved chat LLM = %s/%s, want codex-cli/gpt-5.6-sol", gotProvider, gotModel)
 	}
 }
 
@@ -582,6 +582,34 @@ func TestLiveInputDoesNotWaitForQueryLaunchLane(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("live input blocked behind the long-running query launch lane")
+	}
+}
+
+func TestQueryRequestForContinuationRestoresWorkflowPhaseContext(t *testing.T) {
+	req := QueryRequest{
+		AgentMode:     "multi-agent", // adapted engine mode inside handleQuery
+		PhaseID:       "workflow-builder",
+		PresetQueryID: "wf-marketing",
+		Query:         "continue the workflow",
+	}
+
+	got := queryRequestForContinuation(req, true, "Workflow/llmprovideropensourcemarketing")
+	if got.AgentMode != "workflow_phase" {
+		t.Fatalf("agent mode = %q, want workflow_phase", got.AgentMode)
+	}
+	if got.PhaseID != req.PhaseID || got.PresetQueryID != req.PresetQueryID {
+		t.Fatalf("workflow identity changed: phase=%q preset=%q", got.PhaseID, got.PresetQueryID)
+	}
+	if got.SelectedFolder != "Workflow/llmprovideropensourcemarketing" {
+		t.Fatalf("selected folder = %q, want workflow folder", got.SelectedFolder)
+	}
+}
+
+func TestQueryRequestForContinuationLeavesMultiAgentContextUnchanged(t *testing.T) {
+	req := QueryRequest{AgentMode: "multi-agent", Query: "continue chat", SelectedFolder: "custom"}
+	got := queryRequestForContinuation(req, false, "Workflow/ignored")
+	if got.AgentMode != req.AgentMode || got.SelectedFolder != req.SelectedFolder {
+		t.Fatalf("non-workflow continuation changed: got=%#v want=%#v", got, req)
 	}
 }
 

--- a/agent_go/cmd/server/delegation_tier_profile_test.go
+++ b/agent_go/cmd/server/delegation_tier_profile_test.go
@@ -15,8 +15,11 @@ func TestResolveDelegationTierConfigExpandsProviderProfile(t *testing.T) {
 	if resolved == nil {
 		t.Fatal("resolveDelegationTierConfig() = nil")
 	}
-	if resolved.Main == nil || resolved.Main.ModelID != "claude-sonnet-5" {
-		t.Fatalf("main = %+v, want claude-sonnet-5", resolved.Main)
+	if resolved.Main == nil || resolved.Main.ModelID != "claude-opus-4-8" {
+		t.Fatalf("main = %+v, want claude-opus-4-8", resolved.Main)
+	}
+	if got := resolved.Main.Options["reasoning_effort"]; got != "high" {
+		t.Fatalf("main reasoning_effort = %#v, want high", got)
 	}
 	if resolved.ChiefOfStaff == nil || resolved.ChiefOfStaff.ModelID != "claude-opus-4-8" {
 		t.Fatalf("chief_of_staff = %+v, want claude-opus-4-8", resolved.ChiefOfStaff)

--- a/agent_go/cmd/server/polling.go
+++ b/agent_go/cmd/server/polling.go
@@ -87,6 +87,7 @@ type GetEventsResponse struct {
 	HasMore                    bool           `json:"has_more"`
 	SessionID                  string         `json:"session_id"`
 	SessionStatus              string         `json:"session_status,omitempty"`                // Session status: "running", "completed", "error", "stopped", "inactive"
+	DisplayStatus              string         `json:"display_status,omitempty"`                // Consolidated live status: "busy", "idle", "stopped"
 	LastProcessedIndex         int            `json:"last_processed_index"`                    // Last index processed in unfiltered array (for correct sinceIndex tracking)
 	HasRunningBackgroundAgents bool           `json:"has_running_background_agents,omitempty"` // Whether background agents are still running for this session
 	IsSyntheticTurn            bool           `json:"is_synthetic_turn,omitempty"`             // True when running auto-notification turn (frontend should not block input)
@@ -180,14 +181,15 @@ func (api *StreamingAPI) handleGetSessionEvents(w http.ResponseWriter, r *http.R
 		}
 		sessionStatus = activeSession.Status
 	}
-	canSteer := api.canSteerSession(sessionID)
 	hasRunningBackgroundAgents := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID)
 	if api.shouldCompleteIdleForegroundSession(sessionID, sessionStatus, hasRunningBackgroundAgents) {
 		api.setSessionBusy(sessionID, false)
 		api.updateSessionStatus(sessionID, "completed")
 		sessionStatus = "completed"
-		canSteer = false
 	}
+	runtimeStatus := api.sessionDisplayStatus(sessionID)
+	canSteer := runtimeStatus.CanSteer
+	hasRunningBackgroundAgents = runtimeStatus.HasRunningBackgroundAgents
 
 	// If the session doesn't exist in the in-memory event store, return an
 	// empty events payload. This happens when polling starts before events
@@ -198,6 +200,7 @@ func (api *StreamingAPI) handleGetSessionEvents(w http.ResponseWriter, r *http.R
 			HasMore:                    false,
 			SessionID:                  sessionID,
 			SessionStatus:              sessionStatus,
+			DisplayStatus:              runtimeStatus.Status,
 			LastProcessedIndex:         -1,
 			HasRunningBackgroundAgents: hasRunningBackgroundAgents,
 			CanSteer:                   canSteer,
@@ -236,6 +239,7 @@ func (api *StreamingAPI) handleGetSessionEvents(w http.ResponseWriter, r *http.R
 		HasMore:                    hasMore,
 		SessionID:                  sessionID,
 		SessionStatus:              sessionStatus,
+		DisplayStatus:              runtimeStatus.Status,
 		LastProcessedIndex:         lastProcessedIndex,
 		HasRunningBackgroundAgents: hasRunningBackgroundAgents,
 		CanSteer:                   canSteer,
@@ -530,17 +534,18 @@ func (api *StreamingAPI) handleGetSessionStatus(w http.ResponseWriter, r *http.R
 	// Return active session info
 	status := activeSession.Status
 	hasRunningBackgroundAgents := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID)
-	canSteer := api.canSteerSession(sessionID)
 	hasRetainedTmuxSession := api.sessionHasRetainedCodingTmux(sessionID)
 	if api.shouldCompleteIdleForegroundSession(sessionID, status, hasRunningBackgroundAgents) {
 		api.setSessionBusy(sessionID, false)
 		api.updateSessionStatus(sessionID, "completed")
 		status = "completed"
-		canSteer = false
 	}
+	runtimeStatus := api.sessionDisplayStatus(sessionID)
+	canSteer := runtimeStatus.CanSteer
 	response := map[string]interface{}{
 		"session_id":                activeSession.SessionID,
 		"status":                    status,
+		"display_status":            runtimeStatus.Status,
 		"agent_mode":                activeSession.AgentMode,
 		"created_at":                activeSession.CreatedAt,
 		"last_activity":             activeSession.LastActivity,

--- a/agent_go/cmd/server/runtime_coordinator.go
+++ b/agent_go/cmd/server/runtime_coordinator.go
@@ -1,0 +1,388 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RuntimePhase is the coordinator's normalized lifecycle vocabulary. Phase 1
+// observes and compares this state only; existing stores remain authoritative.
+type RuntimePhase string
+
+const (
+	runtimePhaseStarting  RuntimePhase = "starting"
+	runtimePhaseRunning   RuntimePhase = "running"
+	runtimePhaseWaiting   RuntimePhase = "waiting"
+	runtimePhaseIdle      RuntimePhase = "idle"
+	runtimePhaseCompleted RuntimePhase = "completed"
+	runtimePhaseFailed    RuntimePhase = "failed"
+	runtimePhaseCanceled  RuntimePhase = "canceled"
+)
+
+type RuntimeForegroundSnapshot struct {
+	Busy      bool `json:"busy"`
+	HasCancel bool `json:"has_cancel"`
+	CanSteer  bool `json:"can_steer"`
+	Synthetic bool `json:"synthetic"`
+}
+
+type RuntimeChildSnapshot struct {
+	ExecutionID string     `json:"execution_id"`
+	Kind        string     `json:"kind,omitempty"`
+	Status      string     `json:"status"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
+type RuntimeBackgroundSnapshot struct {
+	AgentID     string     `json:"agent_id"`
+	Status      string     `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
+type RuntimeTerminalSnapshot struct {
+	TerminalID  string    `json:"terminal_id"`
+	ExecutionID string    `json:"execution_id,omitempty"`
+	State       string    `json:"state"`
+	Active      bool      `json:"active"`
+	HasTmux     bool      `json:"has_tmux"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// RuntimeSnapshot is an immutable, revisioned observer view assembled from the
+// existing runtime stores. Callers always receive deep copies.
+type RuntimeSnapshot struct {
+	SessionID        string                      `json:"session_id"`
+	Generation       uint64                      `json:"generation"`
+	Revision         uint64                      `json:"revision"`
+	Phase            RuntimePhase                `json:"phase"`
+	Reason           string                      `json:"reason,omitempty"`
+	RawSessionStatus string                      `json:"raw_session_status,omitempty"`
+	ForegroundTurn   RuntimeForegroundSnapshot   `json:"foreground_turn"`
+	ChildExecutions  []RuntimeChildSnapshot      `json:"child_executions,omitempty"`
+	BackgroundAgents []RuntimeBackgroundSnapshot `json:"background_agents,omitempty"`
+	BackgroundLive   bool                        `json:"background_live"`
+	Terminals        []RuntimeTerminalSnapshot   `json:"terminals,omitempty"`
+	TerminalBusy     bool                        `json:"terminal_busy"`
+	WaitingForUser   bool                        `json:"waiting_for_user"`
+	WaitingMessage   string                      `json:"waiting_message,omitempty"`
+	LastProgressAt   time.Time                   `json:"last_progress_at"`
+	StartedAt        time.Time                   `json:"started_at"`
+	CompletedAt      *time.Time                  `json:"completed_at,omitempty"`
+	ObservedAt       time.Time                   `json:"observed_at"`
+}
+
+type runtimeCoordinatorRecord struct {
+	snapshot              RuntimeSnapshot
+	lastMismatchSignature string
+}
+
+// RuntimeCoordinator stores observer snapshots. It deliberately has no
+// transition APIs that mutate the existing runtime stores in Phase 1.
+type RuntimeCoordinator struct {
+	mu           sync.RWMutex
+	records      map[string]runtimeCoordinatorRecord
+	nextRevision uint64
+}
+
+func NewRuntimeCoordinator() *RuntimeCoordinator {
+	return &RuntimeCoordinator{records: make(map[string]runtimeCoordinatorRecord)}
+}
+
+func (c *RuntimeCoordinator) Observe(candidate RuntimeSnapshot) (RuntimeSnapshot, bool) {
+	if c == nil || strings.TrimSpace(candidate.SessionID) == "" {
+		return RuntimeSnapshot{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	previous, exists := c.records[candidate.SessionID]
+	candidate.Generation = runtimeSnapshotGeneration(previous.snapshot, candidate, exists)
+	if exists && runtimeSnapshotsSemanticallyEqual(previous.snapshot, candidate) {
+		return cloneRuntimeSnapshot(previous.snapshot), false
+	}
+
+	c.nextRevision++
+	candidate.Revision = c.nextRevision
+	candidate.ObservedAt = time.Now().UTC()
+	previous.snapshot = cloneRuntimeSnapshot(candidate)
+	c.records[candidate.SessionID] = previous
+	return cloneRuntimeSnapshot(candidate), true
+}
+
+func (c *RuntimeCoordinator) Snapshot(sessionID string) (RuntimeSnapshot, bool) {
+	if c == nil {
+		return RuntimeSnapshot{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	record, ok := c.records[sessionID]
+	if !ok {
+		return RuntimeSnapshot{}, false
+	}
+	return cloneRuntimeSnapshot(record.snapshot), true
+}
+
+func (c *RuntimeCoordinator) CompareLegacy(snapshot RuntimeSnapshot, legacy SessionDisplayStatus) {
+	if c == nil || snapshot.SessionID == "" {
+		return
+	}
+	observerDisplay := runtimePhaseDisplayStatus(snapshot.Phase)
+	signature := ""
+	if observerDisplay != legacy.Status || snapshot.ForegroundTurn.CanSteer != legacy.CanSteer ||
+		snapshot.BackgroundLive != legacy.HasRunningBackgroundAgents {
+		signature = fmt.Sprintf("phase=%s display=%s legacy=%s steer=%t/%t bg=%t/%t",
+			snapshot.Phase, observerDisplay, legacy.Status,
+			snapshot.ForegroundTurn.CanSteer, legacy.CanSteer,
+			snapshot.BackgroundLive, legacy.HasRunningBackgroundAgents)
+	}
+
+	c.mu.Lock()
+	record, ok := c.records[snapshot.SessionID]
+	if !ok || record.snapshot.Revision != snapshot.Revision || record.lastMismatchSignature == signature {
+		c.mu.Unlock()
+		return
+	}
+	record.lastMismatchSignature = signature
+	c.records[snapshot.SessionID] = record
+	c.mu.Unlock()
+
+	if signature != "" {
+		log.Printf("[RUNTIME_OBSERVER] mismatch session=%s generation=%d revision=%d %s reason=%q",
+			snapshot.SessionID, snapshot.Generation, snapshot.Revision, signature, snapshot.Reason)
+	}
+}
+
+func runtimeSnapshotGeneration(previous, candidate RuntimeSnapshot, exists bool) uint64 {
+	if !exists {
+		return 1
+	}
+	generation := previous.Generation
+	if generation == 0 {
+		generation = 1
+	}
+	newStart := !previous.StartedAt.IsZero() && !candidate.StartedAt.IsZero() &&
+		!previous.StartedAt.Equal(candidate.StartedAt)
+	restartedAfterQuiescence := (runtimePhaseIsTerminal(previous.Phase) || previous.Phase == runtimePhaseIdle) &&
+		(candidate.Phase == runtimePhaseStarting || candidate.Phase == runtimePhaseRunning)
+	if newStart || restartedAfterQuiescence {
+		generation++
+	}
+	return generation
+}
+
+func runtimeSnapshotsSemanticallyEqual(a, b RuntimeSnapshot) bool {
+	a.Revision, b.Revision = 0, 0
+	a.ObservedAt, b.ObservedAt = time.Time{}, time.Time{}
+	return reflect.DeepEqual(a, b)
+}
+
+func cloneRuntimeSnapshot(snapshot RuntimeSnapshot) RuntimeSnapshot {
+	copy := snapshot
+	copy.ChildExecutions = append([]RuntimeChildSnapshot(nil), snapshot.ChildExecutions...)
+	copy.BackgroundAgents = append([]RuntimeBackgroundSnapshot(nil), snapshot.BackgroundAgents...)
+	copy.Terminals = append([]RuntimeTerminalSnapshot(nil), snapshot.Terminals...)
+	if snapshot.CompletedAt != nil {
+		completedAt := *snapshot.CompletedAt
+		copy.CompletedAt = &completedAt
+	}
+	for i := range copy.ChildExecutions {
+		if snapshot.ChildExecutions[i].CompletedAt != nil {
+			completedAt := *snapshot.ChildExecutions[i].CompletedAt
+			copy.ChildExecutions[i].CompletedAt = &completedAt
+		}
+	}
+	for i := range copy.BackgroundAgents {
+		if snapshot.BackgroundAgents[i].CompletedAt != nil {
+			completedAt := *snapshot.BackgroundAgents[i].CompletedAt
+			copy.BackgroundAgents[i].CompletedAt = &completedAt
+		}
+	}
+	return copy
+}
+
+func runtimePhaseDisplayStatus(phase RuntimePhase) string {
+	switch phase {
+	case runtimePhaseStarting, runtimePhaseRunning:
+		return sessionExecutionDisplayBusy
+	case runtimePhaseCompleted, runtimePhaseFailed, runtimePhaseCanceled:
+		return sessionExecutionDisplayStopped
+	default:
+		return sessionExecutionDisplayIdle
+	}
+}
+
+func runtimePhaseIsTerminal(phase RuntimePhase) bool {
+	return phase == runtimePhaseCompleted || phase == runtimePhaseFailed || phase == runtimePhaseCanceled
+}
+
+func sortRuntimeSnapshot(snapshot *RuntimeSnapshot) {
+	sort.Slice(snapshot.ChildExecutions, func(i, j int) bool {
+		return snapshot.ChildExecutions[i].ExecutionID < snapshot.ChildExecutions[j].ExecutionID
+	})
+	sort.Slice(snapshot.BackgroundAgents, func(i, j int) bool {
+		return snapshot.BackgroundAgents[i].AgentID < snapshot.BackgroundAgents[j].AgentID
+	})
+	sort.Slice(snapshot.Terminals, func(i, j int) bool {
+		return snapshot.Terminals[i].TerminalID < snapshot.Terminals[j].TerminalID
+	})
+}
+
+func (api *StreamingAPI) observeRuntimeSnapshot(sessionID string, legacy *SessionDisplayStatus) (RuntimeSnapshot, bool) {
+	if api == nil || api.runtimeCoordinator == nil || strings.TrimSpace(sessionID) == "" {
+		return RuntimeSnapshot{}, false
+	}
+	snapshot, changed := api.runtimeCoordinator.Observe(api.collectRuntimeSnapshot(sessionID))
+	if legacy != nil {
+		api.runtimeCoordinator.CompareLegacy(snapshot, *legacy)
+	}
+	return snapshot, changed
+}
+
+func (api *StreamingAPI) collectRuntimeSnapshot(sessionID string) RuntimeSnapshot {
+	snapshot := RuntimeSnapshot{SessionID: strings.TrimSpace(sessionID)}
+	now := time.Now().UTC()
+
+	if active, ok := api.getActiveSession(sessionID); ok && active != nil {
+		snapshot.RawSessionStatus = active.Status
+		snapshot.StartedAt = active.CreatedAt
+		snapshot.LastProgressAt = active.LastActivity
+		snapshot.WaitingForUser = active.NeedsUserInput
+		snapshot.WaitingMessage = active.WaitingMessage
+		snapshot.ForegroundTurn.Synthetic = active.IsSyntheticTurn
+	}
+
+	snapshot.ForegroundTurn.Busy = api.isSessionBusy(sessionID)
+	snapshot.ForegroundTurn.HasCancel = api.hasActiveTurnCancel(sessionID)
+	snapshot.ForegroundTurn.CanSteer = api.canSteerSession(sessionID)
+
+	for _, execution := range api.trackedExecutionsForSession(sessionID) {
+		if execution == nil {
+			continue
+		}
+		snapshot.ChildExecutions = append(snapshot.ChildExecutions, RuntimeChildSnapshot{
+			ExecutionID: execution.ExecutionID,
+			Kind:        execution.Kind,
+			Status:      execution.Status,
+			StartedAt:   execution.StartedAt,
+			CompletedAt: cloneRuntimeTime(execution.CompletedAt),
+		})
+		snapshot.StartedAt = earliestRuntimeTime(snapshot.StartedAt, execution.StartedAt)
+		snapshot.LastProgressAt = latestRuntimeTime(snapshot.LastProgressAt, execution.StartedAt)
+		if execution.CompletedAt != nil {
+			snapshot.LastProgressAt = latestRuntimeTime(snapshot.LastProgressAt, *execution.CompletedAt)
+		}
+	}
+
+	if api.bgAgentRegistry != nil {
+		snapshot.BackgroundLive = api.bgAgentRegistry.HasRunningAgents(sessionID)
+		for _, backgroundAgent := range api.bgAgentRegistry.GetAll(sessionID) {
+			if backgroundAgent == nil {
+				continue
+			}
+			agent := backgroundAgent.GetSnapshot()
+			snapshot.BackgroundAgents = append(snapshot.BackgroundAgents, RuntimeBackgroundSnapshot{
+				AgentID:     agent.ID,
+				Status:      string(agent.Status),
+				CreatedAt:   agent.CreatedAt,
+				CompletedAt: cloneRuntimeTime(agent.CompletedAt),
+			})
+			snapshot.StartedAt = earliestRuntimeTime(snapshot.StartedAt, agent.CreatedAt)
+			snapshot.LastProgressAt = latestRuntimeTime(snapshot.LastProgressAt, agent.CreatedAt)
+			if agent.CompletedAt != nil {
+				snapshot.LastProgressAt = latestRuntimeTime(snapshot.LastProgressAt, *agent.CompletedAt)
+			}
+		}
+	}
+
+	if api.terminalStore != nil {
+		snapshot.TerminalBusy = api.terminalStore.SessionHasBusyCodingTmux(sessionID)
+		for _, terminal := range api.terminalStore.ListMetadata(sessionID) {
+			snapshot.Terminals = append(snapshot.Terminals, RuntimeTerminalSnapshot{
+				TerminalID:  terminal.TerminalID,
+				ExecutionID: terminal.ExecutionID,
+				State:       terminal.State,
+				Active:      terminal.Active,
+				HasTmux:     strings.TrimSpace(terminal.TmuxSession) != "",
+				UpdatedAt:   terminal.UpdatedAt,
+			})
+			snapshot.StartedAt = earliestRuntimeTime(snapshot.StartedAt, terminal.CreatedAt)
+			snapshot.LastProgressAt = latestRuntimeTime(snapshot.LastProgressAt, terminal.UpdatedAt)
+		}
+	}
+
+	snapshot.Phase, snapshot.Reason = deriveRuntimePhase(snapshot, now)
+	if runtimePhaseIsTerminal(snapshot.Phase) {
+		completedAt := snapshot.LastProgressAt
+		if completedAt.IsZero() {
+			completedAt = now
+		}
+		snapshot.CompletedAt = &completedAt
+	}
+	sortRuntimeSnapshot(&snapshot)
+	return snapshot
+}
+
+func deriveRuntimePhase(snapshot RuntimeSnapshot, now time.Time) (RuntimePhase, string) {
+	if snapshot.WaitingForUser {
+		return runtimePhaseWaiting, "session requires user input"
+	}
+	if snapshot.ForegroundTurn.Busy || snapshot.ForegroundTurn.HasCancel || snapshot.ForegroundTurn.CanSteer {
+		return runtimePhaseRunning, "foreground turn is active"
+	}
+	for _, execution := range snapshot.ChildExecutions {
+		if execution.Status == trackedExecutionStatusRunning {
+			return runtimePhaseRunning, "tracked child execution is active"
+		}
+	}
+	if snapshot.BackgroundLive {
+		return runtimePhaseRunning, "background agent is active or in completion grace"
+	}
+	if snapshot.TerminalBusy {
+		return runtimePhaseRunning, "coding-agent terminal is busy"
+	}
+
+	switch normalizeSessionLifecycleStatus(snapshot.RawSessionStatus) {
+	case sessionLifecycleFailed:
+		return runtimePhaseFailed, "session reported failure"
+	case sessionLifecycleStopped:
+		return runtimePhaseCanceled, "session was stopped"
+	case sessionLifecycleCompleted:
+		return runtimePhaseCompleted, "session completed"
+	case sessionLifecycleRunning:
+		if !snapshot.StartedAt.IsZero() && now.Sub(snapshot.StartedAt) < 10*time.Second {
+			return runtimePhaseStarting, "session started and runtime work is not registered yet"
+		}
+		return runtimePhaseIdle, "session reports running but no live work is registered"
+	default:
+		return runtimePhaseIdle, "no live runtime work is registered"
+	}
+}
+
+func cloneRuntimeTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func earliestRuntimeTime(current, candidate time.Time) time.Time {
+	if candidate.IsZero() || (!current.IsZero() && !candidate.Before(current)) {
+		return current
+	}
+	return candidate
+}
+
+func latestRuntimeTime(current, candidate time.Time) time.Time {
+	if candidate.After(current) {
+		return candidate
+	}
+	return current
+}

--- a/agent_go/cmd/server/runtime_coordinator.go
+++ b/agent_go/cmd/server/runtime_coordinator.go
@@ -129,6 +129,18 @@ func (c *RuntimeCoordinator) Snapshot(sessionID string) (RuntimeSnapshot, bool) 
 	return cloneRuntimeSnapshot(record.snapshot), true
 }
 
+// Evict removes observer state when the authoritative session retention window
+// expires. The coordinator is non-authoritative, so it must never outlive the
+// session it mirrors.
+func (c *RuntimeCoordinator) Evict(sessionID string) {
+	if c == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.records, sessionID)
+	c.mu.Unlock()
+}
+
 func (c *RuntimeCoordinator) CompareLegacy(snapshot RuntimeSnapshot, legacy SessionDisplayStatus) {
 	if c == nil || snapshot.SessionID == "" {
 		return

--- a/agent_go/cmd/server/runtime_coordinator_test.go
+++ b/agent_go/cmd/server/runtime_coordinator_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -39,6 +40,42 @@ func TestRuntimeCoordinatorSnapshotsAreImmutableAndDeduplicated(t *testing.T) {
 	}
 	if stored.ChildExecutions[0].Status != trackedExecutionStatusCompleted || stored.ChildExecutions[0].CompletedAt.IsZero() {
 		t.Fatalf("returned snapshot mutated coordinator state: %#v", stored.ChildExecutions[0])
+	}
+}
+
+func TestRuntimeCoordinatorEvictsRetainedSnapshot(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	coordinator.Observe(RuntimeSnapshot{SessionID: "session-1", Phase: runtimePhaseIdle})
+
+	coordinator.Evict("session-1")
+
+	if _, ok := coordinator.Snapshot("session-1"); ok {
+		t.Fatal("evicted runtime snapshot is still retained")
+	}
+}
+
+func TestSessionDisplayStatusDoesNotObserveOnRead(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	api := &StreamingAPI{
+		runtimeCoordinator: coordinator,
+		activeSessions: map[string]*ActiveSessionInfo{
+			"session-1": {SessionID: "session-1", Status: "running"},
+		},
+		sessionBusy:      map[string]bool{"session-1": true},
+		agentCancelFuncs: map[string]context.CancelFunc{},
+	}
+
+	status := api.sessionDisplayStatus("session-1")
+	if status.Status != sessionExecutionDisplayBusy {
+		t.Fatalf("display status = %q, want busy", status.Status)
+	}
+	if _, ok := coordinator.Snapshot("session-1"); ok {
+		t.Fatal("display-status read performed an expensive runtime observation")
+	}
+
+	api.observeRuntimeSnapshot("session-1", &status)
+	if _, ok := coordinator.Snapshot("session-1"); !ok {
+		t.Fatal("explicit status-cadence observation was not recorded")
 	}
 }
 

--- a/agent_go/cmd/server/runtime_coordinator_test.go
+++ b/agent_go/cmd/server/runtime_coordinator_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRuntimeCoordinatorSnapshotsAreImmutableAndDeduplicated(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	startedAt := time.Now().Add(-time.Minute).UTC()
+	completedAt := startedAt.Add(10 * time.Second)
+	candidate := RuntimeSnapshot{
+		SessionID:  "session-1",
+		Phase:      runtimePhaseRunning,
+		StartedAt:  startedAt,
+		ObservedAt: time.Now(),
+		ChildExecutions: []RuntimeChildSnapshot{{
+			ExecutionID: "child-1",
+			Status:      trackedExecutionStatusCompleted,
+			StartedAt:   startedAt,
+			CompletedAt: &completedAt,
+		}},
+	}
+
+	first, changed := coordinator.Observe(candidate)
+	if !changed || first.Revision == 0 || first.Generation != 1 {
+		t.Fatalf("first observation = %#v changed=%t", first, changed)
+	}
+	second, changed := coordinator.Observe(candidate)
+	if changed || second.Revision != first.Revision {
+		t.Fatalf("identical observation created revision: first=%d second=%d changed=%t", first.Revision, second.Revision, changed)
+	}
+
+	first.ChildExecutions[0].Status = trackedExecutionStatusFailed
+	*first.ChildExecutions[0].CompletedAt = time.Time{}
+	stored, ok := coordinator.Snapshot(candidate.SessionID)
+	if !ok {
+		t.Fatal("expected stored snapshot")
+	}
+	if stored.ChildExecutions[0].Status != trackedExecutionStatusCompleted || stored.ChildExecutions[0].CompletedAt.IsZero() {
+		t.Fatalf("returned snapshot mutated coordinator state: %#v", stored.ChildExecutions[0])
+	}
+}
+
+func TestRuntimeCoordinatorStartsNewGenerationAfterIdle(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	startedAt := time.Now().Add(-time.Hour).UTC()
+	idle, _ := coordinator.Observe(RuntimeSnapshot{
+		SessionID: "session-1",
+		Phase:     runtimePhaseIdle,
+		StartedAt: startedAt,
+	})
+	running, _ := coordinator.Observe(RuntimeSnapshot{
+		SessionID: "session-1",
+		Phase:     runtimePhaseRunning,
+		StartedAt: startedAt,
+	})
+	stillRunning, _ := coordinator.Observe(RuntimeSnapshot{
+		SessionID: "session-1",
+		Phase:     runtimePhaseRunning,
+		StartedAt: startedAt,
+		Reason:    "progressed",
+	})
+
+	if idle.Generation != 1 || running.Generation != 2 || stillRunning.Generation != 2 {
+		t.Fatalf("unexpected generations: idle=%d running=%d progressed=%d", idle.Generation, running.Generation, stillRunning.Generation)
+	}
+}
+
+func TestRuntimeCoordinatorDoesNotCreateGenerationWhenStartTimestampArrivesLate(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	first, _ := coordinator.Observe(RuntimeSnapshot{
+		SessionID: "session-1",
+		Phase:     runtimePhaseRunning,
+	})
+	withTimestamp, _ := coordinator.Observe(RuntimeSnapshot{
+		SessionID: "session-1",
+		Phase:     runtimePhaseRunning,
+		StartedAt: time.Now().UTC(),
+	})
+	if first.Generation != 1 || withTimestamp.Generation != 1 {
+		t.Fatalf("late start timestamp changed generation: first=%d later=%d", first.Generation, withTimestamp.Generation)
+	}
+}
+
+func TestRuntimeCoordinatorCollectsExistingRuntimeStoresWithoutMutatingThem(t *testing.T) {
+	now := time.Now().UTC()
+	api := &StreamingAPI{
+		runtimeCoordinator: NewRuntimeCoordinator(),
+		activeSessions: map[string]*ActiveSessionInfo{
+			"session-1": {
+				SessionID:    "session-1",
+				Status:       "running",
+				CreatedAt:    now.Add(-time.Minute),
+				LastActivity: now,
+			},
+		},
+		sessionBusy: map[string]bool{"session-1": true},
+		trackedWorkflowExecutions: map[string]*TrackedWorkflowExecution{
+			"child-1": {
+				ExecutionID: "child-1",
+				SessionID:   "session-1",
+				Kind:        "workflow_step",
+				Status:      trackedExecutionStatusRunning,
+				StartedAt:   now.Add(-30 * time.Second),
+			},
+		},
+	}
+
+	snapshot, changed := api.observeRuntimeSnapshot("session-1", nil)
+	if !changed || snapshot.Phase != runtimePhaseRunning || len(snapshot.ChildExecutions) != 1 {
+		t.Fatalf("running aggregate = %#v changed=%t", snapshot, changed)
+	}
+	if api.activeSessions["session-1"].Status != "running" || api.trackedWorkflowExecutions["child-1"].Status != trackedExecutionStatusRunning {
+		t.Fatal("observer changed an authoritative runtime store")
+	}
+
+	completedAt := now.Add(time.Second)
+	api.sessionBusy["session-1"] = false
+	api.activeSessions["session-1"].Status = "completed"
+	api.activeSessions["session-1"].LastActivity = completedAt
+	api.trackedWorkflowExecutions["child-1"].Status = trackedExecutionStatusCompleted
+	api.trackedWorkflowExecutions["child-1"].CompletedAt = &completedAt
+
+	completed, changed := api.observeRuntimeSnapshot("session-1", nil)
+	if !changed || completed.Phase != runtimePhaseCompleted || completed.CompletedAt == nil {
+		t.Fatalf("completed aggregate = %#v changed=%t", completed, changed)
+	}
+}
+
+func TestRuntimeCoordinatorLegacyMismatchIsDeduplicatedAndCleared(t *testing.T) {
+	coordinator := NewRuntimeCoordinator()
+	snapshot, _ := coordinator.Observe(RuntimeSnapshot{SessionID: "session-1", Phase: runtimePhaseRunning})
+	mismatch := SessionDisplayStatus{Status: sessionExecutionDisplayIdle}
+	coordinator.CompareLegacy(snapshot, mismatch)
+
+	record := coordinator.records["session-1"]
+	if record.lastMismatchSignature == "" {
+		t.Fatal("expected mismatch signature")
+	}
+	signature := record.lastMismatchSignature
+	coordinator.CompareLegacy(snapshot, mismatch)
+	if coordinator.records["session-1"].lastMismatchSignature != signature {
+		t.Fatal("identical mismatch was not deduplicated")
+	}
+
+	coordinator.CompareLegacy(snapshot, SessionDisplayStatus{Status: sessionExecutionDisplayBusy})
+	if coordinator.records["session-1"].lastMismatchSignature != "" {
+		t.Fatal("matching legacy state did not clear mismatch signature")
+	}
+}

--- a/agent_go/cmd/server/runtime_state_consistency_test.go
+++ b/agent_go/cmd/server/runtime_state_consistency_test.go
@@ -75,6 +75,7 @@ func TestInactiveCleanupPreservesLiveTurnAndMarksTrulyIdleSession(t *testing.T) 
 	liveCtx, liveCancel := context.WithCancel(context.Background())
 	defer liveCancel()
 	api := &StreamingAPI{
+		runtimeCoordinator: NewRuntimeCoordinator(),
 		activeSessions: map[string]*ActiveSessionInfo{
 			"live": {
 				SessionID: "live", Status: "running", CreatedAt: now.Add(-time.Hour), LastActivity: now.Add(-20 * time.Minute),
@@ -97,6 +98,10 @@ func TestInactiveCleanupPreservesLiveTurnAndMarksTrulyIdleSession(t *testing.T) 
 	}
 	if got := api.activeSessions["idle"].Status; got != "inactive" {
 		t.Fatalf("truly idle session status = %q, want inactive", got)
+	}
+	observed, ok := api.runtimeCoordinator.Snapshot("idle")
+	if !ok || observed.RawSessionStatus != "inactive" {
+		t.Fatalf("inactive transition was not observed immediately: %#v, ok=%v", observed, ok)
 	}
 	active := api.getAllActiveSessions()
 	if len(active) != 2 {

--- a/agent_go/cmd/server/runtime_state_consistency_test.go
+++ b/agent_go/cmd/server/runtime_state_consistency_test.go
@@ -113,6 +113,32 @@ func TestInactiveCleanupPreservesLiveTurnAndMarksTrulyIdleSession(t *testing.T) 
 	}
 }
 
+func TestInactiveCleanupEvictsRuntimeCoordinatorRecord(t *testing.T) {
+	now := time.Now()
+	coordinator := NewRuntimeCoordinator()
+	coordinator.Observe(RuntimeSnapshot{SessionID: "expired", Phase: runtimePhaseCompleted})
+	api := &StreamingAPI{
+		runtimeCoordinator: coordinator,
+		activeSessions: map[string]*ActiveSessionInfo{
+			"expired": {
+				SessionID:    "expired",
+				Status:       "completed",
+				CreatedAt:    now.Add(-26 * time.Hour),
+				LastActivity: now.Add(-25 * time.Hour),
+			},
+		},
+	}
+
+	api.cleanupInactiveSessionsAt(now)
+
+	if _, ok := api.activeSessions["expired"]; ok {
+		t.Fatal("expired active session was not removed")
+	}
+	if _, ok := coordinator.Snapshot("expired"); ok {
+		t.Fatal("expired session left a runtime coordinator record behind")
+	}
+}
+
 func TestScheduleStopInvalidatesLateCompletion(t *testing.T) {
 	canceled := false
 	startedAt := time.Now().Add(-time.Minute)

--- a/agent_go/cmd/server/runtime_state_consistency_test.go
+++ b/agent_go/cmd/server/runtime_state_consistency_test.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"mcp-agent-builder-go/agent_go/internal/events"
+)
+
+func TestNormalizeSessionLifecycleStatus(t *testing.T) {
+	tests := map[string]sessionLifecycleStatus{
+		"running":                   sessionLifecycleRunning,
+		"active":                    sessionLifecycleRunning,
+		"success":                   sessionLifecycleCompleted,
+		"completed":                 sessionLifecycleCompleted,
+		"error":                     sessionLifecycleFailed,
+		"failed":                    sessionLifecycleFailed,
+		legacyCanceledBritishStatus: sessionLifecycleStopped,
+		"stopped":                   sessionLifecycleStopped,
+		"inactive":                  sessionLifecycleInactive,
+	}
+	for input, want := range tests {
+		if got := normalizeSessionLifecycleStatus(input); got != want {
+			t.Fatalf("normalizeSessionLifecycleStatus(%q) = %q, want %q", input, got, want)
+		}
+	}
+	if !isStoppedSessionStatus("failed") || !isStoppedSessionStatus("error") {
+		t.Fatal("both failed and legacy error statuses must be terminal")
+	}
+}
+
+func TestActiveSessionReadsReturnSnapshots(t *testing.T) {
+	waitingSince := time.Now().Add(-time.Minute)
+	api := &StreamingAPI{
+		activeSessions: map[string]*ActiveSessionInfo{
+			"session-1": {
+				SessionID:    "session-1",
+				Status:       "running",
+				CreatedAt:    time.Now().Add(-time.Hour),
+				LastActivity: time.Now(),
+				WaitingSince: &waitingSince,
+			},
+		},
+	}
+
+	snapshot, ok := api.getActiveSession("session-1")
+	if !ok {
+		t.Fatal("expected active session")
+	}
+	snapshot.Status = "stopped"
+	*snapshot.WaitingSince = time.Time{}
+	if api.activeSessions["session-1"].Status != "running" {
+		t.Fatal("mutating a returned session changed shared state")
+	}
+	if api.activeSessions["session-1"].WaitingSince.IsZero() {
+		t.Fatal("nested pointer was not copied")
+	}
+
+	all := api.getAllActiveSessions()
+	if len(all) != 1 {
+		t.Fatalf("getAllActiveSessions returned %d sessions, want 1", len(all))
+	}
+	all[0].Status = "failed"
+	if api.activeSessions["session-1"].Status != "running" {
+		t.Fatal("mutating an active-session list item changed shared state")
+	}
+}
+
+func TestInactiveCleanupPreservesLiveTurnAndMarksTrulyIdleSession(t *testing.T) {
+	now := time.Now()
+	liveCtx, liveCancel := context.WithCancel(context.Background())
+	defer liveCancel()
+	api := &StreamingAPI{
+		activeSessions: map[string]*ActiveSessionInfo{
+			"live": {
+				SessionID: "live", Status: "running", CreatedAt: now.Add(-time.Hour), LastActivity: now.Add(-20 * time.Minute),
+			},
+			"idle": {
+				SessionID: "idle", Status: "running", CreatedAt: now.Add(-time.Hour), LastActivity: now.Add(-20 * time.Minute),
+			},
+		},
+		agentCancelFuncs:         map[string]context.CancelFunc{"live": liveCancel},
+		pendingCompletions:       map[string][]string{},
+		completionRetryScheduled: map[string]bool{},
+		bgAgentRegistry:          NewBackgroundAgentRegistry(),
+	}
+	_ = liveCtx
+
+	api.cleanupInactiveSessionsAt(now)
+
+	if got := api.activeSessions["live"].Status; got != "running" {
+		t.Fatalf("live foreground turn status = %q, want running", got)
+	}
+	if got := api.activeSessions["idle"].Status; got != "inactive" {
+		t.Fatalf("truly idle session status = %q, want inactive", got)
+	}
+	active := api.getAllActiveSessions()
+	if len(active) != 2 {
+		t.Fatalf("active sessions count = %d, want retained live plus inactive session", len(active))
+	}
+	foundLive := false
+	for _, session := range active {
+		if session.SessionID == "live" {
+			foundLive = true
+		}
+	}
+	if !foundLive {
+		t.Fatal("old session with a live foreground turn was hidden from active-session list")
+	}
+}
+
+func TestScheduleStopInvalidatesLateCompletion(t *testing.T) {
+	canceled := false
+	startedAt := time.Now().Add(-time.Minute)
+	svc := &SchedulerService{
+		runtimeStates: map[string]*ScheduleRuntimeState{
+			"schedule-1": {
+				LastStatus: "running", LastRunAt: &startedAt, runGeneration: 4,
+				runCancel: func() { canceled = true },
+			},
+		},
+	}
+
+	svc.StopRunningJob("schedule-1")
+	state := svc.GetRuntimeState("schedule-1")
+	if state.LastStatus != "stopped" || state.LastError != "stopped by user" {
+		t.Fatalf("stopped state = %#v", state)
+	}
+	if !canceled {
+		t.Fatal("StopRunningJob did not cancel the run context")
+	}
+	if svc.finishScheduleRun("schedule-1", 4, "success", "", 100, nil) {
+		t.Fatal("late generation was allowed to commit")
+	}
+	state = svc.GetRuntimeState("schedule-1")
+	if state.LastStatus != "stopped" {
+		t.Fatalf("late completion overwrote stopped state with %q", state.LastStatus)
+	}
+}
+
+func TestScheduleRuntimeReadReturnsSnapshot(t *testing.T) {
+	lastRun := time.Now()
+	duration := int64(10)
+	svc := &SchedulerService{runtimeStates: map[string]*ScheduleRuntimeState{
+		"schedule-1": {LastStatus: "running", LastRunAt: &lastRun, LastDurationMs: &duration},
+	}}
+
+	snapshot := svc.getRuntimeStateSnapshot("schedule-1")
+	snapshot.LastStatus = "stopped"
+	*snapshot.LastRunAt = time.Time{}
+	*snapshot.LastDurationMs = 999
+	state := svc.runtimeStates["schedule-1"]
+	if state.LastStatus != "running" || state.LastRunAt.IsZero() || *state.LastDurationMs != 10 {
+		t.Fatalf("mutating schedule snapshot changed shared state: %#v", state)
+	}
+}
+
+func TestScheduleReconciliationPreservesStoppedStatus(t *testing.T) {
+	now := time.Now()
+	svc := &SchedulerService{api: &StreamingAPI{
+		activeSessions: map[string]*ActiveSessionInfo{
+			"schedule-session": {SessionID: "schedule-session", Status: "stopped", LastActivity: now},
+		},
+	}}
+	status, _, terminal := svc.reconciledScheduleRunStatus(&ScheduleRunEntry{
+		SessionID: "schedule-session",
+		StartedAt: now.Add(-time.Minute),
+	}, now)
+	if !terminal || status != "stopped" {
+		t.Fatalf("reconciled stopped session = status %q terminal=%t", status, terminal)
+	}
+}
+
+func TestRuntimeEndpointsUseSameDisplayStatus(t *testing.T) {
+	store := events.NewEventStore(10)
+	defer store.Stop()
+	const sessionID = "session-busy"
+	now := time.Now()
+	api := &StreamingAPI{
+		eventStore:      store,
+		bgAgentRegistry: NewBackgroundAgentRegistry(),
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running", CreatedAt: now, LastActivity: now},
+		},
+		sessionBusy:      map[string]bool{sessionID: true},
+		sessionBusySince: map[string]time.Time{sessionID: now},
+	}
+
+	eventsRequest := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/events?since=0", nil)
+	eventsRequest = mux.SetURLVars(eventsRequest, map[string]string{"session_id": sessionID})
+	eventsResponse := httptest.NewRecorder()
+	api.handleGetSessionEvents(eventsResponse, eventsRequest)
+	var pollingBody GetEventsResponse
+	if err := json.Unmarshal(eventsResponse.Body.Bytes(), &pollingBody); err != nil {
+		t.Fatalf("decode polling response: %v", err)
+	}
+
+	statusRequest := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/status", nil)
+	statusRequest = mux.SetURLVars(statusRequest, map[string]string{"session_id": sessionID})
+	statusResponse := httptest.NewRecorder()
+	api.handleGetSessionStatus(statusResponse, statusRequest)
+	var statusBody struct {
+		DisplayStatus string `json:"display_status"`
+	}
+	if err := json.Unmarshal(statusResponse.Body.Bytes(), &statusBody); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+
+	if pollingBody.DisplayStatus != sessionExecutionDisplayBusy || statusBody.DisplayStatus != pollingBody.DisplayStatus {
+		t.Fatalf("display status mismatch: polling=%q status=%q", pollingBody.DisplayStatus, statusBody.DisplayStatus)
+	}
+	sseBody := sseStatusMessage{DisplayStatus: api.sessionDisplayStatus(sessionID).Status}
+	if sseBody.DisplayStatus != pollingBody.DisplayStatus {
+		t.Fatalf("SSE display status=%q, polling=%q", sseBody.DisplayStatus, pollingBody.DisplayStatus)
+	}
+}

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -1189,11 +1189,13 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	s.runtimeStatesMu.Lock()
 	state := s.getRuntimeStateLocked(schedID)
 	if sctx.runGeneration == 0 {
-		if state.LastStatus != "running" {
-			state.LastStatus = "running"
-			state.LastRunAt = &startTime
-			state.runGeneration++
+		if state.LastStatus == "running" {
+			s.runtimeStatesMu.Unlock()
+			return "", errWorkshopSequenceInterrupted
 		}
+		state.LastStatus = "running"
+		state.LastRunAt = &startTime
+		state.runGeneration++
 		sctx.runGeneration = state.runGeneration
 	}
 	if state.LastStatus != "running" || state.runGeneration != sctx.runGeneration {

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -31,6 +31,7 @@ type ScheduleContext struct {
 	UserID        string // Set for multi-agent schedules (derived from _users/{userID}/ path)
 	SourceType    string // "workflow" or "multi-agent"
 	TriggerSource string // "cron" (default) or "manual"; encoded into the session ID
+	runGeneration uint64 // identifies the in-memory run that owns runtime-state updates
 }
 
 // newScheduleSessionID mints the session ID for a scheduled run. Encoding the
@@ -58,6 +59,8 @@ type ScheduleRuntimeState struct {
 	LastDurationMs      *int64     `json:"last_duration_ms,omitempty"`
 	RunCount            int        `json:"run_count"`
 	ConsecutiveFailures int        `json:"consecutive_failures"`
+	runGeneration       uint64
+	runCancel           context.CancelFunc
 }
 
 // registeredJob is a schedule registered for wall-clock evaluation.
@@ -506,9 +509,11 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 		nextRun = getNextRunTime(sched.CronExpression, sched.Timezone)
 	}
 
-	// Initialize runtime state with next run
-	state := s.getOrCreateRuntimeState(sched.ID)
+	// Initialize runtime state with next run.
+	s.runtimeStatesMu.Lock()
+	state := s.getRuntimeStateLocked(sched.ID)
 	state.NextRunAt = nextRun
+	s.runtimeStatesMu.Unlock()
 
 	nextRunStr := "unknown"
 	if nextRun != nil {
@@ -589,12 +594,7 @@ func (s *SchedulerService) RemoveJob(id string) error {
 
 // GetRuntimeState returns the in-memory runtime state for a schedule.
 func (s *SchedulerService) GetRuntimeState(scheduleID string) ScheduleRuntimeState {
-	s.runtimeStatesMu.RLock()
-	var merged ScheduleRuntimeState
-	if state, ok := s.runtimeStates[scheduleID]; ok {
-		merged = *state
-	}
-	s.runtimeStatesMu.RUnlock()
+	merged := s.getRuntimeStateSnapshot(scheduleID)
 
 	if userID := s.GetUserForSchedule(scheduleID); userID != "" {
 		runs, err := ReadMultiAgentScheduleRuns(context.Background(), userID)
@@ -613,6 +613,36 @@ func (s *SchedulerService) GetRuntimeState(scheduleID string) ScheduleRuntimeSta
 	}
 
 	return merged
+}
+
+func (s *SchedulerService) getRuntimeStateSnapshot(scheduleID string) ScheduleRuntimeState {
+	s.runtimeStatesMu.RLock()
+	defer s.runtimeStatesMu.RUnlock()
+	if state, ok := s.runtimeStates[scheduleID]; ok && state != nil {
+		return cloneScheduleRuntimeState(state)
+	}
+	return ScheduleRuntimeState{}
+}
+
+func cloneScheduleRuntimeState(state *ScheduleRuntimeState) ScheduleRuntimeState {
+	if state == nil {
+		return ScheduleRuntimeState{}
+	}
+	copy := *state
+	copy.runCancel = nil
+	if state.LastRunAt != nil {
+		value := *state.LastRunAt
+		copy.LastRunAt = &value
+	}
+	if state.NextRunAt != nil {
+		value := *state.NextRunAt
+		copy.NextRunAt = &value
+	}
+	if state.LastDurationMs != nil {
+		value := *state.LastDurationMs
+		copy.LastDurationMs = &value
+	}
+	return copy
 }
 
 func (s *SchedulerService) reconcileWorkflowScheduleRuns(ctx context.Context, workspacePath, scheduleID string) error {
@@ -679,7 +709,9 @@ func (s *SchedulerService) reconciledScheduleRunStatus(run *ScheduleRunEntry, no
 		return "", "", false
 	case "completed":
 		return "success", "", true
-	case "error", "stopped", "inactive", "dismissed":
+	case "stopped", "dismissed":
+		return "stopped", fmt.Sprintf("session ended with status %s", session.Status), true
+	case "error", "failed", "inactive":
 		return "error", fmt.Sprintf("session ended with status %s", session.Status), true
 	default:
 		return "", "", false
@@ -793,10 +825,13 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 	state.LastStatus = "running"
 	state.LastRunAt = &startTime
 	state.LastError = ""
+	state.runGeneration++
+	runGeneration := state.runGeneration
 	s.runtimeStatesMu.Unlock()
 
 	sctx := buildScheduleContext(workspacePath, manifest, *sched)
 	sctx.TriggerSource = "manual"
+	sctx.runGeneration = runGeneration
 
 	if err := RecordWorkflowScheduleExecution(context.Background(), workspacePath, *sched, startTime); err != nil {
 		s.logf(sctx, "[SCHEDULER] Warning: failed to record manual schedule execution for %s: %v", scheduleID, err)
@@ -842,10 +877,13 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 	state.LastStatus = "running"
 	state.LastRunAt = &startTime
 	state.LastError = ""
+	state.runGeneration++
+	runGeneration := state.runGeneration
 	s.runtimeStatesMu.Unlock()
 
 	sctx := buildMultiAgentScheduleContext(userID, *sched, f.Capabilities)
 	sctx.TriggerSource = "manual"
+	sctx.runGeneration = runGeneration
 
 	go func() {
 		if _, err := s.runJob(context.Background(), sctx); err != nil {
@@ -858,24 +896,37 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 
 // StopRunningJob stops a running scheduled job by canceling its session.
 func (s *SchedulerService) StopRunningJob(scheduleID string) {
-	state := s.GetRuntimeState(scheduleID)
-	sessionID := state.LastSessionID
-	if sessionID == "" {
+	s.runtimeStatesMu.Lock()
+	state := s.getRuntimeStateLocked(scheduleID)
+	if state.LastStatus != "running" {
+		s.runtimeStatesMu.Unlock()
 		return
 	}
+	sessionID := state.LastSessionID
+	cancel := state.runCancel
+	durationMs := int64(0)
+	if state.LastRunAt != nil {
+		durationMs = time.Since(*state.LastRunAt).Milliseconds()
+	}
+	state.LastStatus = "stopped"
+	state.LastError = "stopped by user"
+	state.LastDurationMs = &durationMs
+	state.runGeneration++ // invalidates every late write from the stopped run
+	state.runCancel = nil
+	s.runtimeStatesMu.Unlock()
 
 	scheduleLogf("[SCHEDULER] Stopping running job %s (session: %s)", scheduleID, sessionID)
+	if cancel != nil {
+		cancel()
+	}
+	if sessionID == "" {
+		scheduleLogf("[SCHEDULER] Stopped job %s before its session was registered", scheduleID)
+		return
+	}
 	if isScheduledSession(sessionID) {
 		s.api.markSessionTurnInterrupted(sessionID)
 	}
 	s.cancelScheduledSessionWork(sessionID, "scheduled job stopped by user")
-
-	// Update runtime state
-	s.runtimeStatesMu.Lock()
-	if st, ok := s.runtimeStates[scheduleID]; ok {
-		st.LastStatus = "stopped"
-	}
-	s.runtimeStatesMu.Unlock()
 
 	scheduleLogf("[SCHEDULER] Stopped job %s (session: %s)", scheduleID, sessionID)
 }
@@ -1105,6 +1156,8 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 	state.LastStatus = "running"
 	state.LastRunAt = &startTime
 	state.LastError = ""
+	state.runGeneration++
+	freshCtx.runGeneration = state.runGeneration
 	s.runtimeStatesMu.Unlock()
 
 	if freshCtx.SourceType == "workflow" {
@@ -1128,10 +1181,29 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	s.logf(sctx, "[SCHEDULER] runJob starting for %s (%s) at %s, groups=%v",
 		schedID, sctx.Schedule.Name, startTime.Format(time.RFC3339), sctx.Schedule.GroupNames)
 
-	// Clear session/error fields — status is already "running" (set atomically by caller)
-	state := s.getOrCreateRuntimeState(schedID)
+	// Bind this goroutine to the exact run generation that started it. Stop or a
+	// later restart invalidates the generation, so this run cannot overwrite the
+	// newer state when it eventually returns.
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	s.runtimeStatesMu.Lock()
+	state := s.getRuntimeStateLocked(schedID)
+	if sctx.runGeneration == 0 {
+		if state.LastStatus != "running" {
+			state.LastStatus = "running"
+			state.LastRunAt = &startTime
+			state.runGeneration++
+		}
+		sctx.runGeneration = state.runGeneration
+	}
+	if state.LastStatus != "running" || state.runGeneration != sctx.runGeneration {
+		s.runtimeStatesMu.Unlock()
+		return "", errWorkshopSequenceInterrupted
+	}
 	state.LastSessionID = ""
 	state.LastError = ""
+	state.runCancel = runCancel
+	s.runtimeStatesMu.Unlock()
 
 	// Create run history entry (file-based)
 	runID := uuid.New().String()
@@ -1153,7 +1225,7 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	}
 
 	// Execute
-	sessionID, runFolder, execErr := s.executeJob(ctx, sctx, runID)
+	sessionID, runFolder, execErr := s.executeJob(runCtx, sctx, runID)
 
 	// Calculate results
 	durationMs := time.Since(startTime).Milliseconds()
@@ -1161,10 +1233,15 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 
 	status := "success"
 	errMsg := ""
-	userInterrupted := errors.Is(execErr, errWorkshopSequenceInterrupted)
+	userInterrupted := errors.Is(execErr, errWorkshopSequenceInterrupted) || s.scheduleRunInvalidated(schedID, sctx.runGeneration)
 	if userInterrupted {
 		status = "stopped"
-		errMsg = execErr.Error()
+		if execErr != nil {
+			errMsg = execErr.Error()
+		} else {
+			errMsg = "stopped by user"
+			execErr = errWorkshopSequenceInterrupted
+		}
 		s.sessionLogf(sctx, sessionID, "[SCHEDULER] %s stopped by user after %dms", schedID, durationMs)
 	} else if execErr != nil {
 		status = "error"
@@ -1180,7 +1257,7 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	// frequent cron can start the next workflow run while Pulse is between steps.
 	// That makes the next Pulse turn fail with workflow_busy (commonly after the
 	// LLM/cost/time report), so cadence/backup/publish/notify never run.
-	state.LastSessionID = sessionID
+	s.setScheduleSessionID(schedID, sctx.runGeneration, sessionID)
 
 	// Update run history entry for the actual workflow/task run. Post-run Pulse
 	// may continue after this, but it does not change the recorded run result.
@@ -1216,15 +1293,10 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	}
 
 	// Now the whole scheduled job, including post-run side effects, is done.
-	state.LastStatus = status
-	state.LastError = errMsg
-	state.LastDurationMs = &durationMs
-	state.NextRunAt = nextRun
-	state.RunCount++
-	if status == "error" {
-		state.ConsecutiveFailures++
-	} else {
-		state.ConsecutiveFailures = 0
+	if !s.finishScheduleRun(schedID, sctx.runGeneration, status, errMsg, durationMs, nextRun) {
+		stateSnapshot := s.getRuntimeStateSnapshot(schedID)
+		s.sessionLogf(sctx, sessionID, "[SCHEDULER] Ignoring late completion for %s generation %d; current generation=%d status=%s",
+			schedID, sctx.runGeneration, stateSnapshot.runGeneration, stateSnapshot.LastStatus)
 	}
 
 	return sessionID, execErr
@@ -1919,8 +1991,7 @@ func (s *SchedulerService) executeWorkshopJob(ctx context.Context, sctx *Schedul
 
 	sessionID := s.newScheduleSessionID(sctx)
 
-	state := s.getOrCreateRuntimeState(sctx.Schedule.ID)
-	state.LastSessionID = sessionID
+	s.setScheduleSessionID(sctx.Schedule.ID, sctx.runGeneration, sessionID)
 
 	if runID != "" {
 		_ = UpdateScheduleRun(ctx, sctx.WorkspacePath, runID, "running", "", nil, runFolder, sessionID)
@@ -2210,8 +2281,7 @@ func (s *SchedulerService) executeMultiAgentJob(ctx context.Context, sctx *Sched
 
 	sessionID := s.newScheduleSessionID(sctx)
 
-	state := s.getOrCreateRuntimeState(sctx.Schedule.ID)
-	state.LastSessionID = sessionID
+	s.setScheduleSessionID(sctx.Schedule.ID, sctx.runGeneration, sessionID)
 
 	if runID != "" {
 		_ = UpdateMultiAgentScheduleRun(ctx, sctx.UserID, runID, "running", "", nil, sessionID)
@@ -2802,18 +2872,6 @@ func (api *StreamingAPI) refreshSessionTmuxSnapshotsForIdleCheck(ctx context.Con
 	return nil
 }
 
-// getOrCreateRuntimeState returns (or creates) the in-memory runtime state for a schedule.
-func (s *SchedulerService) getOrCreateRuntimeState(scheduleID string) *ScheduleRuntimeState {
-	s.runtimeStatesMu.Lock()
-	defer s.runtimeStatesMu.Unlock()
-	if state, ok := s.runtimeStates[scheduleID]; ok {
-		return state
-	}
-	state := &ScheduleRuntimeState{}
-	s.runtimeStates[scheduleID] = state
-	return state
-}
-
 // getRuntimeStateLocked returns or creates runtime state. Caller MUST hold runtimeStatesMu write lock.
 func (s *SchedulerService) getRuntimeStateLocked(scheduleID string) *ScheduleRuntimeState {
 	if state, ok := s.runtimeStates[scheduleID]; ok {
@@ -2822,6 +2880,45 @@ func (s *SchedulerService) getRuntimeStateLocked(scheduleID string) *ScheduleRun
 	state := &ScheduleRuntimeState{}
 	s.runtimeStates[scheduleID] = state
 	return state
+}
+
+func (s *SchedulerService) setScheduleSessionID(scheduleID string, generation uint64, sessionID string) bool {
+	s.runtimeStatesMu.Lock()
+	defer s.runtimeStatesMu.Unlock()
+	state := s.getRuntimeStateLocked(scheduleID)
+	if state.LastStatus != "running" || state.runGeneration != generation {
+		return false
+	}
+	state.LastSessionID = sessionID
+	return true
+}
+
+func (s *SchedulerService) scheduleRunInvalidated(scheduleID string, generation uint64) bool {
+	s.runtimeStatesMu.RLock()
+	defer s.runtimeStatesMu.RUnlock()
+	state := s.runtimeStates[scheduleID]
+	return state == nil || state.LastStatus != "running" || state.runGeneration != generation
+}
+
+func (s *SchedulerService) finishScheduleRun(scheduleID string, generation uint64, status, errMsg string, durationMs int64, nextRun *time.Time) bool {
+	s.runtimeStatesMu.Lock()
+	defer s.runtimeStatesMu.Unlock()
+	state := s.getRuntimeStateLocked(scheduleID)
+	if state.LastStatus != "running" || state.runGeneration != generation {
+		return false
+	}
+	state.LastStatus = status
+	state.LastError = errMsg
+	state.LastDurationMs = &durationMs
+	state.NextRunAt = nextRun
+	state.RunCount++
+	state.runCancel = nil
+	if status == "error" {
+		state.ConsecutiveFailures++
+	} else {
+		state.ConsecutiveFailures = 0
+	}
+	return true
 }
 
 func runningWorkflowScheduleInSetLocked(runtimeStates map[string]*ScheduleRuntimeState, scheduleIDs []string, ignoreScheduleID string) (string, string) {

--- a/agent_go/cmd/server/scheduler_routes.go
+++ b/agent_go/cmd/server/scheduler_routes.go
@@ -1115,17 +1115,13 @@ func stopScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 
 		svc.StopRunningJob(id)
 
-		// Update runtime state
-		svc.runtimeStatesMu.Lock()
-		s := svc.getRuntimeStateLocked(id)
+		// StopRunningJob owns the runtime transition. The route only mirrors that
+		// terminal state into persisted run history.
+		stoppedState := svc.getRuntimeStateSnapshot(id)
 		durationMs := int64(0)
-		if s.LastRunAt != nil {
-			durationMs = time.Since(*s.LastRunAt).Milliseconds()
+		if stoppedState.LastDurationMs != nil {
+			durationMs = *stoppedState.LastDurationMs
 		}
-		s.LastStatus = "error"
-		s.LastError = "stopped by user"
-		s.LastDurationMs = &durationMs
-		svc.runtimeStatesMu.Unlock()
 
 		// Update latest run entry — check multi-agent first, then workflow
 		userID := svc.GetUserForSchedule(id)
@@ -1134,7 +1130,7 @@ func stopScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			if err == nil {
 				for i := range runs {
 					if runs[i].ScheduleID == id && runs[i].Status == "running" {
-						_ = UpdateMultiAgentScheduleRun(r.Context(), userID, runs[i].ID, "error", "stopped by user", &durationMs, "")
+						_ = UpdateMultiAgentScheduleRun(r.Context(), userID, runs[i].ID, "stopped", "stopped by user", &durationMs, "")
 						break
 					}
 				}
@@ -1146,7 +1142,7 @@ func stopScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				if err == nil && len(runs) > 0 {
 					for i := range runs {
 						if runs[i].ScheduleID == id && runs[i].Status == "running" {
-							_ = UpdateScheduleRun(r.Context(), workspacePath, runs[i].ID, "error", "stopped by user", &durationMs, "", "")
+							_ = UpdateScheduleRun(r.Context(), workspacePath, runs[i].ID, "stopped", "stopped by user", &durationMs, "", "")
 							break
 						}
 					}

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -1821,6 +1821,29 @@ func TestWaitForWorkshopIdleAbortsCanceledTurnBeforeNextMessage(t *testing.T) {
 	}
 }
 
+func TestRunJobGenerationZeroDoesNotJoinActiveRun(t *testing.T) {
+	startedAt := time.Now().Add(-time.Minute)
+	svc := &SchedulerService{runtimeStates: map[string]*ScheduleRuntimeState{
+		"schedule-1": {
+			LastStatus:    "running",
+			LastRunAt:     &startedAt,
+			runGeneration: 7,
+		},
+	}}
+	sctx := &ScheduleContext{Schedule: WorkflowSchedule{ID: "schedule-1", Name: "Active schedule"}}
+
+	_, err := svc.runJob(context.Background(), sctx)
+	if !errors.Is(err, errWorkshopSequenceInterrupted) {
+		t.Fatalf("runJob error = %v, want errWorkshopSequenceInterrupted", err)
+	}
+	if sctx.runGeneration != 0 {
+		t.Fatalf("generation-zero caller adopted generation %d", sctx.runGeneration)
+	}
+	if got := svc.runtimeStates["schedule-1"].runGeneration; got != 7 {
+		t.Fatalf("active run generation changed to %d", got)
+	}
+}
+
 func TestWaitForWorkshopIdleTimesOutWhenSessionStaysBusy(t *testing.T) {
 	oldInterval := schedulerWorkshopIdlePollInterval
 	oldMaxInactivity := schedulerWorkshopMaxInactivity

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -3701,7 +3701,14 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Process the query in the background
 	go func() {
+		var agentCancel context.CancelFunc
 		defer func() {
+			if agentCancel != nil {
+				agentCancel()
+				api.agentCancelMux.Lock()
+				delete(api.agentCancelFuncs, sessionID)
+				api.agentCancelMux.Unlock()
+			}
 			// Publish completion before releasing the turn lane. A queued synthetic
 			// turn can then acquire the lane and set running=true without an older
 			// cleanup racing afterward and clearing its state.
@@ -3709,6 +3716,7 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 				api.setSyntheticTurn(sessionID, false)
 				api.setSessionBusy(sessionID, false)
 			}
+			api.observeRuntimeSnapshot(sessionID, nil)
 			if queryInputLaneRelease != nil {
 				queryInputLaneRelease()
 			}
@@ -5771,11 +5779,6 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[BG AGENT] Stored agent for session %s for synthetic turn reuse", sessionID)
 		}
 
-		// Clean up the agent cancel function when streaming is complete
-		api.agentCancelMux.Lock()
-		delete(api.agentCancelFuncs, sessionID)
-		api.agentCancelMux.Unlock()
-
 		// Update active session status to completed
 		log.Printf("[COMPLETION] Updating session %s status to completed", sessionID)
 		api.updateSessionStatus(sessionID, "completed")
@@ -6607,6 +6610,7 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 	}
 
 	sessionsToEvictEventBuffer := make([]string, 0)
+	sessionsToEvictRuntime := make([]string, 0)
 	api.activeSessionsMux.Lock()
 	for sessionID, session := range api.activeSessions {
 		age := now.Sub(session.LastActivity)
@@ -6626,6 +6630,7 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 		}
 		if age >= sessionRetention {
 			delete(api.activeSessions, sessionID)
+			sessionsToEvictRuntime = append(sessionsToEvictRuntime, sessionID)
 			if api.terminalStore != nil {
 				api.terminalStore.RemoveSession(sessionID)
 			}
@@ -6633,6 +6638,12 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 		}
 	}
 	api.activeSessionsMux.Unlock()
+
+	for _, sessionID := range sessionsToEvictRuntime {
+		if api.runtimeCoordinator != nil {
+			api.runtimeCoordinator.Evict(sessionID)
+		}
+	}
 
 	for _, sessionID := range sessionsToEvictEventBuffer {
 		if api.eventStore != nil {

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -306,6 +306,10 @@ type StreamingAPI struct {
 	// View-only runtime terminal snapshots for coding-agent TUI streams.
 	terminalStore *terminals.Store
 
+	// Phase 1 observer: immutable aggregate runtime snapshots. Existing stores
+	// remain authoritative until observer comparisons are proven in production.
+	runtimeCoordinator *RuntimeCoordinator
+
 	// Raw tmux pipe-pane recorder used for append/replay terminal display.
 	terminalPipeRecorder *terminalPipeRecorder
 
@@ -1242,6 +1246,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		inspectorStore:                     inspector.NewStore(),
 		eventStore:                         eventStore,
 		terminalStore:                      terminalStore,
+		runtimeCoordinator:                 NewRuntimeCoordinator(),
 		terminalPipeRecorder:               terminalPipeRecorder,
 		liveAttach:                         newLiveAttachManagerIfEnabled(),
 		provider:                           config.Provider,
@@ -3667,8 +3672,9 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 	// start the next turn from a lightweight live-input message when a retained
 	// coding CLI session is idle. Synthetic turns also reuse this context.
 	req.userID = currentUserID
+	continuationReq := queryRequestForContinuation(req, isWorkflowPhase, workflowPhaseFolder)
 	api.lastQueryMu.Lock()
-	api.lastQueryRequests[sessionID] = req
+	api.lastQueryRequests[sessionID] = continuationReq
 	api.lastQueryMu.Unlock()
 
 	// Set user-facing busy state for regular chat turns.
@@ -6187,23 +6193,23 @@ func (api *StreamingAPI) seedCodingAgentRuntimeFromRestoredConversation(sessionI
 // updateSessionActivity updates the LastActivity timestamp for a session when events are added
 func (api *StreamingAPI) updateSessionActivity(sessionID string) {
 	api.activeSessionsMux.Lock()
-	defer api.activeSessionsMux.Unlock()
-
 	if session, exists := api.activeSessions[sessionID]; exists {
 		session.LastActivity = time.Now()
 		// Don't log every activity update to avoid log spam
 	}
+	api.activeSessionsMux.Unlock()
 }
 
 // updateSessionStatus updates the status of an active session in memory.
 func (api *StreamingAPI) updateSessionStatus(sessionID, status string) {
 	api.activeSessionsMux.Lock()
-	defer api.activeSessionsMux.Unlock()
 	if session, exists := api.activeSessions[sessionID]; exists {
 		session.Status = status
 		session.LastActivity = time.Now()
 		log.Printf("[ACTIVE_SESSION] Updated session %s status to: %s", sessionID, status)
 	}
+	api.activeSessionsMux.Unlock()
+	api.observeRuntimeSnapshot(sessionID, nil)
 }
 
 // removeSessionQueryID removes a completed workflow query from the session ->
@@ -6491,27 +6497,49 @@ func (api *StreamingAPI) getActiveSession(sessionID string) (*ActiveSessionInfo,
 	defer api.activeSessionsMux.RUnlock()
 
 	session, exists := api.activeSessions[sessionID]
-	return session, exists
+	if !exists || session == nil {
+		return nil, false
+	}
+	return cloneActiveSessionInfo(session), true
+}
+
+func cloneActiveSessionInfo(session *ActiveSessionInfo) *ActiveSessionInfo {
+	if session == nil {
+		return nil
+	}
+	copy := *session
+	if session.WaitingSince != nil {
+		waitingSince := *session.WaitingSince
+		copy.WaitingSince = &waitingSince
+	}
+	return &copy
 }
 
 // getAllActiveSessions returns live sessions plus retained terminal sessions.
 func (api *StreamingAPI) getAllActiveSessions() []*ActiveSessionInfo {
 	api.activeSessionsMux.RLock()
-	defer api.activeSessionsMux.RUnlock()
+	snapshots := make([]*ActiveSessionInfo, 0, len(api.activeSessions))
+	for _, session := range api.activeSessions {
+		snapshots = append(snapshots, cloneActiveSessionInfo(session))
+	}
+	api.activeSessionsMux.RUnlock()
 
 	now := time.Now()
 	inactivityTimeout := 10 * time.Minute
 	sessionRetention := 24 * time.Hour
-	sessions := make([]*ActiveSessionInfo, 0, len(api.activeSessions))
+	sessions := make([]*ActiveSessionInfo, 0, len(snapshots))
 
-	for _, session := range api.activeSessions {
-		// Include running sessions that have been active within the last 10 minutes
-		if session.Status == "running" && now.Sub(session.LastActivity) < inactivityTimeout {
-			sessions = append(sessions, session)
+	for _, session := range snapshots {
+		if normalizeSessionLifecycleStatus(session.Status) == sessionLifecycleRunning {
+			hasBg := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(session.SessionID)
+			hasRunningWork := api.sessionHasRunningWork(session.SessionID, hasBg, api.canSteerSession(session.SessionID))
+			if now.Sub(session.LastActivity) < inactivityTimeout || hasRunningWork {
+				sessions = append(sessions, session)
+			}
 			continue
 		}
 
-		isTerminal := session.Status == "completed" || session.Status == "inactive" || session.Status == "stopped" || session.Status == "error"
+		isTerminal := isStoppedSessionStatus(session.Status)
 		if isTerminal && now.Sub(session.LastActivity) < sessionRetention {
 			sessions = append(sessions, session)
 		}
@@ -6534,73 +6562,82 @@ func (api *StreamingAPI) cleanupInactiveSessions() {
 	defer ticker.Stop()
 
 	for range ticker.C {
-		api.activeSessionsMux.Lock()
 		now := time.Now()
-		inactivityTimeout := 10 * time.Minute
-		sessionRetention := 24 * time.Hour
-		eventBufferRetention := sessionRetention
-		sessionsToMarkInactive := make([]string, 0)
-		sessionsToEvictEventBuffer := make([]string, 0)
-		sessionsToDelete := make([]string, 0)
-
-		for sessionID, session := range api.activeSessions {
-			// Mark as inactive if no activity for 10 minutes and status is still "running",
-			// but only when there are no pending completions or running background agents
-			// (race-inactive-pending-completion fix: avoid stranding completions by
-			// marking the session inactive before they can be drained).
-			if session.Status == "running" && now.Sub(session.LastActivity) >= inactivityTimeout {
-				hasPending := false
-				api.pendingMu.RLock()
-				if len(api.pendingCompletions[sessionID]) > 0 || api.completionRetryScheduled[sessionID] {
-					hasPending = true
-				}
-				api.pendingMu.RUnlock()
-				if !hasPending && api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID) {
-					hasPending = true
-				}
-				if !hasPending {
-					sessionsToMarkInactive = append(sessionsToMarkInactive, sessionID)
-				}
-			}
-			isTerminal := session.Status == "completed" || session.Status == "inactive" || session.Status == "stopped" || session.Status == "error"
-			age := now.Sub(session.LastActivity)
-			// Evict SSE event buffers after 30 min to free streaming memory.
-			if isTerminal && age >= eventBufferRetention {
-				sessionsToEvictEventBuffer = append(sessionsToEvictEventBuffer, sessionID)
-			}
-			// Fully delete session entry after 24 hours.
-			if isTerminal && age >= sessionRetention {
-				sessionsToDelete = append(sessionsToDelete, sessionID)
-			}
-		}
-
-		for _, sessionID := range sessionsToDelete {
-			if session, exists := api.activeSessions[sessionID]; exists {
-				delete(api.activeSessions, sessionID)
-				if api.terminalStore != nil {
-					api.terminalStore.RemoveSession(sessionID)
-				}
-				log.Printf("[ACTIVE_SESSION] Cleanup: Removed old %s session %s from memory (>24h)", session.Status, sessionID)
-			}
-		}
-
-		api.activeSessionsMux.Unlock()
-
-		for _, sessionID := range sessionsToEvictEventBuffer {
-			if api.eventStore != nil {
-				api.eventStore.RemoveSession(sessionID)
-				log.Printf("[ACTIVE_SESSION] Cleanup: Removed event buffer for session %s", sessionID)
-			}
-		}
-
-		// Mark sessions as inactive (outside lock to avoid deadlock)
-		for _, sessionID := range sessionsToMarkInactive {
-			log.Printf("[ACTIVE_SESSION] Marking session %s as inactive (no activity for 10+ minutes)", sessionID)
-			api.updateSessionStatus(sessionID, "inactive")
-		}
-
+		api.cleanupInactiveSessionsAt(now)
 		if closed := api.cleanupStaleCodingAgentTmuxSessions(now); closed > 0 {
 			log.Printf("[ACTIVE_SESSION] Cleanup: Closed %d stale coding-agent tmux session(s)", closed)
+		}
+	}
+}
+
+type inactiveSessionCandidate struct {
+	sessionID    string
+	status       string
+	lastActivity time.Time
+}
+
+func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
+	const (
+		inactivityTimeout    = 10 * time.Minute
+		sessionRetention     = 24 * time.Hour
+		eventBufferRetention = 24 * time.Hour
+	)
+
+	api.activeSessionsMux.RLock()
+	candidates := make([]inactiveSessionCandidate, 0, len(api.activeSessions))
+	for sessionID, session := range api.activeSessions {
+		candidates = append(candidates, inactiveSessionCandidate{
+			sessionID: sessionID, status: session.Status, lastActivity: session.LastActivity,
+		})
+	}
+	api.activeSessionsMux.RUnlock()
+
+	markInactive := make(map[string]time.Time)
+	for _, candidate := range candidates {
+		if normalizeSessionLifecycleStatus(candidate.status) != sessionLifecycleRunning || now.Sub(candidate.lastActivity) < inactivityTimeout {
+			continue
+		}
+		api.pendingMu.RLock()
+		hasPending := len(api.pendingCompletions[candidate.sessionID]) > 0 || api.completionRetryScheduled[candidate.sessionID]
+		api.pendingMu.RUnlock()
+		hasBg := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(candidate.sessionID)
+		if !hasPending && !api.sessionHasRunningWork(candidate.sessionID, hasBg, api.canSteerSession(candidate.sessionID)) {
+			markInactive[candidate.sessionID] = candidate.lastActivity
+		}
+	}
+
+	sessionsToEvictEventBuffer := make([]string, 0)
+	api.activeSessionsMux.Lock()
+	for sessionID, session := range api.activeSessions {
+		age := now.Sub(session.LastActivity)
+		if previousActivity, ok := markInactive[sessionID]; ok &&
+			session.LastActivity.Equal(previousActivity) &&
+			normalizeSessionLifecycleStatus(session.Status) == sessionLifecycleRunning {
+			session.Status = string(sessionLifecycleInactive)
+			session.LastActivity = now
+			age = 0
+			log.Printf("[ACTIVE_SESSION] Marked session %s inactive after verified idle timeout", sessionID)
+		}
+		if !isStoppedSessionStatus(session.Status) {
+			continue
+		}
+		if age >= eventBufferRetention {
+			sessionsToEvictEventBuffer = append(sessionsToEvictEventBuffer, sessionID)
+		}
+		if age >= sessionRetention {
+			delete(api.activeSessions, sessionID)
+			if api.terminalStore != nil {
+				api.terminalStore.RemoveSession(sessionID)
+			}
+			log.Printf("[ACTIVE_SESSION] Cleanup: Removed old %s session %s from memory (>24h)", session.Status, sessionID)
+		}
+	}
+	api.activeSessionsMux.Unlock()
+
+	for _, sessionID := range sessionsToEvictEventBuffer {
+		if api.eventStore != nil {
+			api.eventStore.RemoveSession(sessionID)
+			log.Printf("[ACTIVE_SESSION] Cleanup: Removed event buffer for session %s", sessionID)
 		}
 	}
 }
@@ -6967,6 +7004,22 @@ type internalResponseCapture struct {
 	header http.Header
 	status int
 	body   bytes.Buffer
+}
+
+// queryRequestForContinuation restores the product-level mode after handleQuery
+// has adapted a workflow-builder request to the shared multi-agent engine. The
+// stored request is later used by /live-input when a retained CLI object is
+// between turns. Persisting the adapted "multi-agent" value silently restarted
+// workflow follow-ups in _users/default/Chats instead of their workflow folder.
+func queryRequestForContinuation(req QueryRequest, isWorkflowPhase bool, workflowPhaseFolder string) QueryRequest {
+	if !isWorkflowPhase {
+		return req
+	}
+	req.AgentMode = "workflow_phase"
+	if strings.TrimSpace(req.SelectedFolder) == "" {
+		req.SelectedFolder = strings.TrimSpace(workflowPhaseFolder)
+	}
+	return req
 }
 
 func (c *internalResponseCapture) Header() http.Header {

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -6611,6 +6611,7 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 
 	sessionsToEvictEventBuffer := make([]string, 0)
 	sessionsToEvictRuntime := make([]string, 0)
+	sessionsMarkedInactive := make([]string, 0)
 	api.activeSessionsMux.Lock()
 	for sessionID, session := range api.activeSessions {
 		age := now.Sub(session.LastActivity)
@@ -6619,6 +6620,7 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 			normalizeSessionLifecycleStatus(session.Status) == sessionLifecycleRunning {
 			session.Status = string(sessionLifecycleInactive)
 			session.LastActivity = now
+			sessionsMarkedInactive = append(sessionsMarkedInactive, sessionID)
 			age = 0
 			log.Printf("[ACTIVE_SESSION] Marked session %s inactive after verified idle timeout", sessionID)
 		}
@@ -6638,6 +6640,10 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 		}
 	}
 	api.activeSessionsMux.Unlock()
+
+	for _, sessionID := range sessionsMarkedInactive {
+		api.observeRuntimeSnapshot(sessionID, nil)
+	}
 
 	for _, sessionID := range sessionsToEvictRuntime {
 		if api.runtimeCoordinator != nil {

--- a/agent_go/cmd/server/session_status.go
+++ b/agent_go/cmd/server/session_status.go
@@ -101,7 +101,6 @@ func (api *StreamingAPI) sessionDisplayStatus(sessionID string) SessionDisplaySt
 		CanSteer:                   canSteer,
 		HasRunningBackgroundAgents: hasBg,
 	}
-	api.observeRuntimeSnapshot(sessionID, &result)
 	return result
 }
 

--- a/agent_go/cmd/server/session_status.go
+++ b/agent_go/cmd/server/session_status.go
@@ -1,5 +1,7 @@
 package server
 
+import "strings"
+
 // Consolidated session "live status" logic — the single source of truth for
 // whether a session is busy / idle / stopped (and steerable). Previously this
 // determination was reimplemented in several places (the execution-tree summary,
@@ -12,6 +14,38 @@ type SessionDisplayStatus struct {
 	Status                     string // sessionExecutionDisplay{Busy,Idle,Stopped}
 	CanSteer                   bool
 	HasRunningBackgroundAgents bool
+}
+
+type sessionLifecycleStatus string
+
+const legacyCanceledBritishStatus = "cancel" + "led"
+
+const (
+	sessionLifecycleRunning   sessionLifecycleStatus = "running"
+	sessionLifecycleCompleted sessionLifecycleStatus = "completed"
+	sessionLifecycleFailed    sessionLifecycleStatus = "failed"
+	sessionLifecycleStopped   sessionLifecycleStatus = "stopped"
+	sessionLifecycleInactive  sessionLifecycleStatus = "inactive"
+	sessionLifecycleUnknown   sessionLifecycleStatus = "unknown"
+)
+
+// normalizeSessionLifecycleStatus gives internal state decisions one stable
+// vocabulary while preserving the legacy wire value in existing API fields.
+func normalizeSessionLifecycleStatus(status string) sessionLifecycleStatus {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "running", "active", "busy", "paused", "waiting":
+		return sessionLifecycleRunning
+	case "completed", "complete", "success", "succeeded", "done":
+		return sessionLifecycleCompleted
+	case "error", "failed", "failure":
+		return sessionLifecycleFailed
+	case "stopped", "canceled", legacyCanceledBritishStatus, "dismissed":
+		return sessionLifecycleStopped
+	case "inactive", "idle":
+		return sessionLifecycleInactive
+	default:
+		return sessionLifecycleUnknown
+	}
 }
 
 // deriveSessionDisplayStatus maps raw running/terminal signals to the
@@ -30,8 +64,8 @@ func deriveSessionDisplayStatus(hasRunningWork, isStopped bool) string {
 // isStoppedSessionStatus reports whether a session-level status string means the
 // session has finished/halted (vs. actively idle and able to continue).
 func isStoppedSessionStatus(status string) bool {
-	switch status {
-	case "completed", "stopped", "inactive", "dismissed":
+	switch normalizeSessionLifecycleStatus(status) {
+	case sessionLifecycleCompleted, sessionLifecycleFailed, sessionLifecycleStopped, sessionLifecycleInactive:
 		return true
 	default:
 		return false
@@ -45,6 +79,7 @@ func isStoppedSessionStatus(status string) bool {
 // tree (scheduler, polling).
 func (api *StreamingAPI) sessionHasRunningWork(sessionID string, hasRunningBackgroundAgents, canSteer bool) bool {
 	return api.isSessionBusy(sessionID) ||
+		api.hasActiveTurnCancel(sessionID) ||
 		hasRunningBackgroundAgents ||
 		api.hasRunningTrackedExecutionForSession(sessionID) ||
 		canSteer
@@ -61,11 +96,13 @@ func (api *StreamingAPI) sessionDisplayStatus(sessionID string) SessionDisplaySt
 	}
 	hasBg := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID)
 	canSteer := api.canSteerSession(sessionID)
-	return SessionDisplayStatus{
+	result := SessionDisplayStatus{
 		Status:                     deriveSessionDisplayStatus(api.sessionHasRunningWork(sessionID, hasBg, canSteer), isStoppedSessionStatus(sessionStatus)),
 		CanSteer:                   canSteer,
 		HasRunningBackgroundAgents: hasBg,
 	}
+	api.observeRuntimeSnapshot(sessionID, &result)
+	return result
 }
 
 // sessionIsBusy is a convenience wrapper: true when the session's consolidated

--- a/agent_go/cmd/server/sse.go
+++ b/agent_go/cmd/server/sse.go
@@ -17,6 +17,7 @@ import (
 type sseEventMessage struct {
 	Events                     []events.Event `json:"events"`
 	SessionStatus              string         `json:"session_status,omitempty"`
+	DisplayStatus              string         `json:"display_status,omitempty"`
 	LastProcessedIndex         int            `json:"last_processed_index"`
 	HasRunningBackgroundAgents bool           `json:"has_running_background_agents,omitempty"`
 	IsSyntheticTurn            bool           `json:"is_synthetic_turn,omitempty"` // True when running auto-notification turn (frontend should not block input)
@@ -26,6 +27,7 @@ type sseEventMessage struct {
 // sseStatusMessage is sent on the "status" SSE event.
 type sseStatusMessage struct {
 	SessionStatus              string `json:"session_status,omitempty"`
+	DisplayStatus              string `json:"display_status,omitempty"`
 	HasRunningBackgroundAgents bool   `json:"has_running_background_agents,omitempty"`
 	IsSyntheticTurn            bool   `json:"is_synthetic_turn,omitempty"`
 	CanSteer                   bool   `json:"can_steer,omitempty"`
@@ -106,13 +108,15 @@ func (api *StreamingAPI) handleSSEStream(w http.ResponseWriter, r *http.Request)
 			IncludeStreaming: true,
 		})
 		if len(result.Events) > 0 {
+			runtimeStatus := api.sessionDisplayStatus(sessionID)
 			msg := sseEventMessage{
 				Events:                     result.Events,
 				SessionStatus:              sessionStatus,
+				DisplayStatus:              runtimeStatus.Status,
 				LastProcessedIndex:         result.LastProcessedIndex,
-				HasRunningBackgroundAgents: api.bgAgentRegistry.HasRunningAgents(sessionID),
+				HasRunningBackgroundAgents: runtimeStatus.HasRunningBackgroundAgents,
 				IsSyntheticTurn:            api.isSyntheticTurn(sessionID),
-				CanSteer:                   api.canSteerSession(sessionID),
+				CanSteer:                   runtimeStatus.CanSteer,
 			}
 			if err := writeSSEEvent(w, "event", result.LastProcessedIndex, msg); err != nil {
 				return
@@ -162,13 +166,15 @@ func (api *StreamingAPI) handleSSEStream(w http.ResponseWriter, r *http.Request)
 				currentStatus = sessionStatus
 			}
 
+			runtimeStatus := api.sessionDisplayStatus(sessionID)
 			msg := sseEventMessage{
 				Events:                     []events.Event{event},
 				SessionStatus:              currentStatus,
+				DisplayStatus:              runtimeStatus.Status,
 				LastProcessedIndex:         lastIndex,
-				HasRunningBackgroundAgents: api.bgAgentRegistry.HasRunningAgents(sessionID),
+				HasRunningBackgroundAgents: runtimeStatus.HasRunningBackgroundAgents,
 				IsSyntheticTurn:            api.isSyntheticTurn(sessionID),
-				CanSteer:                   api.canSteerSession(sessionID),
+				CanSteer:                   runtimeStatus.CanSteer,
 			}
 			if err := writeSSEEvent(w, "event", lastIndex, msg); err != nil {
 				return
@@ -182,11 +188,13 @@ func (api *StreamingAPI) handleSSEStream(w http.ResponseWriter, r *http.Request)
 			} else {
 				sessionStatus = currentStatus // update cached status
 			}
+			runtimeStatus := api.sessionDisplayStatus(sessionID)
 			msg := sseStatusMessage{
 				SessionStatus:              currentStatus,
-				HasRunningBackgroundAgents: api.bgAgentRegistry.HasRunningAgents(sessionID),
+				DisplayStatus:              runtimeStatus.Status,
+				HasRunningBackgroundAgents: runtimeStatus.HasRunningBackgroundAgents,
 				IsSyntheticTurn:            api.isSyntheticTurn(sessionID),
-				CanSteer:                   api.canSteerSession(sessionID),
+				CanSteer:                   runtimeStatus.CanSteer,
 			}
 			if err := writeSSEEvent(w, "status", -1, msg); err != nil {
 				return

--- a/agent_go/cmd/server/sse.go
+++ b/agent_go/cmd/server/sse.go
@@ -109,6 +109,7 @@ func (api *StreamingAPI) handleSSEStream(w http.ResponseWriter, r *http.Request)
 		})
 		if len(result.Events) > 0 {
 			runtimeStatus := api.sessionDisplayStatus(sessionID)
+			api.observeRuntimeSnapshot(sessionID, &runtimeStatus)
 			msg := sseEventMessage{
 				Events:                     result.Events,
 				SessionStatus:              sessionStatus,
@@ -189,6 +190,10 @@ func (api *StreamingAPI) handleSSEStream(w http.ResponseWriter, r *http.Request)
 				sessionStatus = currentStatus // update cached status
 			}
 			runtimeStatus := api.sessionDisplayStatus(sessionID)
+			// Runtime observation is intentionally tied to the status cadence,
+			// not the event case above. Token streams can emit dozens of events
+			// per second, while the observer clones and sorts several stores.
+			api.observeRuntimeSnapshot(sessionID, &runtimeStatus)
 			msg := sseStatusMessage{
 				SessionStatus:              currentStatus,
 				DisplayStatus:              runtimeStatus.Status,

--- a/agent_go/cmd/server/workflow_execution_tracker.go
+++ b/agent_go/cmd/server/workflow_execution_tracker.go
@@ -203,6 +203,7 @@ func (api *StreamingAPI) trackExecutionStart(exec *TrackedWorkflowExecution) {
 	api.trackedWorkflowExecutions[exec.ExecutionID] = exec
 	api.pruneTrackedExecutionsLocked(time.Now().UTC())
 	api.trackedWorkflowExecutionsMux.Unlock()
+	api.observeRuntimeSnapshot(exec.SessionID, nil)
 }
 
 func (api *StreamingAPI) trackWorkflowRunStart(exec *ActiveWorkflowExecution) {
@@ -260,12 +261,13 @@ func (api *StreamingAPI) completeTrackedExecution(executionID, status, errorMess
 	}
 
 	api.trackedWorkflowExecutionsMux.Lock()
-	defer api.trackedWorkflowExecutionsMux.Unlock()
 
 	exec := api.trackedWorkflowExecutions[executionID]
 	if exec == nil || exec.Status != trackedExecutionStatusRunning {
+		api.trackedWorkflowExecutionsMux.Unlock()
 		return
 	}
+	sessionID := exec.SessionID
 
 	now := time.Now().UTC()
 	exec.Status = status
@@ -281,6 +283,8 @@ func (api *StreamingAPI) completeTrackedExecution(executionID, status, errorMess
 		exec.Kind = inferTrackedExecutionKind(exec.Source, exec.PhaseID, exec.Name, meta)
 	}
 	api.pruneTrackedExecutionsLocked(now)
+	api.trackedWorkflowExecutionsMux.Unlock()
+	api.observeRuntimeSnapshot(sessionID, nil)
 }
 
 func (api *StreamingAPI) cancelTrackedExecutionsForSession(sessionID string) {
@@ -289,7 +293,6 @@ func (api *StreamingAPI) cancelTrackedExecutionsForSession(sessionID string) {
 	}
 
 	api.trackedWorkflowExecutionsMux.Lock()
-	defer api.trackedWorkflowExecutionsMux.Unlock()
 
 	now := time.Now().UTC()
 	for _, exec := range api.trackedWorkflowExecutions {
@@ -300,6 +303,8 @@ func (api *StreamingAPI) cancelTrackedExecutionsForSession(sessionID string) {
 		exec.CompletedAt = &now
 	}
 	api.pruneTrackedExecutionsLocked(now)
+	api.trackedWorkflowExecutionsMux.Unlock()
+	api.observeRuntimeSnapshot(sessionID, nil)
 }
 
 func (api *StreamingAPI) finalizeTrackedExecutionIfRunning(executionID, status, errorMessage string) {
@@ -308,12 +313,13 @@ func (api *StreamingAPI) finalizeTrackedExecutionIfRunning(executionID, status, 
 	}
 
 	api.trackedWorkflowExecutionsMux.Lock()
-	defer api.trackedWorkflowExecutionsMux.Unlock()
 
 	exec := api.trackedWorkflowExecutions[executionID]
 	if exec == nil || exec.Status != trackedExecutionStatusRunning {
+		api.trackedWorkflowExecutionsMux.Unlock()
 		return
 	}
+	sessionID := exec.SessionID
 
 	now := time.Now().UTC()
 	exec.Status = status
@@ -322,6 +328,8 @@ func (api *StreamingAPI) finalizeTrackedExecutionIfRunning(executionID, status, 
 		exec.LastError = errorMessage
 	}
 	api.pruneTrackedExecutionsLocked(now)
+	api.trackedWorkflowExecutionsMux.Unlock()
+	api.observeRuntimeSnapshot(sessionID, nil)
 }
 
 // runningWorkflowExecutionBySessionLocked returns the latest running top-level workflow execution.

--- a/agent_go/cmd/server/workshop_llm_config_test.go
+++ b/agent_go/cmd/server/workshop_llm_config_test.go
@@ -77,13 +77,13 @@ func TestWorkshopResolveLLMConfigExpandsCodingAgentMode(t *testing.T) {
 	if !ok {
 		t.Fatal("expected Claude Code coding-agent defaults")
 	}
-	if defaults.Builder.ModelID != "claude-sonnet-5" ||
+	if defaults.Builder.ModelID != "claude-opus-4-8" ||
 		defaults.High.ModelID == "claude-fable-5" ||
 		defaults.Medium.ModelID == "claude-fable-5" ||
 		defaults.Low.ModelID == "claude-fable-5" ||
 		defaults.Maintenance.ModelID != "claude-opus-4-8" ||
 		defaults.Pulse.ModelID != "claude-sonnet-5" {
-		t.Fatalf("sonnet 5 should be builder/phase/pulse default and opus 4.8 should be maintenance/advisor default, got defaults: %+v", defaults)
+		t.Fatalf("opus 4.8 should be builder/maintenance default and sonnet 5 should remain the pulse default, got defaults: %+v", defaults)
 	}
 
 	builder, tiered := workshopResolveLLMConfig(&workflowtypes.PresetLLMConfig{

--- a/agent_go/go.mod
+++ b/agent_go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/manishiitg/mcp-agent-builder-go/workspace v0.0.0
 	github.com/manishiitg/mcpagent v1.7.10
-	github.com/manishiitg/multi-llm-provider-go v0.5.21-0.20260710161557-9b9236843d0a
+	github.com/manishiitg/multi-llm-provider-go v0.6.2-0.20260713045530-9e88f0324804
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/openai/openai-go/v3 v3.36.0
 	github.com/pkoukk/tiktoken-go v0.1.8

--- a/agent_go/go.mod
+++ b/agent_go/go.mod
@@ -16,12 +16,10 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/manishiitg/mcp-agent-builder-go/workspace v0.0.0
 	github.com/manishiitg/mcpagent v1.7.10
-	github.com/manishiitg/multi-llm-provider-go v0.6.2-0.20260713045530-9e88f0324804
+	github.com/manishiitg/multi-llm-provider-go v0.7.2
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/openai/openai-go/v3 v3.36.0
-	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/slack-go/slack v0.17.3
 	github.com/spf13/cobra v1.10.1
@@ -100,11 +98,13 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.8 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/zerolog v1.35.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/agent_go/pkg/workflowtypes/types_test.go
+++ b/agent_go/pkg/workflowtypes/types_test.go
@@ -87,6 +87,31 @@ func TestNormalizePresetLLMConfigMigratesLegacyCodingAgentToProviderProfile(t *t
 	}
 }
 
+func TestResolveProviderProfileConfigUsesBuilderDefaults(t *testing.T) {
+	tests := []struct {
+		provider string
+		model    string
+		effort   string
+	}{
+		{provider: "claude-code", model: "claude-opus-4-8", effort: "high"},
+		{provider: "codex-cli", model: "gpt-5.6-sol", effort: "high"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			builder, _, ok := ResolveProviderProfileConfig(providerProfile(tt.provider))
+			if !ok || builder == nil {
+				t.Fatalf("ResolveProviderProfileConfig(%q) = %+v, ok=%v", tt.provider, builder, ok)
+			}
+			if builder.Provider != tt.provider || builder.ModelID != tt.model {
+				t.Fatalf("builder = %+v, want %s/%s", builder, tt.provider, tt.model)
+			}
+			if got := builder.Options["reasoning_effort"]; got != tt.effort {
+				t.Fatalf("reasoning_effort = %#v, want %q", got, tt.effort)
+			}
+		})
+	}
+}
+
 func TestResolveProviderProfileMaintenanceConfigUsesProviderDefault(t *testing.T) {
 	got, ok := ResolveProviderProfileMaintenanceConfig(providerProfile("claude-code"))
 	if !ok || got.Provider != "claude-code" || got.ModelID != "claude-opus-4-8" {

--- a/frontend/src/components/SchedulePresetPopup.tsx
+++ b/frontend/src/components/SchedulePresetPopup.tsx
@@ -594,7 +594,13 @@ const SchedulePresetPopup: React.FC<SchedulePresetPopupProps> = ({
                         <div>Next run: {new Date(existingJob.next_run_at).toLocaleString()}</div>
                       )}
                       {existingJob.last_status && (
-                        <div className={existingJob.last_status === 'error' ? 'text-red-500' : 'text-green-600 dark:text-green-400'}>
+                        <div className={
+                          existingJob.last_status === 'error'
+                            ? 'text-red-500'
+                            : existingJob.last_status === 'stopped'
+                              ? 'text-amber-600 dark:text-amber-400'
+                              : 'text-green-600 dark:text-green-400'
+                        }>
                           Last status: {existingJob.last_status}
                           {existingJob.last_error && ` — ${existingJob.last_error}`}
                         </div>

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -14,6 +14,7 @@ import { terminalReconnectDelayMs, terminalSnapshotCanReconnect } from '../utils
 import { useTheme } from '../hooks/useTheme'
 import type { Theme } from '../contexts/ThemeContext'
 import { normalizeAnsiForEmbeddedXterm } from '../utils/ansiSanitize'
+import { preserveTerminalContinuity } from '../utils/terminalContinuity'
 import { MarkdownRenderer } from './ui/MarkdownRenderer'
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 
@@ -3376,14 +3377,14 @@ const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, 
             terminalMatchesWorkflow(terminal, terminalWorkflowPathFilter)
           )
         )
-        if (!viewAll && currentSessionId && nextTerminals.length === 0 && current.length > 0 && currentMatchesScope) {
-          emptyResponseCountRef.current += 1
-          if (emptyResponseCountRef.current <= EMPTY_TERMINAL_RESPONSE_GRACE_POLLS) {
-            return current
-          }
-        }
-        emptyResponseCountRef.current = nextTerminals.length === 0 ? emptyResponseCountRef.current : 0
-        return nextTerminals
+        const continuity = preserveTerminalContinuity(current, nextTerminals, {
+          sameScope: !viewAll && !!currentSessionId && currentMatchesScope,
+          hasPendingActivity: hasPendingTerminalActivity,
+          emptyPollCount: emptyResponseCountRef.current,
+          gracePolls: EMPTY_TERMINAL_RESPONSE_GRACE_POLLS,
+        })
+        emptyResponseCountRef.current = continuity.emptyPollCount
+        return continuity.terminals
       })
       setError(null)
     } catch (err) {
@@ -3395,7 +3396,7 @@ const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, 
         fetchInFlightScopeRef.current = null
       }
     }
-  }, [currentSessionId, dismissedTerminalIDs, terminalWorkflowPathFilter, viewAll])
+  }, [currentSessionId, dismissedTerminalIDs, hasPendingTerminalActivity, terminalWorkflowPathFilter, viewAll])
 
   const dismissTerminal = useCallback(async (terminal: TerminalSnapshot) => {
     if (!canDismissTerminal(terminal)) return

--- a/frontend/src/services/api-types.ts
+++ b/frontend/src/services/api-types.ts
@@ -555,6 +555,7 @@ export interface GetEventsResponse {
   has_more: boolean
   session_id: string
   session_status: string // Session status: "running", "completed", "error", "stopped", "inactive" (required - source of truth)
+  display_status?: 'busy' | 'idle' | 'stopped'
   last_processed_index?: number // Last index processed in unfiltered array (for correct sinceIndex tracking when filtering)
   has_running_background_agents?: boolean // Whether background agents are still running for this session
   is_synthetic_turn?: boolean // True when running auto-notification turn (input remains locked as normal)
@@ -687,6 +688,7 @@ export interface ReconnectSessionResponse {
 export interface SessionStatusResponse {
   session_id: string
   status: string // "active", "completed", "not_found"
+  display_status?: 'busy' | 'idle' | 'stopped'
   agent_mode?: string
   created_at?: string
   last_activity?: string
@@ -1080,6 +1082,7 @@ export interface WorkflowBuilderSessionResponse {
 export interface SSEEventMessage {
   events: PollingEvent[]
   session_status?: string
+  display_status?: 'busy' | 'idle' | 'stopped'
   last_processed_index: number
   has_running_background_agents?: boolean
   is_synthetic_turn?: boolean
@@ -1088,6 +1091,7 @@ export interface SSEEventMessage {
 
 export interface SSEStatusMessage {
   session_status?: string
+  display_status?: 'busy' | 'idle' | 'stopped'
   has_running_background_agents?: boolean
   is_synthetic_turn?: boolean
   can_steer?: boolean
@@ -2263,7 +2267,7 @@ export interface ScheduledJob {
   last_run_at?: string
   next_run_at?: string
   last_session_id?: string
-  last_status?: 'success' | 'error' | 'running'
+  last_status?: 'success' | 'error' | 'running' | 'stopped'
   last_error?: string
   last_duration_ms?: number
   run_count: number

--- a/frontend/src/utils/terminalContinuity.test.ts
+++ b/frontend/src/utils/terminalContinuity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalSnapshot } from '../services/api-types'
+import { preserveTerminalContinuity } from './terminalContinuity'
+
+const liveMain: TerminalSnapshot = {
+  terminal_id: 'session-1:main:session-1',
+  session_id: 'session-1',
+  owner_id: 'main:session-1',
+  execution_kind: 'main_agent',
+  tmux_session: 'tmux-main',
+  state: 'running',
+  active: true,
+} as TerminalSnapshot
+
+describe('preserveTerminalContinuity', () => {
+  it('keeps the live pane while an active next-turn handoff returns no terminal', () => {
+    const result = preserveTerminalContinuity([liveMain], [], {
+      sameScope: true,
+      hasPendingActivity: true,
+      emptyPollCount: 50,
+      gracePolls: 10,
+    })
+
+    expect(result.terminals).toEqual([liveMain])
+  })
+
+  it('keeps the live pane when the handoff exposes only a hidden archived turn', () => {
+    const archived = {
+      ...liveMain,
+      terminal_id: `${liveMain.terminal_id}:turn-1`,
+      active: false,
+      state: 'completed',
+    } as TerminalSnapshot
+    const result = preserveTerminalContinuity([liveMain], [archived], {
+      sameScope: true,
+      hasPendingActivity: true,
+      emptyPollCount: 0,
+      gracePolls: 10,
+    })
+
+    expect(result.terminals.map(terminal => terminal.terminal_id)).toEqual([
+      archived.terminal_id,
+      liveMain.terminal_id,
+    ])
+  })
+
+  it('switches to the new canonical pane as soon as it is registered', () => {
+    const next = { ...liveMain, tmux_session: 'tmux-next', updated_at: new Date().toISOString() }
+    const result = preserveTerminalContinuity([liveMain], [next], {
+      sameScope: true,
+      hasPendingActivity: true,
+      emptyPollCount: 4,
+      gracePolls: 10,
+    })
+
+    expect(result.terminals).toEqual([next])
+    expect(result.emptyPollCount).toBe(0)
+  })
+
+  it('eventually drops a gone pane when there is no pending turn', () => {
+    const result = preserveTerminalContinuity([liveMain], [], {
+      sameScope: true,
+      hasPendingActivity: false,
+      emptyPollCount: 10,
+      gracePolls: 10,
+    })
+
+    expect(result.terminals).toEqual([])
+  })
+})

--- a/frontend/src/utils/terminalContinuity.ts
+++ b/frontend/src/utils/terminalContinuity.ts
@@ -1,0 +1,64 @@
+import type { TerminalSnapshot } from '../services/api-types'
+
+export interface TerminalContinuityOptions {
+  sameScope: boolean
+  hasPendingActivity: boolean
+  emptyPollCount: number
+  gracePolls: number
+}
+
+export interface TerminalContinuityResult {
+  terminals: TerminalSnapshot[]
+  emptyPollCount: number
+}
+
+function isMainAgentTerminal(terminal: TerminalSnapshot): boolean {
+  const kind = (terminal.execution_kind || '').toLowerCase()
+  const ownerID = (terminal.owner_id || '').toLowerCase()
+  const terminalID = (terminal.terminal_id || '').toLowerCase()
+  return kind === 'main_agent' || kind === 'main' || kind === 'chat' ||
+    ownerID.startsWith('main:') || terminalID.includes(':main:')
+}
+
+function isRenderableTerminal(terminal: TerminalSnapshot): boolean {
+  return !(terminal.terminal_id.includes(':turn-') && isMainAgentTerminal(terminal))
+}
+
+function dedupeByTerminalID(terminals: TerminalSnapshot[]): TerminalSnapshot[] {
+  const byID = new Map<string, TerminalSnapshot>()
+  for (const terminal of terminals) byID.set(terminal.terminal_id, terminal)
+  return Array.from(byID.values())
+}
+
+/**
+ * Keep the last real pane mounted while a coding CLI changes foreground turns.
+ * During that handoff the terminal registry can briefly return no canonical pane
+ * (or only a hidden archived :turn-N snapshot). Replacing the list at that point
+ * closes the live xterm and paints a false "Starting terminal" screen even though
+ * the retained tmux session is still usable.
+ */
+export function preserveTerminalContinuity(
+  current: TerminalSnapshot[],
+  next: TerminalSnapshot[],
+  options: TerminalContinuityOptions,
+): TerminalContinuityResult {
+  const currentRenderable = current.filter(isRenderableTerminal)
+  const nextRenderable = next.filter(isRenderableTerminal)
+
+  if (nextRenderable.length > 0) {
+    return { terminals: next, emptyPollCount: 0 }
+  }
+
+  const emptyPollCount = options.emptyPollCount + 1
+  const shouldPreserve = options.sameScope && currentRenderable.length > 0 && (
+    options.hasPendingActivity || emptyPollCount <= options.gracePolls
+  )
+  if (!shouldPreserve) {
+    return { terminals: next, emptyPollCount }
+  }
+
+  return {
+    terminals: dedupeByTerminalID([...next, ...currentRenderable]),
+    emptyPollCount,
+  }
+}


### PR DESCRIPTION
## Summary

- normalize backend runtime lifecycle values and expose one consolidated `display_status`
- make active-session and scheduler runtime reads copy-safe
- prevent late schedule completion from overwriting an explicit Stop by using run generations
- reject generation-zero callers when another schedule run is active
- keep quiet but live foreground, child, background-agent, and tmux work from being deactivated by cleanup
- add an immutable, revisioned `RuntimeCoordinator` in observer mode
- observe runtime state on lifecycle transitions and the 2-second SSE status cadence, not every streamed event
- evict coordinator snapshots with retained sessions and guarantee foreground cancel-map cleanup
- preserve the real terminal pane during retained-CLI turn handoffs
- restore workflow context for retained live-input continuations
- pin provider defaults from merged [llm-provider-mcp#25](https://github.com/manishiitg/llm-provider-mcp/pull/25)

## Why

Runtime state was reconstructed independently by sessions, scheduler runs, tracked executions, background agents, tmux terminals, polling, SSE, and frontend terminal state. Those stores could disagree, causing stopped runs to become successful later, live work to appear inactive, and working terminals to be replaced by a false "Starting terminal" screen.

This PR completes the correctness work in Phase 0 and introduces the Phase 1 observer described in issue #137. Existing stores remain authoritative; the coordinator only records immutable snapshots and logs deduplicated mismatches for review.

**Related to #137**

## Root cause

- lifecycle vocabulary differed across stores
- mutable runtime pointers escaped their locks
- schedule completion had no generation guard
- inactivity cleanup did not consider every live-work signal
- frontend terminal polling could temporarily receive no canonical pane during a valid retained-session handoff
- the first observer implementation collected and sorted all runtime stores for every SSE token event
- coordinator records and foreground cancel handles lacked guaranteed lifecycle cleanup

## Review fixes

- merged provider PR #25 first and pinned `v0.6.2-0.20260713045530-9e88f0324804`
- moved expensive observation off the SSE event/token path
- evicted coordinator records during 24-hour session cleanup
- added defer-backed `agentCancelFuncs` cleanup for all main-turn exits
- made generation-zero scheduled runs fail closed when an active run exists

## Validation

- `go test ./...` in `agent_go`
- focused `go test -race` runtime-state suite
- `golangci-lint run ./cmd/server/...`
- frontend unit tests: **13 files, 73 tests passed**
- frontend production build
- agent, workspace, and Electron builds from the repository commit hook
- gitleaks and sensitive-file checks
- `git diff --check`

## Scope note

This does not make `RuntimeCoordinator` authoritative yet. API and frontend migration remain later phases of #137.