### PR TITLE
Enforce frontend performance contracts in CI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -57,12 +57,22 @@ jobs:
             frontend/package-lock.json
             desktop/package-lock.json
 
-      - name: Build Frontend Static Assets
+      - name: Install Frontend Dependencies
         run: |
           set -euo pipefail
           cd frontend
           npm ci
-          npm test -- --run
+
+      - name: Test Frontend Performance Contracts
+        run: |
+          set -euo pipefail
+          cd frontend
+          npm test
+
+      - name: Build Frontend Static Assets
+        run: |
+          set -euo pipefail
+          cd frontend
           npm run build
 
       - name: Copy Frontend Into Agent Static Directory
@@ -151,12 +161,22 @@ jobs:
             frontend/package-lock.json
             desktop/package-lock.json
 
-      - name: Build Frontend Static Assets
+      - name: Install Frontend Dependencies
         run: |
           set -euo pipefail
           cd frontend
           npm ci
-          npm test -- --run
+
+      - name: Test Frontend Performance Contracts
+        run: |
+          set -euo pipefail
+          cd frontend
+          npm test
+
+      - name: Build Frontend Static Assets
+        run: |
+          set -euo pipefail
+          cd frontend
           npm run build
 
       - name: Copy Frontend Into Agent Static Directory

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,6 +62,7 @@ jobs:
           set -euo pipefail
           cd frontend
           npm ci
+          npm test -- --run
           npm run build
 
       - name: Copy Frontend Into Agent Static Directory
@@ -155,6 +156,7 @@ jobs:
           set -euo pipefail
           cd frontend
           npm ci
+          npm test -- --run
           npm run build
 
       - name: Copy Frontend Into Agent Static Directory

--- a/frontend/src/services/requestCoalescer.test.ts
+++ b/frontend/src/services/requestCoalescer.test.ts
@@ -7,13 +7,13 @@ describe('createRequestCoalescer', () => {
     let resolve!: (value: string) => void
     const request = vi.fn(() => new Promise<string>(done => { resolve = done }))
 
-    const first = coalesce('terminals:all', request)
-    const second = coalesce('terminals:all', request)
-    expect(first).toBe(second)
+    const requests = Array.from({ length: 20 }, () => coalesce('terminals:all', request))
+    const first = requests[0]
+    expect(requests.every(pending => pending === first)).toBe(true)
     expect(request).toHaveBeenCalledTimes(1)
 
     resolve('ok')
-    await expect(first).resolves.toBe('ok')
+    await expect(Promise.all(requests)).resolves.toEqual(Array(20).fill('ok'))
   })
 
   it('does not combine different request keys', async () => {

--- a/frontend/src/stores/useChatStore.hydration.test.ts
+++ b/frontend/src/stores/useChatStore.hydration.test.ts
@@ -42,7 +42,7 @@ describe('useChatStore hydration bootstrap', () => {
     })
   })
 
-  it('does not persist streaming chunks and coalesces durable changes', async () => {
+  it('does not persist 1,000 streaming chunks and coalesces durable changes', async () => {
     vi.useFakeTimers()
     const storage = createMemoryStorage()
     const setItem = vi.spyOn(storage, 'setItem')
@@ -53,7 +53,7 @@ describe('useChatStore hydration bootstrap', () => {
     vi.advanceTimersByTime(250)
     setItem.mockClear()
 
-    for (let index = 1; index <= 20; index += 1) {
+    for (let index = 1; index <= 1_000; index += 1) {
       chatStore.useChatStore.getState().appendStreamingChunk('session-1', index, `chunk-${index}`)
     }
     vi.advanceTimersByTime(250)
@@ -65,6 +65,38 @@ describe('useChatStore hydration bootstrap', () => {
     vi.advanceTimersByTime(250)
 
     expect(setItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces repeated workflow switches into one durable write', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-13T00:00:00Z'))
+    const storage = createMemoryStorage()
+    const setItem = vi.spyOn(storage, 'setItem')
+    vi.stubGlobal('localStorage', storage)
+    const chatStore = await import('./useChatStore')
+    await chatStore.waitForChatStoreHydration()
+
+    const firstTab = await chatStore.useChatStore.getState().createChatTab('First workflow', {
+      mode: 'workflow',
+      phaseId: 'workflow-builder',
+      presetQueryId: 'workflow-one',
+    })
+    vi.setSystemTime(new Date('2026-07-13T00:00:00.001Z'))
+    const secondTab = await chatStore.useChatStore.getState().createChatTab('Second workflow', {
+      mode: 'workflow',
+      phaseId: 'workflow-builder',
+      presetQueryId: 'workflow-two',
+    })
+    vi.advanceTimersByTime(250)
+    setItem.mockClear()
+
+    for (let index = 0; index < 100; index += 1) {
+      chatStore.useChatStore.getState().switchTab(index % 2 === 0 ? firstTab : secondTab)
+    }
+    vi.advanceTimersByTime(250)
+
+    expect(setItem).toHaveBeenCalledTimes(1)
+    expect(chatStore.useChatStore.getState().activeTabId).toBe(secondTab)
   })
 
   it('restores the existing persisted chat-store envelope', async () => {

--- a/frontend/src/utils/narrowStoreSubscriptions.test.ts
+++ b/frontend/src/utils/narrowStoreSubscriptions.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const CRITICAL_COMPONENTS = [
+  'src/App.tsx',
+  'src/components/ChatInput.tsx',
+  'src/components/ChatTabs.tsx',
+  'src/components/ModePresetBar.tsx',
+  'src/components/Workspace.tsx',
+  'src/components/workflow/WorkflowLayout.tsx',
+]
+
+const PROTECTED_STORES = new Set([
+  'useAppStore',
+  'useChatStore',
+  'useGlobalPresetStore',
+  'useModeStore',
+  'useWorkspaceStore',
+])
+
+function bareStoreSubscriptions(filepath: string): string[] {
+  const sourceText = readFileSync(filepath, 'utf8')
+  const source = ts.createSourceFile(filepath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const findings: string[] = []
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      PROTECTED_STORES.has(node.expression.text) &&
+      node.arguments.length === 0
+    ) {
+      const position = source.getLineAndCharacterOfPosition(node.getStart(source))
+      findings.push(`${filepath}:${position.line + 1} ${node.expression.text}()`)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(source)
+  return findings
+}
+
+describe('critical frontend store subscriptions', () => {
+  it('never subscribes performance-critical roots to an entire Zustand store', () => {
+    const findings = CRITICAL_COMPONENTS.flatMap(bareStoreSubscriptions)
+    expect(findings, findings.join('\n')).toEqual([])
+  })
+})

--- a/frontend/src/utils/terminalSnapshotIdentity.test.ts
+++ b/frontend/src/utils/terminalSnapshotIdentity.test.ts
@@ -36,6 +36,17 @@ describe('reconcileTerminalSnapshots', () => {
     expect(result[0]).toBe(current[0])
   })
 
+  it('does not churn state for 20 unchanged active terminals', () => {
+    const current = Array.from({ length: 20 }, (_, index) => terminal(`terminal-${index}`))
+    const incoming = current.map(item => ({
+      ...item,
+      rows: [...item.rows],
+      status: { ...item.status },
+    }))
+
+    expect(reconcileTerminalSnapshots(current, incoming)).toBe(current)
+  })
+
   it('ignores backend ordering changes when the terminal set is unchanged', () => {
     const current = [terminal('one'), terminal('two')]
     const incoming = [{ ...current[1] }, { ...current[0] }]


### PR DESCRIPTION
## What changed

- Run the frontend Vitest suite in both DMG artifact jobs before the production build.
- Exercise 1,000 streamed chunks and assert they cause no durable storage writes.
- Exercise 100 rapid workflow switches and assert persistence coalesces to one write.
- Exercise 20 unchanged active terminal snapshots and assert React-facing state identity is preserved.
- Exercise 20 concurrent identical runtime reads and assert only one backend request is made.

## Why

Issue #138 required a no-regression benchmark for startup, switching, terminal population, streaming, and network behavior. Deterministic operation-count contracts are stable in CI and directly guard the regressions fixed by the preceding PRs, unlike wall-clock thresholds that vary across GitHub runners.

## Validation

- `npm test -- --run`: 19 files, 94 tests passed.
- Repository pre-commit checks passed, including frontend, Go, workspace, and Electron builds.

Stacked on #149. Completes the remaining test/CI acceptance work for #138.