### PR TITLE
Narrow frontend root store subscriptions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
 import { useEffect, useCallback, useRef, useState, forwardRef, lazy, Suspense } from "react";
 import { ThemeProvider } from "./contexts/ThemeContext.tsx";
 import { UpdateProgressToast } from "./components/UpdateProgressToast";
@@ -198,8 +199,13 @@ function App() {
   const [orgHtmlPreviewDevice, setOrgHtmlPreviewDevice] = useState<OrgHtmlPreviewDevice>(() => getOrgHtmlPreviewDevice())
 
   // Store subscriptions
-  const { setAgentMode } = useAppStore()
-  const { hasCompletedInitialSetup, selectedModeCategory, setModeCategory, completeInitialSetup } = useModeStore()
+  const setAgentMode = useAppStore(state => state.setAgentMode)
+  const { hasCompletedInitialSetup, selectedModeCategory, setModeCategory, completeInitialSetup } = useModeStore(useShallow(state => ({
+    hasCompletedInitialSetup: state.hasCompletedInitialSetup,
+    selectedModeCategory: state.selectedModeCategory,
+    setModeCategory: state.setModeCategory,
+    completeInitialSetup: state.completeInitialSetup,
+  })))
   const defaultsLoaded = useLLMStore(state => state.defaultsLoaded)
   const savedLLMs = useLLMStore(state => state.savedLLMs)
   const llmConfigLocked = useLLMStore(state => state.llmConfigLocked)
@@ -220,7 +226,17 @@ function App() {
     setMultiAgentRightPanelView,
     showWorkflowsOverview,
     setShowWorkflowsOverview
-  } = useAppStore()
+  } = useAppStore(useShallow(state => ({
+    setSelectedPresetId: state.setSelectedPresetId,
+    workspaceMinimized: state.workspaceMinimized,
+    workspaceMinimizedByMode: state.workspaceMinimizedByMode,
+    setWorkspaceMinimized: state.setWorkspaceMinimized,
+    setWorkspaceMinimizedForLayout: state.setWorkspaceMinimizedForLayout,
+    multiAgentRightPanelView: state.multiAgentRightPanelView,
+    setMultiAgentRightPanelView: state.setMultiAgentRightPanelView,
+    showWorkflowsOverview: state.showWorkflowsOverview,
+    setShowWorkflowsOverview: state.setShowWorkflowsOverview,
+  })))
   const [hasOpenedWorkflowsOverview, setHasOpenedWorkflowsOverview] = useState(showWorkflowsOverview)
   
   const {
@@ -241,7 +257,25 @@ function App() {
     getHasUnsavedChanges,
     saveFile,
     binaryFileData
-  } = useWorkspaceStore()
+  } = useWorkspaceStore(useShallow(state => ({
+    selectedFile: state.selectedFile,
+    fileContent: state.fileContent,
+    loadingFileContent: state.loadingFileContent,
+    showFileContent: state.showFileContent,
+    setShowFileContent: state.setShowFileContent,
+    setFileContent: state.setFileContent,
+    setLoadingFileContent: state.setLoadingFileContent,
+    showRevisionsModal: state.showRevisionsModal,
+    setShowRevisionsModal: state.setShowRevisionsModal,
+    isEditMode: state.isEditMode,
+    setIsEditMode: state.setIsEditMode,
+    editedContent: state.editedContent,
+    setEditedContent: state.setEditedContent,
+    isSaving: state.isSaving,
+    getHasUnsavedChanges: state.getHasUnsavedChanges,
+    saveFile: state.saveFile,
+    binaryFileData: state.binaryFileData,
+  })))
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -707,7 +741,11 @@ function App() {
   const hasCreatedDefaultTabRef = useRef<string | null>(null)
 
   
-  const { clearActivePreset, applyPreset, getActivePreset } = useGlobalPresetStore()
+  const { clearActivePreset, applyPreset, getActivePreset } = useGlobalPresetStore(useShallow(state => ({
+    clearActivePreset: state.clearActivePreset,
+    applyPreset: state.applyPreset,
+    getActivePreset: state.getActivePreset,
+  })))
 
   useEffect(() => {
     const handleOpenQuickSwitcher = (event: Event) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -741,11 +741,9 @@ function App() {
   const hasCreatedDefaultTabRef = useRef<string | null>(null)
 
   
-  const { clearActivePreset, applyPreset, getActivePreset } = useGlobalPresetStore(useShallow(state => ({
-    clearActivePreset: state.clearActivePreset,
-    applyPreset: state.applyPreset,
-    getActivePreset: state.getActivePreset,
-  })))
+  const clearActivePreset = useGlobalPresetStore(state => state.clearActivePreset)
+  const applyPreset = useGlobalPresetStore(state => state.applyPreset)
+  const getActivePreset = useGlobalPresetStore(state => state.getActivePreset)
 
   useEffect(() => {
     const handleOpenQuickSwitcher = (event: Event) => {

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useCallback, useMemo, useState, useEffect, useLayoutEffect } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 
 const DBG = '[skill-popup]'
 import { Send, Square, Code2, Sparkles, Wand2, Loader2, Search, Globe, Layers, X, History, Bot, Server, Download, Paperclip, CalendarClock, MessageSquare, Terminal } from 'lucide-react'
@@ -540,7 +541,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     agentMode,
     setWorkspaceMinimized,
     showWorkflowsOverview
-  } = useAppStore()
+  } = useAppStore(useShallow(state => ({
+    agentMode: state.agentMode,
+    setWorkspaceMinimized: state.setWorkspaceMinimized,
+    showWorkflowsOverview: state.showWorkflowsOverview,
+  })))
   const selectedModeCategory = useModeStore(state => state.selectedModeCategory)
   const storeActiveTabId = useChatStore(state => state.activeTabId)
   const activeTabId = scopedTabId === null ? null : (scopedTabId ?? storeActiveTabId)
@@ -605,7 +610,11 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     providerManifest,
     providerManifestLoaded,
     loadProviderManifest,
-  } = useLLMStore()
+  } = useLLMStore(useShallow(state => ({
+    providerManifest: state.providerManifest,
+    providerManifestLoaded: state.providerManifestLoaded,
+    loadProviderManifest: state.loadProviderManifest,
+  })))
   
   // Note: activeTab may be undefined during initial render before tabs are created
   // This is expected and will resolve once the tab store initializes
@@ -841,7 +850,10 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
   const {
     toolList: mcpToolList,
     setChatSelectedServers
-  } = useMCPStore()
+  } = useMCPStore(useShallow(state => ({
+    toolList: state.toolList,
+    setChatSelectedServers: state.setChatSelectedServers,
+  })))
 
   const availableServers = useMemo(
     () => [...new Set(mcpToolList.filter(t => t.status === 'ok').map(t => t.server).filter((s): s is string => typeof s === 'string' && !DEDICATED_MCP_SERVERS.has(s)))],
@@ -1207,10 +1219,23 @@ const ChatInputComponent: React.FC<ChatInputProps> = ({
     refreshAvailableLLMs: onRefreshAvailableLLMs,
     llmConfigLocked,
     workflowPrimaryConfig
-  } = useLLMStore()
+  } = useLLMStore(useShallow(state => ({
+    availableLLMs: state.availableLLMs,
+    getCurrentLLMOption: state.getCurrentLLMOption,
+    refreshAvailableLLMs: state.refreshAvailableLLMs,
+    llmConfigLocked: state.llmConfigLocked,
+    workflowPrimaryConfig: state.workflowPrimaryConfig,
+  })))
 
-  const { scrollToFile } = useWorkspaceStore()
-  const { showSkillImport, showMCPDetails, showMCPConfig, showModels, openDialog, closeDialog } = useCommandDialogStore()
+  const scrollToFile = useWorkspaceStore(state => state.scrollToFile)
+  const { showSkillImport, showMCPDetails, showMCPConfig, showModels, openDialog, closeDialog } = useCommandDialogStore(useShallow(state => ({
+    showSkillImport: state.showSkillImport,
+    showMCPDetails: state.showMCPDetails,
+    showMCPConfig: state.showMCPConfig,
+    showModels: state.showModels,
+    openDialog: state.openDialog,
+    closeDialog: state.closeDialog,
+  })))
 
   // LLM selection (always update tab config)
   const onPrimaryLLMSelect = useCallback((llm: LLMOption) => {

--- a/frontend/src/components/ChatTabs.tsx
+++ b/frontend/src/components/ChatTabs.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { Plus, ArrowDown, ListTree, Terminal, Globe, DollarSign, CalendarClock, SlidersHorizontal, Square } from 'lucide-react'
 import { normalizeEventViewMode, useChatStore, type ChatTab } from '../stores/useChatStore'
 import { useAppStore } from '../stores/useAppStore'
@@ -60,8 +61,22 @@ export const ChatTabs: React.FC<ChatTabsProps> = ({ onNewChat, autoScroll, onTog
     setTabStreaming,
     setTabHasRunningBgAgents,
     activeSessionsCache,
-  } = useChatStore()
-  const { toolList: mcpToolList, setChatSelectedServers } = useMCPStore()
+  } = useChatStore(useShallow(state => ({
+    chatTabs: state.chatTabs,
+    activeTabId: state.activeTabId,
+    switchTab: state.switchTab,
+    autoScroll: state.autoScroll,
+    setAutoScroll: state.setAutoScroll,
+    setTabConfig: state.setTabConfig,
+    setTabViewMode: state.setTabViewMode,
+    setTabStreaming: state.setTabStreaming,
+    setTabHasRunningBgAgents: state.setTabHasRunningBgAgents,
+    activeSessionsCache: state.activeSessionsCache,
+  })))
+  const { toolList: mcpToolList, setChatSelectedServers } = useMCPStore(useShallow(state => ({
+    toolList: state.toolList,
+    setChatSelectedServers: state.setChatSelectedServers,
+  })))
   const delegationTierConfig = useLLMStore(state => state.delegationTierConfig)
   const setShowTierModal = useLLMStore(state => state.setShowTierModal)
 

--- a/frontend/src/components/ModePresetBar.tsx
+++ b/frontend/src/components/ModePresetBar.tsx
@@ -1,4 +1,5 @@
 import React, { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { Workflow, Users, Settings, Copy, Keyboard, Bot, Building2, HelpCircle } from 'lucide-react'
 import { useModeStore } from '../stores/useModeStore'
 import { useGlobalPresetStore, usePresetApplication, usePresetManagement } from '../stores/useGlobalPresetStore'
@@ -130,11 +131,19 @@ const workflowManifestToPreset = (manifest: WorkflowManifest, workspacePath: str
  * Allows users to select mode (multi-agent/workflow) and presets regardless of active tabs
  */
 export const ModePresetBar: React.FC = () => {
-  const { selectedModeCategory, setModeCategory, getAgentModeFromCategory } = useModeStore()
+  const { selectedModeCategory, setModeCategory, getAgentModeFromCategory } = useModeStore(useShallow(state => ({
+    selectedModeCategory: state.selectedModeCategory,
+    setModeCategory: state.setModeCategory,
+    getAgentModeFromCategory: state.getAgentModeFromCategory,
+  })))
   const presetModeCategory = selectedModeCategory === 'workflow' || selectedModeCategory === 'multi-agent'
     ? selectedModeCategory
     : null
-  const { setWorkspaceMinimized, workspaceMinimized, agentMode } = useAppStore()
+  const { setWorkspaceMinimized, workspaceMinimized, agentMode } = useAppStore(useShallow(state => ({
+    setWorkspaceMinimized: state.setWorkspaceMinimized,
+    workspaceMinimized: state.workspaceMinimized,
+    agentMode: state.agentMode,
+  })))
   // Use toolList to get all available servers, not just enabled ones
   const toolList = useMCPStore(state => state.toolList)
   const appVersion = useAppVersion()

--- a/frontend/src/components/Workspace.tsx
+++ b/frontend/src/components/Workspace.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useRef, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { Plus, Upload, FolderPlus, ChevronDown, CheckSquare, X, Trash2, PanelRightClose } from 'lucide-react'
 import { agentApi, workspaceApi } from '../services/api'
 import type { PlannerFile } from '../services/api-types'
@@ -41,7 +42,7 @@ export default function Workspace({
   hideMinimizeControl = false
 }: WorkspaceProps) {
   // Get mode-specific file context and handlers
-  const { selectedModeCategory } = useModeStore()
+  const selectedModeCategory = useModeStore(state => state.selectedModeCategory)
   const authUser = useAuthStore(state => state.user)
   const currentUserFolder = `_users/${authUser?.id || 'default'}`
   const showWorkflowsOverview = useAppStore(state => state.showWorkflowsOverview)
@@ -157,7 +158,46 @@ export default function Workspace({
     setBinaryFileData,
     needsRefresh,
     setNeedsRefresh
-  } = useWorkspaceStore()
+  } = useWorkspaceStore(useShallow(state => ({
+    files: state.files,
+    loading: state.loading,
+    error: state.error,
+    setError: state.setError,
+    searchQuery: state.searchQuery,
+    setSearchQuery: state.setSearchQuery,
+    uploadDialog: state.uploadDialog,
+    setUploadDialog: state.setUploadDialog,
+    openUploadDialog: state.openUploadDialog,
+    closeUploadDialog: state.closeUploadDialog,
+    createFolderDialog: state.createFolderDialog,
+    openCreateFolderDialog: state.openCreateFolderDialog,
+    closeCreateFolderDialog: state.closeCreateFolderDialog,
+    deleteDialog: state.deleteDialog,
+    setDeleteDialog: state.setDeleteDialog,
+    openDeleteDialog: state.openDeleteDialog,
+    closeDeleteDialog: state.closeDeleteDialog,
+    deleteAllFilesDialog: state.deleteAllFilesDialog,
+    setDeleteAllFilesDialog: state.setDeleteAllFilesDialog,
+    openDeleteAllFilesDialog: state.openDeleteAllFilesDialog,
+    closeDeleteAllFilesDialog: state.closeDeleteAllFilesDialog,
+    showActionsDropdown: state.showActionsDropdown,
+    setShowActionsDropdown: state.setShowActionsDropdown,
+    expandedFolders: state.expandedFolders,
+    setExpandedFolders: state.setExpandedFolders,
+    expandFoldersForFile: state.expandFoldersForFile,
+    expandFoldersToLevel: state.expandFoldersToLevel,
+    toggleFolder: state.toggleFolder,
+    highlightedFile: state.highlightedFile,
+    setSelectedFile: state.setSelectedFile,
+    setFileContent: state.setFileContent,
+    setLoadingFileContent: state.setLoadingFileContent,
+    setShowFileContent: state.setShowFileContent,
+    fetchFiles: state.fetchFiles,
+    setActiveFolder: state.setActiveFolder,
+    setBinaryFileData: state.setBinaryFileData,
+    needsRefresh: state.needsRefresh,
+    setNeedsRefresh: state.setNeedsRefresh,
+  })))
 
   const fetchCapabilities = useCapabilitiesStore(s => s.fetchCapabilities)
 

--- a/frontend/src/components/workflow/WorkflowLayout.tsx
+++ b/frontend/src/components/workflow/WorkflowLayout.tsx
@@ -859,9 +859,11 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   }, [])
 
   // Get active workflow preset (file-backed manifests, not DB presets)
-  const getActivePreset = useGlobalPresetStore(state => state.getActivePreset)
   const activePresetId = useGlobalPresetStore(state => state.activePresetIds.workflow)
-  const activeWorkflowPreset = getActivePreset('workflow')
+  const activeWorkflowPreset = useGlobalPresetStore(state => {
+    const presetId = state.activePresetIds.workflow
+    return presetId ? state.workflowPresets.find(preset => preset.id === presetId) ?? null : null
+  })
   const activeWorkflowWorkspacePath = activeWorkflowPreset?.selectedFolder?.filepath ?? null
   const showResumeHint = useChatStore(state => {
     const tabId = state.activeTabId

--- a/frontend/src/components/workflow/WorkflowLayout.tsx
+++ b/frontend/src/components/workflow/WorkflowLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback, useRef, useEffect, forwardRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { PanelRightOpen } from 'lucide-react'
 import { WorkflowCanvas, type WorkflowCanvasRef } from './canvas'
 import { useGlobalPresetStore } from '../../stores/useGlobalPresetStore'
@@ -681,7 +682,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   onCreatePlan,
   onNewChat
 }) => {
-  const { selectedModeCategory } = useModeStore()
+  const selectedModeCategory = useModeStore(state => state.selectedModeCategory)
   // Narrow selectors: bare useChatStore() re-renders on every store update (10x/sec with 2 parallel sessions)
   const currentWorkflowPhase = useChatStore(state => state.currentWorkflowPhase)
   const setCurrentWorkflowPhase = useChatStore(state => state.setCurrentWorkflowPhase)
@@ -781,7 +782,10 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   const setStepOverride = useWorkflowStore(state => state.setStepOverride)
   const selectedGroupIds = useWorkflowStore(state => state.selectedGroupIds)
   const variablesManifest = useWorkflowStore(state => state.variablesManifest)
-  const { fetchFiles, setExpandedFolders } = useWorkspaceStore()
+  const { fetchFiles, setExpandedFolders } = useWorkspaceStore(useShallow(state => ({
+    fetchFiles: state.fetchFiles,
+    setExpandedFolders: state.setExpandedFolders,
+  })))
   // Subscribe to workspace minimized state so we can skip fetches when panel is hidden
   const workspaceMinimized = useAppStore(state => state.workspaceMinimized)
   const setWorkspaceMinimized = useAppStore(state => state.setWorkspaceMinimized)
@@ -855,7 +859,7 @@ export const WorkflowLayout: React.FC<WorkflowLayoutProps> = ({
   }, [])
 
   // Get active workflow preset (file-backed manifests, not DB presets)
-  const { getActivePreset } = useGlobalPresetStore()
+  const getActivePreset = useGlobalPresetStore(state => state.getActivePreset)
   const activePresetId = useGlobalPresetStore(state => state.activePresetIds.workflow)
   const activeWorkflowPreset = getActivePreset('workflow')
   const activeWorkflowWorkspacePath = activeWorkflowPreset?.selectedFolder?.filepath ?? null

--- a/frontend/src/stores/useGlobalPresetStore.ts
+++ b/frontend/src/stores/useGlobalPresetStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { useShallow } from 'zustand/react/shallow'
 import { agentApi, workflowManifestApi } from '../services/api'
 import type { PlannerFile, PresetLLMConfig } from '../services/api-types'
 import type { CustomPreset, PredefinedPreset } from '../types/preset'
@@ -705,8 +706,7 @@ export const useGlobalPresetStore = create<GlobalPresetState>()(
 
 // Export convenience hooks for specific functionality
 export const usePresetApplication = () => {
-  const store = useGlobalPresetStore()
-  return {
+  return useGlobalPresetStore(useShallow(store => ({
     applyPreset: store.applyPreset,
     clearActivePreset: store.clearActivePreset,
     getActivePreset: store.getActivePreset,
@@ -717,29 +717,27 @@ export const usePresetApplication = () => {
     currentPresetTools: store.currentPresetTools,
     activePresetIds: store.activePresetIds,
     workflowPresets: store.workflowPresets,
-  }
+  })))
 }
 
 export const usePresetManagement = () => {
-  const store = useGlobalPresetStore()
-  return {
+  return useGlobalPresetStore(useShallow(store => ({
     workflowPresets: store.workflowPresets,
     loading: store.loading,
     error: store.error,
     refreshPresets: store.refreshPresets,
     savePreset: store.savePreset,
     duplicatePreset: store.duplicatePreset,
-  }
+  })))
 }
 
 export const usePresetState = () => {
-  const store = useGlobalPresetStore()
-  return {
+  return useGlobalPresetStore(useShallow(store => ({
     currentPresetServers: store.currentPresetServers,
     selectedPresetFolder: store.selectedPresetFolder,
     currentQuery: store.currentQuery,
     setCurrentPresetServers: store.setCurrentPresetServers,
     setSelectedPresetFolder: store.setSelectedPresetFolder,
-    setCurrentQuery: store.setCurrentQuery
-  }
+    setCurrentQuery: store.setCurrentQuery,
+  })))
 }


### PR DESCRIPTION
## Summary
- replace whole-store subscriptions in App, Workspace, ChatInput, ChatTabs, ModePresetBar, and WorkflowLayout
- use shallow selectors for grouped state/actions so unrelated streaming and runtime updates do not rerender root surfaces
- fix global-preset convenience hooks to select their declared fields instead of subscribing to the complete store

## Verification
- `npm test -- --run` (17 files, 87 tests)
- `npm run build` (997.07 kB eager gzip, below 1 MB hard budget)
- repository pre-commit checks, agent/workspace builds, and Electron directory build

## Tracking
Partial P1 implementation for #138. This PR is stacked on #147.