### PR TITLE
Reduce frontend hot-state persistence churn

### DIFF
--- a/frontend/src/stores/useChatStore.hydration.test.ts
+++ b/frontend/src/stores/useChatStore.hydration.test.ts
@@ -25,6 +25,8 @@ describe('useChatStore hydration bootstrap', () => {
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -37,6 +39,85 @@ describe('useChatStore hydration bootstrap', () => {
     expect(chatStore.getChatStoreHydrationSnapshot()).toEqual({
       status: 'hydrated',
       error: null,
+    })
+  })
+
+  it('does not persist streaming chunks and coalesces durable changes', async () => {
+    vi.useFakeTimers()
+    const storage = createMemoryStorage()
+    const setItem = vi.spyOn(storage, 'setItem')
+    vi.stubGlobal('localStorage', storage)
+    const chatStore = await import('./useChatStore')
+    await chatStore.waitForChatStoreHydration()
+    chatStore.useChatStore.setState({ eventViewModePreference: 'terminal' })
+    vi.advanceTimersByTime(250)
+    setItem.mockClear()
+
+    for (let index = 1; index <= 20; index += 1) {
+      chatStore.useChatStore.getState().appendStreamingChunk('session-1', index, `chunk-${index}`)
+    }
+    vi.advanceTimersByTime(250)
+    expect(setItem).not.toHaveBeenCalled()
+
+    chatStore.useChatStore.setState({ eventViewModePreference: 'tree' })
+    chatStore.useChatStore.setState({ eventViewModePreference: 'terminal' })
+    chatStore.useChatStore.setState({ eventViewModePreference: 'tree' })
+    vi.advanceTimersByTime(250)
+
+    expect(setItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the existing persisted chat-store envelope', async () => {
+    const storage = createMemoryStorage()
+    const createdAt = Date.now()
+    storage.setItem('chat-store', JSON.stringify({
+      state: {
+        chatTabs: {
+          'legacy-tab': {
+            tabId: 'legacy-tab',
+            name: 'Existing workflow chat',
+            sessionId: 'legacy-session',
+            isStreaming: false,
+            isCompleted: false,
+            hasRunningBgAgents: false,
+            isSyntheticTurn: false,
+            canSteer: false,
+            hideToolCalls: true,
+            viewMode: 'terminal',
+            config: {
+              inputText: '',
+              useCodeExecutionMode: true,
+              selectedServers: [],
+              selectedSkills: [],
+              selectedSecrets: [],
+              llmConfig: { provider: 'codex-cli', model_id: 'gpt-5.6-sol' },
+              fileContext: [],
+              browserMode: 'none',
+              workflowContext: [],
+              queuedMessages: [],
+            },
+            createdAt,
+            lastAccessedAt: createdAt,
+            lastViewedEventCount: 0,
+            lastViewedEventCounts: { micro: 0 },
+            metadata: { mode: 'workflow', presetQueryId: 'existing-workflow' },
+          },
+        },
+        activeTabId: 'legacy-tab',
+        eventViewModePreference: 'terminal',
+      },
+      version: 0,
+    }))
+    vi.stubGlobal('localStorage', storage)
+
+    const chatStore = await import('./useChatStore')
+    await chatStore.waitForChatStoreHydration()
+
+    expect(chatStore.useChatStore.getState().activeTabId).toBe('legacy-tab')
+    expect(chatStore.useChatStore.getState().chatTabs['legacy-tab']).toMatchObject({
+      name: 'Existing workflow chat',
+      sessionId: 'legacy-session',
+      metadata: { mode: 'workflow', presetQueryId: 'existing-workflow' },
     })
   })
 })

--- a/frontend/src/stores/useChatStore.ts
+++ b/frontend/src/stores/useChatStore.ts
@@ -2894,8 +2894,12 @@ export const useChatStore = create<ChatState>()(
 
 if (chatPersistStorage) {
   const flushDurableChatState = () => chatPersistStorage.flush()
+  const flushDurableChatStateWhenHidden = () => {
+    if (globalThis.document?.visibilityState === 'hidden') flushDurableChatState()
+  }
   globalThis.addEventListener?.('pagehide', flushDurableChatState)
   globalThis.addEventListener?.('beforeunload', flushDurableChatState)
+  globalThis.document?.addEventListener('visibilitychange', flushDurableChatStateWhenHidden)
 } else {
   queueMicrotask(() => finalizeChatStoreHydration())
 }

--- a/frontend/src/stores/useChatStore.ts
+++ b/frontend/src/stores/useChatStore.ts
@@ -16,6 +16,7 @@ import { compareEventsChronologically, compareEventsReverseChronologically } fro
 import { getWorkspaceScopedStorageKey } from './useWorkspaceConnectionStore'
 import { looksLikeTerminalScreenText, splitStreamingStatusAndText } from '../utils/streamingStatus'
 import { createHydrationGate, HydrationBackstopError, type HydrationGateSnapshot } from '../utils/hydrationGate'
+import { createBufferedPersistStorage } from '../utils/bufferedPersistStorage'
 
 // Active sessions cache TTL (30 seconds - shorter than polling interval to allow force refresh)
 const ACTIVE_SESSIONS_CACHE_TTL = 30000
@@ -661,6 +662,84 @@ interface ChatState extends StoreActions {
   resetChatState: () => void
   isAtBottom: (element: HTMLDivElement) => boolean
 }
+
+type DurableChatState = Pick<ChatState, 'chatTabs' | 'activeTabId' | 'eventViewModePreference'>
+
+let previousDurableChatTabs: ChatState['chatTabs'] | null = null
+let previousDurableActiveTabId: string | null | undefined
+let previousDurableViewMode: EventViewMode | undefined
+let previousDurableChatState: DurableChatState | null = null
+
+/**
+ * Keeps volatile stream/event updates out of persistence. Zustand invokes
+ * partialize for every set, so unchanged durable input must return the exact
+ * same object for the buffered adapter to skip serialization entirely.
+ */
+const selectDurableChatState = (state: ChatState): DurableChatState => {
+  if (
+    previousDurableChatState &&
+    state.chatTabs === previousDurableChatTabs &&
+    state.activeTabId === previousDurableActiveTabId &&
+    state.eventViewModePreference === previousDurableViewMode
+  ) {
+    return previousDurableChatState
+  }
+
+  const chatTabs = Object.fromEntries(
+    Object.entries(state.chatTabs)
+      .filter(([, tab]) => {
+        const isRelevantMode = tab.metadata?.mode === 'workflow' || tab.metadata?.mode === 'multi-agent'
+        if (!isRelevantMode) return false
+        return Date.now() - (tab.createdAt || 0) < 24 * 60 * 60 * 1000
+      })
+      .map(([tabId, tab]) => [
+        tabId,
+        {
+          tabId: tab.tabId,
+          name: tab.name,
+          sessionId: tab.sessionId,
+          isStreaming: false,
+          isCompleted: false,
+          hasRunningBgAgents: false,
+          isSyntheticTurn: false,
+          canSteer: false,
+          hideToolCalls: tab.hideToolCalls ?? true,
+          viewMode: normalizeEventViewMode(tab.viewMode),
+          config: persistDurableTabConfig(tab.config),
+          createdAt: tab.createdAt,
+          lastAccessedAt: tab.lastAccessedAt || tab.createdAt,
+          lastViewedEventCount: 0,
+          lastViewedEventCounts: { micro: 0 },
+          metadata: tab.metadata,
+        },
+      ]),
+  )
+  const activeTab = state.activeTabId ? state.chatTabs[state.activeTabId] : null
+  const activeTabId = activeTab?.metadata?.mode === 'workflow' || activeTab?.metadata?.mode === 'multi-agent'
+    ? state.activeTabId
+    : null
+
+  previousDurableChatTabs = state.chatTabs
+  previousDurableActiveTabId = state.activeTabId
+  previousDurableViewMode = state.eventViewModePreference
+  previousDurableChatState = {
+    chatTabs,
+    activeTabId,
+    eventViewModePreference: normalizeEventViewMode(state.eventViewModePreference),
+  }
+  return previousDurableChatState
+}
+
+const chatPersistStorage = (() => {
+  try {
+    return typeof globalThis.localStorage === 'undefined'
+      ? undefined
+      : createBufferedPersistStorage<DurableChatState>(globalThis.localStorage)
+  } catch (error) {
+    console.error('[ChatStore] Browser storage is unavailable', error)
+    return undefined
+  }
+})()
 
 const reconcileInactiveSessionTabs = (
   state: ChatState,
@@ -2802,58 +2881,8 @@ export const useChatStore = create<ChatState>()(
       }),
       {
         name: getWorkspaceScopedStorageKey('chat-store'),
-        partialize: (state) => ({
-          // Persist workflow and multi-agent tabs (for reconnection)
-          // Only persist tabs created within the last 24 hours to prevent stale tabs
-          // from accumulating in localStorage and causing page hangs on reload
-          chatTabs: Object.fromEntries(
-            Object.entries(state.chatTabs)
-              .filter(([, tab]) => {
-                const isRelevantMode = tab.metadata?.mode === 'workflow' || tab.metadata?.mode === 'multi-agent'
-                if (!isRelevantMode) return false
-                // Drop tabs older than 24 hours - they won't have active sessions
-                const MAX_TAB_AGE = 24 * 60 * 60 * 1000
-                const age = Date.now() - (tab.createdAt || 0)
-                return age < MAX_TAB_AGE
-              })
-              .map(([tabId, tab]) => [
-              tabId,
-              {
-                tabId: tab.tabId,
-                name: tab.name,
-                sessionId: tab.sessionId, // Persist session ID for direct restore on page refresh
-                isStreaming: false, // Reset streaming state on reload
-                isCompleted: false,
-                hasRunningBgAgents: false,
-                isSyntheticTurn: false,
-                canSteer: false,
-                
-                hideToolCalls: tab.hideToolCalls ?? true, // Default true — collapse tool calls by default
-                viewMode: normalizeEventViewMode(tab.viewMode), // Persist layout mode across reload
-                config: persistDurableTabConfig(tab.config), // Persist durable config including:
-                // - selectedServers (MCP server selections)
-                // - llmConfig (LLM provider, model_id, fallback_models, etc.)
-                // - useCodeExecutionMode (Simple vs Code Exec mode)
-                // - fileContext (selected files/folders)
-                // - inputText (chat input text)
-                // - enableContextSummarization
-                // - restoredConversationPath metadata for resumed coding-agent tabs
-                createdAt: tab.createdAt, // Persist for ordering
-                lastAccessedAt: tab.lastAccessedAt || tab.createdAt,
-                lastViewedEventCount: 0, // @deprecated - Reset on reload
-                lastViewedEventCounts: { micro: 0 }, // Reset on reload
-                metadata: tab.metadata // Persist mode and phase info
-              }
-            ])
-          ),
-          // Persist activeTabId for workflow and multi-agent tabs
-          activeTabId: (() => {
-            const activeTab = state.activeTabId ? state.chatTabs[state.activeTabId] : null
-            return (activeTab?.metadata?.mode === 'workflow' || activeTab?.metadata?.mode === 'multi-agent') ? state.activeTabId : null
-          })(),
-          eventViewModePreference: normalizeEventViewMode(state.eventViewModePreference)
-          // Exclude all other state (isStreaming, pollingInterval, tabEvents, etc.)
-        }),
+        storage: chatPersistStorage,
+        partialize: selectDurableChatState,
         onRehydrateStorage: () => (_state, error) => {
           // Defer until create() has assigned useChatStore. This also makes tab
           // cleanup/migration part of the hydration contract seen by all callers.
@@ -2862,6 +2891,14 @@ export const useChatStore = create<ChatState>()(
       }
     )
 )
+
+if (chatPersistStorage) {
+  const flushDurableChatState = () => chatPersistStorage.flush()
+  globalThis.addEventListener?.('pagehide', flushDurableChatState)
+  globalThis.addEventListener?.('beforeunload', flushDurableChatState)
+} else {
+  queueMicrotask(() => finalizeChatStoreHydration())
+}
 
 function normalizeHydratedChatStore(): void {
   const state = useChatStore.getState()

--- a/frontend/src/utils/bufferedPersistStorage.test.ts
+++ b/frontend/src/utils/bufferedPersistStorage.test.ts
@@ -56,6 +56,23 @@ describe('createBufferedPersistStorage', () => {
     expect(setItem).toHaveBeenCalledTimes(1)
   })
 
+  it('cancels a pending write when state reverts to the persisted value', () => {
+    vi.useFakeTimers()
+    const { storage, values } = createMemoryStorage()
+    storage.setItem('chat-store', JSON.stringify({ state: { mode: 'tree' }, version: 0 }))
+    const setItem = vi.spyOn(storage, 'setItem')
+    const buffered = createBufferedPersistStorage<{ mode: string }>(storage, { delayMs: 250 })
+
+    buffered.getItem('chat-store')
+    buffered.setItem('chat-store', { state: { mode: 'terminal' }, version: 0 })
+    buffered.setItem('chat-store', { state: { mode: 'tree' }, version: 0 })
+    vi.advanceTimersByTime(250)
+
+    expect(setItem).not.toHaveBeenCalled()
+    expect(JSON.parse(values.get('chat-store') || '{}').state.mode).toBe('tree')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('flushes pending state before disposal', () => {
     vi.useFakeTimers()
     const { storage, values } = createMemoryStorage()

--- a/frontend/src/utils/bufferedPersistStorage.test.ts
+++ b/frontend/src/utils/bufferedPersistStorage.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createBufferedPersistStorage } from './bufferedPersistStorage'
+
+const createMemoryStorage = () => {
+  const values = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => {
+      values.delete(key)
+    },
+    setItem: (key, value) => {
+      values.set(key, value)
+    },
+  }
+  return { storage, values }
+}
+
+describe('createBufferedPersistStorage', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('coalesces durable changes and writes only the latest value', () => {
+    vi.useFakeTimers()
+    const { storage, values } = createMemoryStorage()
+    const setItem = vi.spyOn(storage, 'setItem')
+    const buffered = createBufferedPersistStorage<{ count: number }>(storage, { delayMs: 250 })
+
+    buffered.setItem('chat-store', { state: { count: 1 }, version: 0 })
+    buffered.setItem('chat-store', { state: { count: 2 }, version: 0 })
+
+    expect(setItem).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(250)
+    expect(setItem).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(values.get('chat-store') || '{}').state.count).toBe(2)
+  })
+
+  it('skips repeated state references and structurally identical payloads', () => {
+    vi.useFakeTimers()
+    const { storage } = createMemoryStorage()
+    const setItem = vi.spyOn(storage, 'setItem')
+    const buffered = createBufferedPersistStorage<{ count: number }>(storage)
+    const state = { count: 1 }
+
+    buffered.setItem('chat-store', { state, version: 0 })
+    buffered.flush()
+    buffered.setItem('chat-store', { state, version: 0 })
+    buffered.setItem('chat-store', { state: { count: 1 }, version: 0 })
+    vi.runAllTimers()
+
+    expect(setItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes pending state before disposal', () => {
+    vi.useFakeTimers()
+    const { storage, values } = createMemoryStorage()
+    const buffered = createBufferedPersistStorage<{ ready: boolean }>(storage)
+
+    buffered.setItem('chat-store', { state: { ready: true }, version: 0 })
+    buffered.dispose()
+
+    expect(JSON.parse(values.get('chat-store') || '{}').state.ready).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/frontend/src/utils/bufferedPersistStorage.ts
+++ b/frontend/src/utils/bufferedPersistStorage.ts
@@ -1,0 +1,69 @@
+import type { PersistStorage, StorageValue } from 'zustand/middleware'
+
+export interface BufferedPersistStorage<S> extends PersistStorage<S> {
+  flush: () => void
+  dispose: () => void
+}
+
+interface BufferedPersistStorageOptions {
+  delayMs?: number
+}
+
+/**
+ * JSON persistence that skips identical state references, deduplicates equal
+ * payloads, and coalesces durable changes into one browser-storage write.
+ */
+export function createBufferedPersistStorage<S>(
+  storage: Storage,
+  options: BufferedPersistStorageOptions = {},
+): BufferedPersistStorage<S> {
+  const delayMs = options.delayMs ?? 250
+  let lastInputState: S | undefined
+  let lastPersistedValue: string | null = null
+  let pending: { name: string; serialized: string } | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const flush = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    if (!pending) return
+    storage.setItem(pending.name, pending.serialized)
+    lastPersistedValue = pending.serialized
+    pending = null
+  }
+
+  return {
+    getItem: (name) => {
+      const stored = storage.getItem(name)
+      lastPersistedValue = stored
+      return stored ? JSON.parse(stored) as StorageValue<S> : null
+    },
+    setItem: (name, value) => {
+      if (value.state === lastInputState) return
+      lastInputState = value.state
+
+      const serialized = JSON.stringify(value)
+      if (serialized === lastPersistedValue || serialized === pending?.serialized) return
+
+      pending = { name, serialized }
+      if (timer !== null) clearTimeout(timer)
+      timer = setTimeout(flush, delayMs)
+    },
+    removeItem: (name) => {
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+      pending = null
+      lastInputState = undefined
+      lastPersistedValue = null
+      storage.removeItem(name)
+    },
+    flush,
+    dispose: () => {
+      flush()
+    },
+  }
+}

--- a/frontend/src/utils/bufferedPersistStorage.ts
+++ b/frontend/src/utils/bufferedPersistStorage.ts
@@ -45,7 +45,15 @@ export function createBufferedPersistStorage<S>(
       lastInputState = value.state
 
       const serialized = JSON.stringify(value)
-      if (serialized === lastPersistedValue || serialized === pending?.serialized) return
+      if (serialized === lastPersistedValue) {
+        if (timer !== null) {
+          clearTimeout(timer)
+          timer = null
+        }
+        pending = null
+        return
+      }
+      if (serialized === pending?.serialized) return
 
       pending = { name, serialized }
       if (timer !== null) clearTimeout(timer)


### PR DESCRIPTION
## Summary

- memoize the durable chat-state projection so stream and event updates reuse the same persistence object
- buffer durable localStorage writes for 250 ms and coalesce rapid tab/config changes
- flush pending durable state when the page is hidden or unloaded
- retain the existing Zustand storage envelope and verify existing workflow tabs restore unchanged
- add focused adapter and real-store persistence regression tests

## Why

The entire chat store is wrapped in Zustand persistence. Although volatile events and terminal text are excluded from the persisted payload, every hot state update still invoked the durable projection, JSON serialization, and browser-storage write path.

This is especially expensive during active terminal streaming, where dozens of updates can arrive in a short period.

## Impact

- streaming chunks no longer write localStorage after the durable baseline is established
- repeated hot updates skip JSON serialization when tab metadata is unchanged
- rapid durable changes produce one browser-storage write instead of one write per update
- existing persisted tabs remain backward compatible
- unload/page-hide still commits pending durable state

## Validation

- `npm test -- --run`: **15 files, 79 tests passed**
- `npm run build`: bundle budget passed at **995.40 KB gzip / 1,000 KB**
- scoped ESLint passed
- `git diff --check` passed
- repository pre-commit frontend, Go, workspace, Electron, lint, and secret checks passed

Stacked on #144 so this PR contains only the P1 hot-state persistence work.

Progresses #138.