### PR TITLE
Preserve terminal snapshot identity

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,6 @@ import { RenderedContentSearchBar, RenderedContentSearchButton, useRenderedConte
 import { resetSessionId, agentApi } from "./services/api";
 import { AuthWrapper } from "./components/AuthWrapper";
 import type { FileVersion } from "./services/api-types";
-import PushToGistDialog from "./components/workspace/PushToGistDialog";
 import { isValidJSON } from "./utils/event-helpers";
 import { prepareDomForPdfExport } from "./utils/pdfExport";
 import { convertToSlackMarkdown } from "./utils/slackMarkdown";
@@ -24,7 +23,6 @@ import { findBlockingMultiAgentSession, shouldConfirmForSessionStatus, shouldCon
 import { Edit, Save, X, Loader2, Download, Link, Github, PanelRightClose, PanelRightOpen, Smartphone, Laptop } from "lucide-react";
 import { WorkflowLayout } from "./components/workflow";
 import { ModePresetBar } from "./components/ModePresetBar";
-import { QuickSwitcher } from "./components/QuickSwitcher";
 import { ChatTabs } from "./components/ChatTabs";
 import ConfirmationDialog from "./components/ui/ConfirmationDialog";
 import { useAppStore, useMCPStore, useGlobalPresetStore, useWorkspaceStore, useWorkflowStore, useChatStore } from "./stores";
@@ -52,6 +50,8 @@ const queryClient = new QueryClient();
 
 const FileEditor = lazy(() => import('./components/workspace/FileEditor'))
 const FileRevisionsModal = lazy(() => import('./components/workspace/FileRevisionsModal'))
+const PushToGistDialog = lazy(() => import('./components/workspace/PushToGistDialog'))
+const QuickSwitcher = lazy(() => import('./components/QuickSwitcher'))
 const WorkflowsOverviewPage = lazy(() => import('./components/WorkflowsOverviewPage').then(module => ({ default: module.WorkflowsOverviewPage })))
 const XlsxRenderer = lazy(() => import('./components/ui/XlsxRenderer').then(module => ({ default: module.XlsxRenderer })))
 const DocxRenderer = lazy(() => import('./components/ui/DocxRenderer').then(module => ({ default: module.DocxRenderer })))
@@ -1640,11 +1640,15 @@ function App() {
               (ModePresetBar → WorkspaceTopBarControls). */}
           <div className="flex-1 flex flex-col min-w-0 min-h-0 relative z-10 overflow-hidden">
             {/* Quick Switcher (Ctrl+K) - constrained to the main content area */}
-            <QuickSwitcher
-              isOpen={showQuickSwitcher}
-              onClose={() => setShowQuickSwitcher(false)}
-              initialQuery={quickSwitcherInitialQuery}
-            />
+            {showQuickSwitcher && (
+              <Suspense fallback={<LazyModalFallback label="Loading switcher..." />}>
+                <QuickSwitcher
+                  isOpen
+                  onClose={() => setShowQuickSwitcher(false)}
+                  initialQuery={quickSwitcherInitialQuery}
+                />
+              </Suspense>
+            )}
 
             {/* Global Mode & Preset Bar - only above middle content area, not sidebars */}
             <ModePresetBar />
@@ -2251,12 +2255,16 @@ function App() {
         </div>
 
         {/* Push to Gist Dialog */}
-        <PushToGistDialog
-          isOpen={showPushToGistDialog}
-          onClose={() => setShowPushToGistDialog(false)}
-          fileContent={fileContent}
-          fileName={selectedFile?.name || selectedFile?.path?.split('/').pop() || 'document.md'}
-        />
+        {showPushToGistDialog && (
+          <Suspense fallback={<LazyModalFallback label="Loading GitHub sharing..." />}>
+            <PushToGistDialog
+              isOpen
+              onClose={() => setShowPushToGistDialog(false)}
+              fileContent={fileContent}
+              fileName={selectedFile?.name || selectedFile?.path?.split('/').pop() || 'document.md'}
+            />
+          </Suspense>
+        )}
 
         {/* File Revisions Modal */}
         {showRevisionsModal && (

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -5,6 +5,7 @@ import { Terminal as XTerm, type ITheme } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { agentApi } from '../services/api'
+import { reconcileTerminalSnapshots } from '../utils/terminalSnapshotIdentity'
 import type { PollingEvent, TerminalSnapshot } from '../services/api-types'
 import { useGlobalPresetStore } from '../stores/useGlobalPresetStore'
 import { normalizeEventViewMode, useChatStore } from '../stores/useChatStore'
@@ -3384,7 +3385,7 @@ const TerminalCenterInner: React.FC<TerminalCenterProps> = ({ currentSessionId, 
           gracePolls: EMPTY_TERMINAL_RESPONSE_GRACE_POLLS,
         })
         emptyResponseCountRef.current = continuity.emptyPollCount
-        return continuity.terminals
+        return reconcileTerminalSnapshots(current, continuity.terminals)
       })
       setError(null)
     } catch (err) {

--- a/frontend/src/utils/terminalSnapshotIdentity.test.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.test.ts
@@ -16,6 +16,12 @@ const terminal = (id: string, overrides: Partial<TerminalSnapshot> = {}): Termin
 })
 
 describe('reconcileTerminalSnapshots', () => {
+  it('preserves the array for repeated empty polls', () => {
+    const current: TerminalSnapshot[] = []
+
+    expect(reconcileTerminalSnapshots(current, [])).toBe(current)
+  })
+
   it('preserves the array and objects for semantically identical polls', () => {
     const current = [terminal('one'), terminal('two')]
     const incoming = current.map(item => ({

--- a/frontend/src/utils/terminalSnapshotIdentity.test.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalSnapshot } from '../services/api-types'
+import { reconcileTerminalSnapshots } from './terminalSnapshotIdentity'
+
+const terminal = (id: string, overrides: Partial<TerminalSnapshot> = {}): TerminalSnapshot => ({
+  terminal_id: id,
+  session_id: 'session-1',
+  content: '',
+  rows: [],
+  chunk_index: 1,
+  active: true,
+  status: { provider_label: 'Codex', input_tokens: 10 },
+  created_at: '2026-07-13T00:00:00Z',
+  updated_at: '2026-07-13T00:00:01Z',
+  ...overrides,
+})
+
+describe('reconcileTerminalSnapshots', () => {
+  it('preserves the array and objects for semantically identical polls', () => {
+    const current = [terminal('one'), terminal('two')]
+    const incoming = current.map(item => ({
+      ...item,
+      rows: [...item.rows],
+      status: { ...item.status },
+    }))
+
+    const result = reconcileTerminalSnapshots(current, incoming)
+
+    expect(result).toBe(current)
+    expect(result[0]).toBe(current[0])
+  })
+
+  it('ignores backend ordering changes when the terminal set is unchanged', () => {
+    const current = [terminal('one'), terminal('two')]
+    const incoming = [{ ...current[1] }, { ...current[0] }]
+
+    expect(reconcileTerminalSnapshots(current, incoming)).toBe(current)
+  })
+
+  it('reuses unchanged objects while applying changed snapshots', () => {
+    const current = [terminal('one'), terminal('two')]
+    const changed = terminal('two', { chunk_index: 2, updated_at: '2026-07-13T00:00:02Z' })
+
+    const result = reconcileTerminalSnapshots(current, [{ ...current[0] }, changed])
+
+    expect(result).not.toBe(current)
+    expect(result[0]).toBe(current[0])
+    expect(result[1]).toBe(changed)
+  })
+
+  it('applies additions and removals', () => {
+    const current = [terminal('one'), terminal('two')]
+    const added = terminal('three')
+
+    expect(reconcileTerminalSnapshots(current, [current[0], added])).toEqual([current[0], added])
+    expect(reconcileTerminalSnapshots(current, [current[0]])).toEqual([current[0]])
+  })
+})

--- a/frontend/src/utils/terminalSnapshotIdentity.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.ts
@@ -1,0 +1,49 @@
+import type { TerminalSnapshot } from '../services/api-types'
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+)
+
+const jsonValueEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+    return left.every((value, index) => jsonValueEqual(value, right[index]))
+  }
+  if (!isRecord(left) || !isRecord(right)) return false
+
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) return false
+  return leftKeys.every(key => (
+    Object.prototype.hasOwnProperty.call(right, key) && jsonValueEqual(left[key], right[key])
+  ))
+}
+
+/**
+ * Reuses terminal snapshots from the previous poll when their JSON payload is
+ * unchanged. Poll ordering is not treated as a change because the terminal
+ * rail applies its own stable sort before rendering.
+ */
+export function reconcileTerminalSnapshots(
+  current: TerminalSnapshot[],
+  incoming: TerminalSnapshot[],
+): TerminalSnapshot[] {
+  if (current.length === 0) return incoming
+  if (incoming.length === 0) return incoming
+
+  const currentByID = new Map(current.map(terminal => [terminal.terminal_id, terminal]))
+  const incomingIDs = new Set(incoming.map(terminal => terminal.terminal_id))
+  let changed = current.length !== incoming.length
+  const reconciled = incoming.map(terminal => {
+    const existing = currentByID.get(terminal.terminal_id)
+    if (existing && jsonValueEqual(existing, terminal)) return existing
+    changed = true
+    return terminal
+  })
+
+  if (!changed && current.every(terminal => incomingIDs.has(terminal.terminal_id))) {
+    return current
+  }
+  return reconciled
+}

--- a/frontend/src/utils/terminalSnapshotIdentity.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.ts
@@ -33,7 +33,6 @@ export function reconcileTerminalSnapshots(
   if (incoming.length === 0) return incoming
 
   const currentByID = new Map(current.map(terminal => [terminal.terminal_id, terminal]))
-  const incomingIDs = new Set(incoming.map(terminal => terminal.terminal_id))
   let changed = current.length !== incoming.length
   const reconciled = incoming.map(terminal => {
     const existing = currentByID.get(terminal.terminal_id)
@@ -42,8 +41,6 @@ export function reconcileTerminalSnapshots(
     return terminal
   })
 
-  if (!changed && current.every(terminal => incomingIDs.has(terminal.terminal_id))) {
-    return current
-  }
+  if (!changed) return current
   return reconciled
 }

--- a/frontend/src/utils/terminalSnapshotIdentity.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.ts
@@ -29,7 +29,7 @@ export function reconcileTerminalSnapshots(
   current: TerminalSnapshot[],
   incoming: TerminalSnapshot[],
 ): TerminalSnapshot[] {
-  if (current.length === 0) return incoming
+  if (current.length === 0) return incoming.length === 0 ? current : incoming
   if (incoming.length === 0) return incoming
 
   const currentByID = new Map(current.map(terminal => [terminal.terminal_id, terminal]))


### PR DESCRIPTION
## Summary
- semantically compare terminal snapshots returned by metadata polling
- preserve the terminal array when a poll is unchanged, including backend-only ordering changes
- reuse unchanged terminal objects when another terminal advances
- cover identical, reordered, changed, added, and removed snapshots

## Verification
- `npm test -- --run` (17 files, 87 tests)
- `npm run build` (996.18 kB eager gzip, below 1 MB hard budget)
- repository pre-commit checks, agent/workspace builds, and Electron directory build

## Tracking
Partial P1 implementation for #138. This PR is stacked on #146.