### PR TITLE
Virtualize large file trees and bound report caches

### DIFF
--- a/frontend/src/components/Workspace.tsx
+++ b/frontend/src/components/Workspace.tsx
@@ -2153,6 +2153,7 @@ export default function Workspace({
                 onToggleFileSelection={toggleFileSelection}
                 onSelectFileAndEnterSelectionMode={selectFileAndEnterSelectionMode}
                 forceExpandFolders={!!searchQuery.trim()}
+                scrollContainerRef={workspaceScrollRef}
               />
 
               {/* Refresh from server when local search finds nothing */}

--- a/frontend/src/components/workflow/ReportViewer.tsx
+++ b/frontend/src/components/workflow/ReportViewer.tsx
@@ -23,6 +23,7 @@ import { agentApi, workspaceApi } from '../../services/api'
 import { useReportFilePreviewStore } from '../../stores/useReportFilePreviewStore'
 import { useChatStore } from '../../stores/useChatStore'
 import { useRunningWorkflowsStore } from '../../stores/useRunningWorkflowsStore'
+import { createBoundedCache } from '../../utils/boundedCache'
 import {
   applyWidgetFilter,
   evaluateShowIf,
@@ -129,7 +130,7 @@ type ReportViewUiState = {
   tabsBySection: Record<string, string>
 }
 
-const reportViewUiStateCache = new Map<string, ReportViewUiState>()
+const reportViewUiStateCache = createBoundedCache<string, ReportViewUiState>(24)
 
 function reportViewUiStateKey(workspacePath: string, selectedRunFolder?: string | null): string {
   return selectedRunFolder ? `${workspacePath}::run:${selectedRunFolder}` : workspacePath
@@ -521,7 +522,7 @@ interface ReportDataSnapshot {
   sources: SourceCache
 }
 
-const reportDataCache = new Map<string, ReportDataSnapshot>()
+const reportDataCache = createBoundedCache<string, ReportDataSnapshot>(8)
 const reportDataPromises = new Map<string, Promise<ReportDataSnapshot>>()
 
 // Workflow runs write the data reports read (db/db.sqlite + artifacts), so a

--- a/frontend/src/components/workflow/ReportViewer.tsx
+++ b/frontend/src/components/workflow/ReportViewer.tsx
@@ -146,7 +146,10 @@ function getReportViewUiState(key: string): ReportViewUiState {
 
 function setReportViewScrollTop(key: string, scrollTop: number): void {
   const state = getReportViewUiState(key)
-  state.scrollTop = Math.max(0, scrollTop)
+  reportViewUiStateCache.set(key, {
+    ...state,
+    scrollTop: Math.max(0, scrollTop),
+  })
 }
 
 function reportSectionTabStateKey(section: ReportSection, sectionIndex: number): string {
@@ -160,7 +163,13 @@ function getReportSectionTabKey(viewStateKey: string, sectionStateKey: string): 
 
 function setReportSectionTabKey(viewStateKey: string, sectionStateKey: string, tabKey: string): void {
   const state = getReportViewUiState(viewStateKey)
-  state.tabsBySection[sectionStateKey] = tabKey
+  reportViewUiStateCache.set(viewStateKey, {
+    ...state,
+    tabsBySection: {
+      ...state.tabsBySection,
+      [sectionStateKey]: tabKey,
+    },
+  })
 }
 
 function renderReportElementToSvg(reportElement: HTMLElement): string {

--- a/frontend/src/components/workspace/PlannerFileList.test.ts
+++ b/frontend/src/components/workspace/PlannerFileList.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { PlannerFile } from '../../services/api-types'
+import {
+  flattenVisiblePlannerFiles,
+  WORKSPACE_SCROLL_TO_FILE_EVENT,
+} from '../../utils/plannerFileTree'
+
+const file = (filepath: string, type: 'file' | 'folder' = 'file', children?: PlannerFile[]): PlannerFile => ({
+  filepath,
+  type,
+  children,
+})
+
+describe('flattenVisiblePlannerFiles', () => {
+  it('uses a stable event name for virtual row navigation', () => {
+    expect(WORKSPACE_SCROLL_TO_FILE_EVENT).toBe('workspace-scroll-to-file')
+  })
+
+  it('sorts folders before files without mutating backend arrays', () => {
+    const children = [file('root/z.txt'), file('root/a', 'folder')]
+    const files = [file('z.txt'), file('root', 'folder', children), file('a.txt')]
+
+    const rows = flattenVisiblePlannerFiles(files, new Set(['root']), false)
+
+    expect(rows.map(row => [row.file.filepath, row.depth])).toEqual([
+      ['root', 0],
+      ['root/a', 1],
+      ['root/z.txt', 1],
+      ['a.txt', 0],
+      ['z.txt', 0],
+    ])
+    expect(files.map(item => item.filepath)).toEqual(['z.txt', 'root', 'a.txt'])
+    expect(children.map(item => item.filepath)).toEqual(['root/z.txt', 'root/a'])
+  })
+
+  it('only includes descendants of expanded folders', () => {
+    const files = [file('root', 'folder', [file('root/child.txt')])]
+
+    expect(flattenVisiblePlannerFiles(files, new Set(), false)).toHaveLength(1)
+    expect(flattenVisiblePlannerFiles(files, new Set(), true)).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/workspace/PlannerFileList.tsx
+++ b/frontend/src/components/workspace/PlannerFileList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { FileText, Folder, AlertCircle, Loader2, ChevronRight, ChevronDown, Trash2, MessageSquare, Upload, Plus, Image, MoreHorizontal, Move, Download, Archive, CheckSquare, Edit2, Link, Check } from 'lucide-react'
 import type { PlannerFile } from '../../services/api-types'
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '../ui/tooltip'
@@ -140,6 +140,26 @@ export default function PlannerFileList({
       container.removeEventListener('scroll', scheduleViewportUpdate)
     }
   }, [scrollContainerRef])
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef?.current
+    const list = listRef.current
+    if (!container || !list) return
+
+    const containerTop = container.getBoundingClientRect().top
+    const next = {
+      scrollTop: container.scrollTop,
+      height: container.clientHeight,
+      listTop: list.getBoundingClientRect().top - containerTop + container.scrollTop,
+    }
+    setViewport(current => (
+      current.scrollTop === next.scrollTop &&
+      current.height === next.height &&
+      current.listTop === next.listTop
+        ? current
+        : next
+    ))
+  }, [loading, scrollContainerRef, visibleRows.length])
 
   useEffect(() => {
     const container = scrollContainerRef?.current

--- a/frontend/src/components/workspace/PlannerFileList.tsx
+++ b/frontend/src/components/workspace/PlannerFileList.tsx
@@ -609,7 +609,7 @@ export default function PlannerFileList({
           return (
             <div
               key={row.file.filepath}
-              className="absolute inset-x-0"
+              className="absolute inset-x-0 hover:z-50 focus-within:z-50"
               style={{ height: FILE_ROW_HEIGHT, transform: `translateY(${absoluteIndex * FILE_ROW_HEIGHT}px)` }}
             >
               {renderFileItem(row.file, row.depth)}

--- a/frontend/src/components/workspace/PlannerFileList.tsx
+++ b/frontend/src/components/workspace/PlannerFileList.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { FileText, Folder, AlertCircle, Loader2, ChevronRight, ChevronDown, Trash2, MessageSquare, Upload, Plus, Image, MoreHorizontal, Move, Download, Archive, CheckSquare, Edit2, Link, Check } from 'lucide-react'
 import type { PlannerFile } from '../../services/api-types'
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '../ui/tooltip'
 import { useWorkspaceStore } from '../../stores/useWorkspaceStore'
 import { useAuthStore } from '../../stores/useAuthStore'
 import { copyToClipboard } from '../../utils/textUtils'
+import {
+  flattenVisiblePlannerFiles,
+  WORKSPACE_SCROLL_TO_FILE_EVENT,
+  type WorkspaceScrollToFileDetail,
+} from '../../utils/plannerFileTree'
 
 interface PlannerFileListProps {
   files: PlannerFile[]
@@ -40,7 +45,12 @@ interface PlannerFileListProps {
   onToggleFileSelection?: (file: PlannerFile) => void
   onSelectFileAndEnterSelectionMode?: (file: PlannerFile) => void
   forceExpandFolders?: boolean
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
 }
+
+const VIRTUALIZE_FILE_COUNT = 200
+const FILE_ROW_HEIGHT = 40
+const FILE_ROW_OVERSCAN = 8
 
 export default function PlannerFileList({
   files,
@@ -76,10 +86,81 @@ export default function PlannerFileList({
   selectedFiles = new Set(),
   onToggleFileSelection,
   onSelectFileAndEnterSelectionMode,
-  forceExpandFolders = false
+  forceExpandFolders = false,
+  scrollContainerRef,
 }: PlannerFileListProps) {
-  const { scrollToFile } = useWorkspaceStore()
+  const scrollToFile = useWorkspaceStore(state => state.scrollToFile)
   const [copiedPath, setCopiedPath] = useState<string | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0, listTop: 0 })
+  const visibleRows = useMemo(
+    () => flattenVisiblePlannerFiles(files, expandedFolders, forceExpandFolders),
+    [expandedFolders, files, forceExpandFolders],
+  )
+
+  useEffect(() => {
+    const container = scrollContainerRef?.current
+    if (!container) return
+
+    const updateViewport = () => {
+      setViewport(current => {
+        const containerTop = container.getBoundingClientRect().top
+        const listTop = listRef.current
+          ? listRef.current.getBoundingClientRect().top - containerTop + container.scrollTop
+          : 0
+        const next = {
+          scrollTop: container.scrollTop,
+          height: container.clientHeight,
+          listTop,
+        }
+        return current.scrollTop === next.scrollTop &&
+          current.height === next.height &&
+          current.listTop === next.listTop
+          ? current
+          : next
+      })
+    }
+    let animationFrame: number | null = null
+    const scheduleViewportUpdate = () => {
+      if (animationFrame !== null) return
+      animationFrame = window.requestAnimationFrame(() => {
+        animationFrame = null
+        updateViewport()
+      })
+    }
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(scheduleViewportUpdate)
+    resizeObserver?.observe(container)
+    container.addEventListener('scroll', scheduleViewportUpdate, { passive: true })
+    updateViewport()
+    return () => {
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
+      resizeObserver?.disconnect()
+      container.removeEventListener('scroll', scheduleViewportUpdate)
+    }
+  }, [scrollContainerRef])
+
+  useEffect(() => {
+    const container = scrollContainerRef?.current
+    if (!container) return
+
+    const revealFile = (event: Event) => {
+      const filepath = (event as CustomEvent<WorkspaceScrollToFileDetail>).detail?.filepath
+      if (!filepath) return
+      const rowIndex = visibleRows.findIndex(row => (
+        row.file.filepath === filepath || row.file.originalFilepath === filepath
+      ))
+      if (rowIndex < 0) return
+
+      const rowTop = viewport.listTop + rowIndex * FILE_ROW_HEIGHT
+      const centeredTop = rowTop - Math.max(0, (container.clientHeight - FILE_ROW_HEIGHT) / 2)
+      container.scrollTo({ top: Math.max(0, centeredTop), behavior: 'smooth' })
+    }
+
+    window.addEventListener(WORKSPACE_SCROLL_TO_FILE_EVENT, revealFile)
+    return () => window.removeEventListener(WORKSPACE_SCROLL_TO_FILE_EVENT, revealFile)
+  }, [scrollContainerRef, viewport.listTop, visibleRows])
 
   // Render a single item (file or folder) with proper hierarchy
   const renderFileItem = (file: PlannerFile, depth: number = 0) => {
@@ -95,10 +176,10 @@ export default function PlannerFileList({
     const isSelected = selectedFiles.has(file.filepath)
 
     return (
-      <div key={file.filepath} className="select-none">
+      <div key={file.filepath} className="h-10 select-none">
         <div
           className={`
-            flex items-center gap-2 p-2 rounded-md transition-colors
+            flex h-9 items-center gap-2 p-2 rounded-md transition-colors
             ${isSelectionMode ? 'cursor-default' : isClickable ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800' : 'cursor-default'}
             ${isHighlighted ? 'bg-blue-100 dark:bg-blue-900/30 border border-blue-300 dark:border-blue-700' : ''}
             ${isInContext ? 'bg-green-50 dark:bg-green-900/20 border-l-2 border-green-500' : ''}
@@ -465,23 +546,6 @@ export default function PlannerFileList({
           </div>
         </div>
 
-        {/* Render children if folder is expanded */}
-        {file.type === 'folder' && isExpanded && file.children && (
-          <div>
-            {file.children
-              .sort((a, b) => {
-                // If both are folders or both are files, sort alphabetically
-                if (a.type === b.type) {
-                  return a.filepath.localeCompare(b.filepath)
-                }
-                // Folders come first
-                if (a.type === 'folder') return -1
-                if (b.type === 'folder') return 1
-                return 0
-              })
-              .map(child => renderFileItem(child, depth + 1))}
-          </div>
-        )}
       </div>
     )
   }
@@ -519,22 +583,39 @@ export default function PlannerFileList({
     )
   }
 
-  // Sort files to show folders first, then files
-  const sortedFiles = [...files].sort((a, b) => {
-    // If both are folders or both are files, sort alphabetically
-    if (a.type === b.type) {
-      return a.filepath.localeCompare(b.filepath)
-    }
-    // Folders come first
-    if (a.type === 'folder') return -1
-    if (b.type === 'folder') return 1
-    return 0
-  })
+  const shouldVirtualize = visibleRows.length >= VIRTUALIZE_FILE_COUNT && viewport.height > 0
+  const localScrollTop = Math.max(0, viewport.scrollTop - viewport.listTop)
+  const firstVisibleIndex = shouldVirtualize
+    ? Math.max(0, Math.floor(localScrollTop / FILE_ROW_HEIGHT) - FILE_ROW_OVERSCAN)
+    : 0
+  const lastVisibleIndex = shouldVirtualize
+    ? Math.min(
+      visibleRows.length,
+      Math.ceil((localScrollTop + viewport.height) / FILE_ROW_HEIGHT) + FILE_ROW_OVERSCAN,
+    )
+    : visibleRows.length
+  const renderedRows = visibleRows.slice(firstVisibleIndex, lastVisibleIndex)
 
   return (
     <TooltipProvider>
-      <div className="space-y-1">
-        {sortedFiles.map(file => renderFileItem(file))}
+      <div
+        ref={listRef}
+        className={shouldVirtualize ? 'relative' : ''}
+        style={shouldVirtualize ? { height: visibleRows.length * FILE_ROW_HEIGHT } : undefined}
+      >
+        {renderedRows.map((row, renderedIndex) => {
+          if (!shouldVirtualize) return renderFileItem(row.file, row.depth)
+          const absoluteIndex = firstVisibleIndex + renderedIndex
+          return (
+            <div
+              key={row.file.filepath}
+              className="absolute inset-x-0"
+              style={{ height: FILE_ROW_HEIGHT, transform: `translateY(${absoluteIndex * FILE_ROW_HEIGHT}px)` }}
+            >
+              {renderFileItem(row.file, row.depth)}
+            </div>
+          )
+        })}
       </div>
     </TooltipProvider>
   )

--- a/frontend/src/stores/useWorkspaceStore.ts
+++ b/frontend/src/stores/useWorkspaceStore.ts
@@ -4,6 +4,10 @@ import { agentApi } from '../services/api'
 import { extractFolderPaths, processHierarchicalFiles } from '../utils/fileUtils'
 import { getTypedEventData } from '../generated/event-types'
 import type { WorkspaceFileOperationEvent } from '../generated/events-bridge'
+import {
+  WORKSPACE_SCROLL_TO_FILE_EVENT,
+  type WorkspaceScrollToFileDetail,
+} from '../utils/plannerFileTree'
 
 interface WorkspaceState {
   // File Management
@@ -1374,7 +1378,17 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           // it without a folder param fetches ALL files from root, replacing the
           // workflow-scoped tree. The file will appear after the next debounced fetch.
           
-          // Use a small delay to ensure DOM is updated
+          // Virtual rows do not exist in the DOM until their parent list scrolls
+          // them into view. Expand ancestors first, then ask the list to reveal it.
+          get().expandFoldersForFile(filepath)
+          setTimeout(() => {
+            window.dispatchEvent(new CustomEvent<WorkspaceScrollToFileDetail>(
+              WORKSPACE_SCROLL_TO_FILE_EVENT,
+              { detail: { filepath } },
+            ))
+          }, 50)
+
+          // Small non-virtual lists still use the native DOM scroll path.
           setTimeout(() => {
             // Find the file element and scroll to it
             const fileElement = document.querySelector(`[data-filepath="${filepath}"]`)

--- a/frontend/src/utils/boundedCache.test.ts
+++ b/frontend/src/utils/boundedCache.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { createBoundedCache } from './boundedCache'
+
+describe('createBoundedCache', () => {
+  it('evicts the least recently used entry', () => {
+    const cache = createBoundedCache<string, number>(2)
+    cache.set('first', 1)
+    cache.set('second', 2)
+    expect(cache.get('first')).toBe(1)
+
+    cache.set('third', 3)
+
+    expect(cache.get('second')).toBeUndefined()
+    expect(cache.get('first')).toBe(1)
+    expect(cache.get('third')).toBe(3)
+    expect(cache.size()).toBe(2)
+  })
+
+  it('replaces values without growing', () => {
+    const cache = createBoundedCache<string, number>(1)
+    cache.set('key', 1)
+    cache.set('key', 2)
+
+    expect(cache.get('key')).toBe(2)
+    expect(cache.size()).toBe(1)
+  })
+})

--- a/frontend/src/utils/boundedCache.test.ts
+++ b/frontend/src/utils/boundedCache.test.ts
@@ -24,4 +24,16 @@ describe('createBoundedCache', () => {
     expect(cache.get('key')).toBe(2)
     expect(cache.size()).toBe(1)
   })
+
+  it('refreshes an intentionally undefined value', () => {
+    const cache = createBoundedCache<string, number | undefined>(2)
+    cache.set('undefined', undefined)
+    cache.set('second', 2)
+
+    expect(cache.get('undefined')).toBeUndefined()
+    cache.set('third', 3)
+
+    expect(cache.get('second')).toBeUndefined()
+    expect(cache.size()).toBe(2)
+  })
 })

--- a/frontend/src/utils/boundedCache.ts
+++ b/frontend/src/utils/boundedCache.ts
@@ -12,19 +12,19 @@ export function createBoundedCache<K, V>(limit: number): BoundedCache<K, V> {
 
   return {
     get: (key) => {
+      if (!entries.has(key)) return undefined
       const value = entries.get(key)
-      if (value === undefined) return undefined
       entries.delete(key)
-      entries.set(key, value)
+      entries.set(key, value as V)
       return value
     },
     set: (key, value) => {
       entries.delete(key)
       entries.set(key, value)
       while (entries.size > limit) {
-        const oldestKey = entries.keys().next().value as K | undefined
-        if (oldestKey === undefined) break
-        entries.delete(oldestKey)
+        const oldest = entries.keys().next()
+        if (oldest.done) break
+        entries.delete(oldest.value)
       }
     },
     delete: key => entries.delete(key),

--- a/frontend/src/utils/boundedCache.ts
+++ b/frontend/src/utils/boundedCache.ts
@@ -1,0 +1,33 @@
+export interface BoundedCache<K, V> {
+  get: (key: K) => V | undefined
+  set: (key: K, value: V) => void
+  delete: (key: K) => boolean
+  size: () => number
+}
+
+/** Small LRU cache for module-level UI data that must not grow for app life. */
+export function createBoundedCache<K, V>(limit: number): BoundedCache<K, V> {
+  if (!Number.isInteger(limit) || limit < 1) throw new Error('Cache limit must be a positive integer')
+  const entries = new Map<K, V>()
+
+  return {
+    get: (key) => {
+      const value = entries.get(key)
+      if (value === undefined) return undefined
+      entries.delete(key)
+      entries.set(key, value)
+      return value
+    },
+    set: (key, value) => {
+      entries.delete(key)
+      entries.set(key, value)
+      while (entries.size > limit) {
+        const oldestKey = entries.keys().next().value as K | undefined
+        if (oldestKey === undefined) break
+        entries.delete(oldestKey)
+      }
+    },
+    delete: key => entries.delete(key),
+    size: () => entries.size,
+  }
+}

--- a/frontend/src/utils/plannerFileTree.ts
+++ b/frontend/src/utils/plannerFileTree.ts
@@ -1,0 +1,40 @@
+import type { PlannerFile } from '../services/api-types'
+
+export interface VisibleFileRow {
+  file: PlannerFile
+  depth: number
+}
+
+export const WORKSPACE_SCROLL_TO_FILE_EVENT = 'workspace-scroll-to-file'
+
+export interface WorkspaceScrollToFileDetail {
+  filepath: string
+}
+
+const sortPlannerFiles = (files: PlannerFile[]): PlannerFile[] => (
+  [...files].sort((left, right) => {
+    if (left.type === right.type) return left.filepath.localeCompare(right.filepath)
+    if (left.type === 'folder') return -1
+    if (right.type === 'folder') return 1
+    return 0
+  })
+)
+
+export const flattenVisiblePlannerFiles = (
+  files: PlannerFile[],
+  expandedFolders: Set<string>,
+  forceExpandFolders: boolean,
+): VisibleFileRow[] => {
+  const rows: VisibleFileRow[] = []
+  const append = (items: PlannerFile[], depth: number) => {
+    for (const file of sortPlannerFiles(items)) {
+      rows.push({ file, depth })
+      const expanded = forceExpandFolders || expandedFolders.has(file.filepath)
+      if (file.type === 'folder' && expanded && file.children?.length) {
+        append(file.children, depth + 1)
+      }
+    }
+  }
+  append(files, 0)
+  return rows
+}


### PR DESCRIPTION
## What changed

- Flatten and sort the visible workspace tree without mutating backend-owned child arrays.
- Virtualize file lists once 200 visible rows are reached, with requestAnimationFrame-throttled viewport tracking.
- Preserve deep file navigation by expanding ancestors and revealing off-screen virtual rows.
- Bound report UI-state and report-data caches with small LRU limits.

## Why

Large expanded workspaces rendered every row recursively and sorted child arrays during render. Report module caches also grew for the lifetime of the app. This closes the final implementation item from #138 while retaining current file navigation behavior.

## Validation

- `npm test -- --run`: 19 files, 92 tests passed.
- `npm run build`: passed.
- Eager production JavaScript: 992.88 kB gzip, below the 1,000 kB hard budget.
- Repository pre-commit checks: Go lint/build, workspace build, frontend build, and Electron directory build passed.

Stacked on #148. Tracks #138.