### PR TITLE
Coalesce frontend runtime polling

### DIFF
--- a/frontend/src/components/GlobalActivityMonitor.tsx
+++ b/frontend/src/components/GlobalActivityMonitor.tsx
@@ -418,12 +418,16 @@ export const GlobalActivityMonitor: React.FC = () => {
   const workflowPresets = useGlobalPresetStore(state => state.workflowPresets)
 
   useEffect(() => {
+    let disposed = false
+    let refreshPromise: Promise<void> | null = null
+
     const refresh = async () => {
       const [activeResult, runningResult, terminalsResult] = await Promise.allSettled([
-        getActiveSessions(true),
+        getActiveSessions(),
         agentApi.listRunningWorkflows(),
         agentApi.listTerminals(undefined, 'none', { activeOnly: true }),
       ])
+      if (disposed) return
       const active = activeResult.status === 'fulfilled' ? activeResult.value : []
       const running = runningResult.status === 'fulfilled' ? (runningResult.value.running || []) : []
 
@@ -484,17 +488,29 @@ export const GlobalActivityMonitor: React.FC = () => {
           }
         }),
       )
+      if (disposed) return
       setCurrentExecutionBySession(Object.fromEntries(
         treeResults
           .flatMap(result => result.status === 'fulfilled' && result.value ? [result.value] : []),
       ))
     }
 
-    refresh()
-    const interval = window.setInterval(() => {
-      refresh()
-    }, ACTIVITY_DETAILS_POLL_MS)
-    return () => window.clearInterval(interval)
+    const requestRefresh = () => {
+      if (document.hidden || refreshPromise) return
+      refreshPromise = refresh().finally(() => {
+        refreshPromise = null
+      })
+    }
+    const handleVisibilityChange = () => requestRefresh()
+
+    requestRefresh()
+    const interval = window.setInterval(requestRefresh, ACTIVITY_DETAILS_POLL_MS)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      disposed = true
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
   }, [getActiveSessions, workflowPresets])
 
   useEffect(() => {

--- a/frontend/src/components/GlobalActivityMonitor.tsx
+++ b/frontend/src/components/GlobalActivityMonitor.tsx
@@ -12,6 +12,8 @@ import { isLocalActivityFallbackTab } from '../utils/activityFallback'
 import { hasIdleAliveCodingAgent, hasLiveBackgroundAgents, normalizedActivityStatus } from '../utils/activitySessions'
 import { activeSessionsFromLiveWorkflowTerminals } from '../utils/workflowTerminalActivity'
 
+// This matches useChatStore's active-session cache TTL. A longer store TTL also
+// increases the monitor's effective freshness window and should be changed here.
 const ACTIVITY_DETAILS_POLL_MS = 30000
 const MAX_INLINE_ACTIVITY_ITEMS = 2
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -599,6 +599,7 @@ workspaceApi.interceptors.response.use(
 
 
 const coalesceRuntimeRead = createRequestCoalescer()
+const RUNTIME_READ_TIMEOUT_MS = 15_000
 
 export const agentApi = {
   // Observer APIs removed - no longer needed
@@ -652,7 +653,7 @@ export const agentApi = {
     if (options?.activeOnly) params.active_only = 1
     const requestKey = `terminals:${sessionId || '*'}:${content}:${options?.activeOnly ? 'active' : 'all'}`
     return coalesceRuntimeRead(requestKey, async () => {
-      const response = await api.get('/api/terminals', { params, timeout: 15000 })
+      const response = await api.get('/api/terminals', { params, timeout: RUNTIME_READ_TIMEOUT_MS })
       return response.data
     })
   },
@@ -789,7 +790,7 @@ export const agentApi = {
   // Get all active sessions
   getActiveSessions: async (): Promise<GetActiveSessionsResponse> => {
     return coalesceRuntimeRead('active-sessions', async () => {
-      const response = await api.get('/api/sessions/active')
+      const response = await api.get('/api/sessions/active', { timeout: RUNTIME_READ_TIMEOUT_MS })
       return response.data
     })
   },
@@ -840,7 +841,7 @@ export const agentApi = {
   },
 
   getSessionExecutionTree: async (sessionId: string): Promise<SessionExecutionTreeResponse> => {
-    const response = await api.get(`/api/sessions/${sessionId}/execution-tree`)
+    const response = await api.get(`/api/sessions/${sessionId}/execution-tree`, { timeout: RUNTIME_READ_TIMEOUT_MS })
     return response.data
   },
 
@@ -1621,7 +1622,7 @@ export const agentApi = {
 
   listRunningWorkflows: async (): Promise<{ running: RunningWorkflowInfo[] }> => {
     return coalesceRuntimeRead('running-workflows', async () => {
-      const response = await api.get('/api/workflow/running')
+      const response = await api.get('/api/workflow/running', { timeout: RUNTIME_READ_TIMEOUT_MS })
       return response.data
     })
   },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,6 @@
 console.log('Cache bust: 2026-02-08-150000');
 import axios from 'axios'
+import { createRequestCoalescer } from './requestCoalescer'
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 import { useChatStore } from '../stores/useChatStore'
 import { useModeStore } from '../stores/useModeStore'
@@ -597,6 +598,8 @@ workspaceApi.interceptors.response.use(
 )
 
 
+const coalesceRuntimeRead = createRequestCoalescer()
+
 export const agentApi = {
   // Observer APIs removed - no longer needed
 
@@ -647,8 +650,11 @@ export const agentApi = {
   ): Promise<ListTerminalsResponse> => {
     const params: Record<string, string | number | boolean> = sessionId ? { session_id: sessionId, content } : { content }
     if (options?.activeOnly) params.active_only = 1
-    const response = await api.get('/api/terminals', { params, timeout: 15000 })
-    return response.data
+    const requestKey = `terminals:${sessionId || '*'}:${content}:${options?.activeOnly ? 'active' : 'all'}`
+    return coalesceRuntimeRead(requestKey, async () => {
+      const response = await api.get('/api/terminals', { params, timeout: 15000 })
+      return response.data
+    })
   },
 
   getTerminal: async (
@@ -782,8 +788,10 @@ export const agentApi = {
   // Active Session Management
   // Get all active sessions
   getActiveSessions: async (): Promise<GetActiveSessionsResponse> => {
-    const response = await api.get('/api/sessions/active')
-    return response.data
+    return coalesceRuntimeRead('active-sessions', async () => {
+      const response = await api.get('/api/sessions/active')
+      return response.data
+    })
   },
 
   getChatHistoryConversation: async (sessionId: string, workspacePath?: string): Promise<ChatHistoryConversation> => {
@@ -1612,8 +1620,10 @@ export const agentApi = {
   },
 
   listRunningWorkflows: async (): Promise<{ running: RunningWorkflowInfo[] }> => {
-    const response = await api.get('/api/workflow/running')
-    return response.data
+    return coalesceRuntimeRead('running-workflows', async () => {
+      const response = await api.get('/api/workflow/running')
+      return response.data
+    })
   },
 
   updateRunningWorkflow: async (sessionId: string, patch: UpdateRunningWorkflowRequest): Promise<RunningWorkflowInfo> => {

--- a/frontend/src/services/requestCoalescer.test.ts
+++ b/frontend/src/services/requestCoalescer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRequestCoalescer } from './requestCoalescer'
+
+describe('createRequestCoalescer', () => {
+  it('shares concurrent reads with the same key', async () => {
+    const coalesce = createRequestCoalescer()
+    let resolve!: (value: string) => void
+    const request = vi.fn(() => new Promise<string>(done => { resolve = done }))
+
+    const first = coalesce('terminals:all', request)
+    const second = coalesce('terminals:all', request)
+    expect(first).toBe(second)
+    expect(request).toHaveBeenCalledTimes(1)
+
+    resolve('ok')
+    await expect(first).resolves.toBe('ok')
+  })
+
+  it('does not combine different request keys', async () => {
+    const coalesce = createRequestCoalescer()
+    const request = vi.fn(async (value: string) => value)
+
+    await Promise.all([
+      coalesce('terminals:one', () => request('one')),
+      coalesce('terminals:two', () => request('two')),
+    ])
+
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows a retry after a failed request', async () => {
+    const coalesce = createRequestCoalescer()
+    const request = vi.fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce('recovered')
+
+    await expect(coalesce('active-sessions', request)).rejects.toThrow('offline')
+    await expect(coalesce('active-sessions', request)).resolves.toBe('recovered')
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/services/requestCoalescer.ts
+++ b/frontend/src/services/requestCoalescer.ts
@@ -3,6 +3,9 @@ export type RequestCoalescer = <T>(key: string, request: () => Promise<T>) => Pr
 /**
  * Shares one in-flight promise for identical reads. The entry is removed after
  * either success or failure so later polling intervals still fetch fresh data.
+ * A caller immediately following a mutation can join an older in-flight read;
+ * mutation flows that require read-after-write consistency must use a distinct
+ * key or wait for the existing request to settle.
  */
 export function createRequestCoalescer(): RequestCoalescer {
   const inFlight = new Map<string, Promise<unknown>>()

--- a/frontend/src/services/requestCoalescer.ts
+++ b/frontend/src/services/requestCoalescer.ts
@@ -1,0 +1,29 @@
+export type RequestCoalescer = <T>(key: string, request: () => Promise<T>) => Promise<T>
+
+/**
+ * Shares one in-flight promise for identical reads. The entry is removed after
+ * either success or failure so later polling intervals still fetch fresh data.
+ */
+export function createRequestCoalescer(): RequestCoalescer {
+  const inFlight = new Map<string, Promise<unknown>>()
+
+  return <T>(key: string, request: () => Promise<T>): Promise<T> => {
+    const existing = inFlight.get(key)
+    if (existing) return existing as Promise<T>
+
+    let requestResult: Promise<T>
+    try {
+      requestResult = request()
+    } catch (error) {
+      requestResult = Promise.reject(error)
+    }
+
+    let pending: Promise<T>
+    pending = requestResult
+      .finally(() => {
+        if (inFlight.get(key) === pending) inFlight.delete(key)
+      })
+    inFlight.set(key, pending)
+    return pending
+  }
+}


### PR DESCRIPTION
## Summary
- share identical in-flight active-session, running-workflow, and terminal reads at the API boundary
- stop the global activity monitor from bypassing the active-session cache on every tick
- prevent overlapping monitor refreshes and pause monitor polling while the app is hidden
- add request-coalescer coverage for shared reads, independent keys, and retries

## Verification
- `npm test -- --run` (16 files, 83 tests)
- `npm run build` (995.96 kB eager gzip, below 1 MB hard budget)
- repository pre-commit checks, agent/workspace builds, and Electron directory build

## Tracking
Partial P1 implementation for #138. This PR is stacked on #145 and should be rebased to `main` after #144 and #145 merge.