### PR TITLE
Cost accounting: add authoritative SQLite event ledger

### DIFF
--- a/agent_go/cmd/server/cost_routes.go
+++ b/agent_go/cmd/server/cost_routes.go
@@ -179,7 +179,10 @@ func (o *costObserver) recordLegacyTokenUsage(event *unifiedevents.AgentEvent, t
 	entry.EffectiveProvider = provider
 	entry.EffectiveModelID = effectiveModel
 	entry.TurnCount = 1
-	entry.LLMCallCount = costFirstPositive(toInt(tu.GenerationInfo["llm_call_count"]), 1)
+	entry.LLMCallCount = toInt(tu.GenerationInfo["llm_call_count"])
+	if entry.LLMCallCount == 0 && (tu.PromptTokens > 0 || tu.CompletionTokens > 0 || tu.ReasoningTokens > 0 || totalCostUSD > 0) {
+		entry.LLMCallCount = 1
+	}
 	entry.PromptTokens = tu.PromptTokens
 	entry.CompletionTokens = tu.CompletionTokens
 	entry.ReasoningTokens = tu.ReasoningTokens
@@ -236,7 +239,7 @@ func inferCostScope(agentMode, phaseID string) string {
 	case strings.Contains(strings.ToLower(agentMode), "workflow"):
 		return "builder"
 	default:
-		return "builder"
+		return "chat"
 	}
 }
 

--- a/agent_go/cmd/server/cost_routes.go
+++ b/agent_go/cmd/server/cost_routes.go
@@ -5,30 +5,63 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
+	"sync"
 
 	unifiedevents "github.com/manishiitg/mcpagent/events"
 
 	"mcp-agent-builder-go/agent_go/pkg/costledger"
 )
 
-// costObserver implements mcpagent's AgentEventListener. It listens for
-// token_usage events on every agent run (main or sub-agent) and appends one
-// entry per event to the global cost ledger. This is how the cost dashboard
-// gets populated — there is no per-session event persistence anymore.
+// costObserver persists immutable per-LLM-call events. The cumulative
+// token_usage event remains a compatibility fallback for older providers, but
+// is ignored once a per-call completion has been observed.
 type costObserver struct {
-	ledger    *costledger.Ledger
-	sessionID string
-	userID    string
-	agentMode string
+	ledger      *costledger.Ledger
+	sessionID   string
+	userID      string
+	agentMode   string
+	provider    string
+	modelID     string
+	workflowID  string
+	runID       string
+	executionID string
+	scope       string
+
+	mu         sync.Mutex
+	sawPerCall bool
 }
 
-func newCostObserver(ledger *costledger.Ledger, sessionID, userID, agentMode string) *costObserver {
-	return &costObserver{
+type costObserverOption func(*costObserver)
+
+func withCostModel(provider, modelID string) costObserverOption {
+	return func(o *costObserver) {
+		o.provider = strings.TrimSpace(provider)
+		o.modelID = strings.TrimSpace(modelID)
+	}
+}
+
+func withCostAttribution(scope, workflowID, runID, executionID string) costObserverOption {
+	return func(o *costObserver) {
+		o.scope = strings.TrimSpace(scope)
+		o.workflowID = strings.TrimSpace(workflowID)
+		o.runID = strings.TrimSpace(runID)
+		o.executionID = strings.TrimSpace(executionID)
+	}
+}
+
+func newCostObserver(ledger *costledger.Ledger, sessionID, userID, agentMode string, opts ...costObserverOption) *costObserver {
+	observer := &costObserver{
 		ledger:    ledger,
 		sessionID: sessionID,
 		userID:    userID,
 		agentMode: agentMode,
+		scope:     inferCostScope(agentMode, ""),
 	}
+	for _, opt := range opts {
+		opt(observer)
+	}
+	return observer
 }
 
 func (o *costObserver) Name() string { return "costObserver" }
@@ -37,51 +70,224 @@ func (o *costObserver) HandleEvent(_ context.Context, event *unifiedevents.Agent
 	if o == nil || o.ledger == nil || event == nil {
 		return nil
 	}
-	if event.Type != unifiedevents.TokenUsage {
-		return nil
+	switch event.Type {
+	case unifiedevents.LLMGenerationEnd:
+		generation, ok := event.Data.(*unifiedevents.LLMGenerationEndEvent)
+		if !ok || generation == nil {
+			return nil
+		}
+		o.mu.Lock()
+		o.sawPerCall = true
+		o.mu.Unlock()
+		o.recordLLMGeneration(event, generation)
+	case unifiedevents.TokenUsage:
+		o.mu.Lock()
+		sawPerCall := o.sawPerCall
+		o.mu.Unlock()
+		if sawPerCall {
+			return nil
+		}
+		tu, ok := event.Data.(*unifiedevents.TokenUsageEvent)
+		if !ok || tu == nil {
+			return nil
+		}
+		o.recordLegacyTokenUsage(event, tu)
 	}
-	tu, ok := event.Data.(*unifiedevents.TokenUsageEvent)
-	if !ok || tu == nil {
-		return nil
-	}
+	return nil
+}
 
+func (o *costObserver) recordLLMGeneration(event *unifiedevents.AgentEvent, generation *unifiedevents.LLMGenerationEndEvent) {
+	metadata := generation.Metadata
+	cacheRead, cacheWrite := extractCacheTokens(metadata)
+	effectiveModel, estimatedCost := extractCostAndEffectiveModel(metadata)
+	provider := costFirstNonEmpty(costStringValue(metadata["provider"]), o.provider)
+	modelID := o.modelID
+	if modelID == "" {
+		modelID = costStringValue(metadata["requested_model_id"])
+	}
+	totalCostUSD := costNumberValue(metadata["cost_usd"])
+	billingBasis := "provider_actual"
+	pricingSource := "provider"
+	if totalCostUSD <= 0 && estimatedCost > 0 {
+		totalCostUSD = estimatedCost
+		billingBasis = "token_estimate"
+		pricingSource = "model_registry"
+		if isSubscriptionCodingProvider(provider) {
+			billingBasis = "subscription_shadow"
+		}
+	}
+	if totalCostUSD <= 0 {
+		billingBasis = "unpriced"
+		pricingSource = ""
+	}
+	if effectiveModel == "" {
+		effectiveModel = modelID
+	}
+	entry := o.baseEntry(event)
+	entry.Provider = provider
+	entry.ModelID = modelID
+	entry.EffectiveProvider = provider
+	entry.EffectiveModelID = effectiveModel
+	entry.TurnCount = 1
+	entry.LLMCallCount = 1
+	entry.PromptTokens = generation.UsageMetrics.PromptTokens
+	entry.CompletionTokens = generation.UsageMetrics.CompletionTokens
+	entry.ReasoningTokens = generation.UsageMetrics.ReasoningTokens
+	entry.CacheReadTokens = costFirstPositive(cacheRead, generation.UsageMetrics.CacheTokens)
+	entry.CacheWriteTokens = cacheWrite
+	entry.TotalCostUSD = totalCostUSD
+	entry.BillingBasis = billingBasis
+	entry.PricingSource = pricingSource
+	o.append(entry)
+}
+
+func (o *costObserver) recordLegacyTokenUsage(event *unifiedevents.AgentEvent, tu *unifiedevents.TokenUsageEvent) {
 	cacheRead, cacheWrite := extractCacheTokens(tu.GenerationInfo)
 	effectiveModel, estimatedCost := extractCostAndEffectiveModel(tu.GenerationInfo)
-
-	// Provider-blessed cost wins over the adapter-side estimate; the
-	// estimate only fills in for CLIs whose JSON doesn't ship USD
-	// (codex / cursor) or for tmux paths.
-	totalCostUSD := tu.TotalCost
-	costSource := ""
-	if totalCostUSD > 0 {
-		costSource = "provider"
-	} else if estimatedCost > 0 {
+	provider := costFirstNonEmpty(tu.Provider, o.provider)
+	modelID := costFirstNonEmpty(tu.ModelID, o.modelID)
+	totalCostUSD := costNumberValue(tu.GenerationInfo["cost_usd"])
+	billingBasis := "provider_actual"
+	pricingSource := "provider"
+	if totalCostUSD <= 0 && estimatedCost > 0 {
 		totalCostUSD = estimatedCost
-		costSource = "estimated"
+		billingBasis = "token_estimate"
+		pricingSource = "model_registry"
+		if isSubscriptionCodingProvider(provider) {
+			billingBasis = "subscription_shadow"
+		}
+	} else if totalCostUSD <= 0 && tu.TotalCost > 0 {
+		// TotalCost on the cumulative event is generally computed from model
+		// metadata. It must not be labeled as a provider invoice.
+		totalCostUSD = tu.TotalCost
+		billingBasis = "token_estimate"
+		pricingSource = "agent_token_pricing"
+		if isSubscriptionCodingProvider(provider) {
+			billingBasis = "subscription_shadow"
+		}
 	}
+	if totalCostUSD <= 0 {
+		billingBasis = "unpriced"
+		pricingSource = ""
+	}
+	if effectiveModel == "" {
+		effectiveModel = modelID
+	}
+	entry := o.baseEntry(event)
+	entry.Provider = provider
+	entry.ModelID = modelID
+	entry.EffectiveProvider = provider
+	entry.EffectiveModelID = effectiveModel
+	entry.TurnCount = 1
+	entry.LLMCallCount = costFirstPositive(toInt(tu.GenerationInfo["llm_call_count"]), 1)
+	entry.PromptTokens = tu.PromptTokens
+	entry.CompletionTokens = tu.CompletionTokens
+	entry.ReasoningTokens = tu.ReasoningTokens
+	entry.CacheReadTokens = cacheRead
+	entry.CacheWriteTokens = cacheWrite
+	entry.TotalCostUSD = totalCostUSD
+	entry.BillingBasis = billingBasis
+	entry.PricingSource = pricingSource
+	o.append(entry)
+}
 
-	entry := costledger.Entry{
-		Timestamp:        event.Timestamp,
-		SessionID:        o.sessionID,
-		UserID:           o.userID,
-		AgentMode:        o.agentMode,
-		Component:        event.Component,
-		CorrelationID:    event.CorrelationID,
-		Provider:         tu.Provider,
-		ModelID:          tu.ModelID,
-		EffectiveModelID: effectiveModel,
-		PromptTokens:     tu.PromptTokens,
-		CompletionTokens: tu.CompletionTokens,
-		ReasoningTokens:  tu.ReasoningTokens,
-		CacheReadTokens:  cacheRead,
-		CacheWriteTokens: cacheWrite,
-		TotalCostUSD:     totalCostUSD,
-		CostUSDSource:    costSource,
+func (o *costObserver) baseEntry(event *unifiedevents.AgentEvent) costledger.Entry {
+	eventID := strings.TrimSpace(event.SpanID)
+	if eventID == "" {
+		eventID = strings.TrimSpace(event.CorrelationID)
 	}
+	storedEventID := ""
+	idempotencyKey := ""
+	if eventID != "" {
+		storedEventID = strings.Join([]string{o.sessionID, eventID}, ":")
+		idempotencyKey = storedEventID
+	}
+	return costledger.Entry{
+		EventID:        storedEventID,
+		IdempotencyKey: idempotencyKey,
+		Timestamp:      event.Timestamp,
+		SessionID:      o.sessionID,
+		UserID:         o.userID,
+		WorkflowID:     o.workflowID,
+		RunID:          o.runID,
+		ExecutionID:    o.executionID,
+		Scope:          o.scope,
+		AgentMode:      o.agentMode,
+		Component:      event.Component,
+		CorrelationID:  event.CorrelationID,
+	}
+}
+
+func (o *costObserver) append(entry costledger.Entry) {
 	if err := o.ledger.Append(entry); err != nil {
 		log.Printf("[COST_LEDGER] Failed to append entry: %v", err)
 	}
-	return nil
+}
+
+func inferCostScope(agentMode, phaseID string) string {
+	phase := strings.ToLower(strings.TrimSpace(phaseID))
+	switch {
+	case strings.Contains(phase, "post_run_monitor"), strings.Contains(phase, "pulse"):
+		return "pulse"
+	case strings.Contains(phase, "evaluation"), strings.Contains(phase, "eval"):
+		return "evaluation"
+	case strings.Contains(strings.ToLower(agentMode), "chief"):
+		return "chief_of_staff"
+	case strings.Contains(strings.ToLower(agentMode), "workflow"):
+		return "builder"
+	default:
+		return "builder"
+	}
+}
+
+func isSubscriptionCodingProvider(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude-code", "claude_code", "codex-cli", "codex_cli", "cursor-cli", "cursor_cli":
+		return true
+	default:
+		return false
+	}
+}
+
+func costStringValue(v interface{}) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func costNumberValue(v interface{}) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case json.Number:
+		value, _ := n.Float64()
+		return value
+	default:
+		return 0
+	}
+}
+
+func costFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func costFirstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 // extractCostAndEffectiveModel pulls the unified cost+model fields the

--- a/agent_go/cmd/server/cost_routes_test.go
+++ b/agent_go/cmd/server/cost_routes_test.go
@@ -198,6 +198,32 @@ func TestCostObserverHandleEventRecordsTokenUsage(t *testing.T) {
 	}
 }
 
+func TestCostObserverDoesNotInventCallForEmptyFallbackEvent(t *testing.T) {
+	ledger, err := costledger.NewSQLiteLedger(t.TempDir() + "/costs.sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ledger.Close()
+	obs := newCostObserver(ledger, "empty-turn", "user-1", "chat")
+	if err := obs.HandleEvent(context.Background(), &unifiedevents.AgentEvent{
+		Type:      unifiedevents.TokenUsage,
+		Timestamp: time.Now().UTC(),
+		Data:      &unifiedevents.TokenUsageEvent{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, err := ledger.Summarize("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Total.CallCount != 0 || summary.Total.AccountingEventCount != 1 {
+		t.Fatalf("empty fallback totals = %#v", summary.Total)
+	}
+	if inferCostScope("chat", "") != "chat" {
+		t.Fatal("plain chat was not attributed to chat scope")
+	}
+}
+
 func TestCostObserverMultiTurnAccumulation(t *testing.T) {
 	srv := costledger.NewTestServer(t)
 	defer srv.Close()

--- a/agent_go/cmd/server/cost_routes_test.go
+++ b/agent_go/cmd/server/cost_routes_test.go
@@ -234,6 +234,73 @@ func TestCostObserverMultiTurnAccumulation(t *testing.T) {
 	}
 }
 
+func TestCostObserverRecordsPerCallAndIgnoresCumulativeFallback(t *testing.T) {
+	ledger, err := costledger.NewSQLiteLedger(t.TempDir() + "/costs.sqlite")
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger() error = %v", err)
+	}
+	defer ledger.Close()
+	obs := newCostObserver(
+		ledger,
+		"sess-per-call",
+		"user-1",
+		"workflow_phase",
+		withCostModel("codex-cli", "auto"),
+		withCostAttribution("pulse", "Workflow/demo", "iteration-0/default", "exec-1"),
+	)
+
+	perCall := &unifiedevents.AgentEvent{
+		Type:      unifiedevents.LLMGenerationEnd,
+		Timestamp: time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC),
+		SpanID:    "span-call-1",
+		Component: "llm",
+		Data: &unifiedevents.LLMGenerationEndEvent{
+			UsageMetrics: unifiedevents.UsageMetrics{
+				PromptTokens: 120, CompletionTokens: 30, CacheTokens: 40,
+			},
+			BaseEventData: unifiedevents.BaseEventData{Metadata: map[string]interface{}{
+				"provider":                "codex-cli",
+				"codex_effective_model":   "gpt-5.6-sol",
+				"cost_usd_estimated":      0.12,
+				"cache_read_input_tokens": 40,
+			}},
+		},
+	}
+	if err := obs.HandleEvent(context.Background(), perCall); err != nil {
+		t.Fatalf("HandleEvent(per call) error = %v", err)
+	}
+	if err := obs.HandleEvent(context.Background(), &unifiedevents.AgentEvent{
+		Type:      unifiedevents.TokenUsage,
+		Timestamp: perCall.Timestamp.Add(time.Second),
+		SpanID:    "span-cumulative",
+		Data: &unifiedevents.TokenUsageEvent{
+			Provider: "codex-cli", ModelID: "auto", PromptTokens: 120,
+			CompletionTokens: 30, TotalCost: 0.12,
+			GenerationInfo: map[string]interface{}{"llm_call_count": 1},
+		},
+	}); err != nil {
+		t.Fatalf("HandleEvent(cumulative) error = %v", err)
+	}
+	// A duplicate observer delivery of the same event is also idempotent.
+	if err := obs.HandleEvent(context.Background(), perCall); err != nil {
+		t.Fatalf("HandleEvent(duplicate) error = %v", err)
+	}
+
+	summary, err := ledger.Summarize("", "")
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Total.CallCount != 1 || summary.Total.AccountingEventCount != 1 {
+		t.Fatalf("summary total = %#v, want one immutable call", summary.Total)
+	}
+	if summary.Total.SubscriptionShadowUSD != 0.12 {
+		t.Fatalf("SubscriptionShadowUSD = %v, want 0.12", summary.Total.SubscriptionShadowUSD)
+	}
+	if got := summary.ByModel["gpt-5.6-sol"]; got == nil || got.PromptTokens != 120 {
+		t.Fatalf("effective model aggregate = %#v", got)
+	}
+}
+
 func TestCostObserverNilSafety(t *testing.T) {
 	obs := newCostObserver(nil, "", "", "")
 	if err := obs.HandleEvent(context.Background(), nil); err != nil {

--- a/agent_go/cmd/server/delegation.go
+++ b/agent_go/cmd/server/delegation.go
@@ -271,7 +271,7 @@ func (api *StreamingAPI) executeDelegatedTask(ctx context.Context, parentReq Que
 			parentReq.AgentMode,
 			withCostModel(string(provider), modelID),
 			withCostAttribution(
-				"background_review",
+				inferCostScope(parentReq.AgentMode, parentReq.PhaseID),
 				parentReq.SelectedFolder,
 				"",
 				delegationID,

--- a/agent_go/cmd/server/delegation.go
+++ b/agent_go/cmd/server/delegation.go
@@ -264,7 +264,22 @@ func (api *StreamingAPI) executeDelegatedTask(ctx context.Context, parentReq Que
 		}
 		underlyingAgent.AddEventListener(subAgentObserver)
 		parentUserID, _ := ctx.Value(common.UserIDKey).(string)
-		underlyingAgent.AddEventListener(newCostObserver(api.costLedger, sessionID, parentUserID, parentReq.AgentMode))
+		subAgentCostObserver := newCostObserver(
+			api.costLedger,
+			sessionID,
+			parentUserID,
+			parentReq.AgentMode,
+			withCostModel(string(provider), modelID),
+			withCostAttribution(
+				"background_review",
+				parentReq.SelectedFolder,
+				"",
+				delegationID,
+			),
+		)
+		underlyingAgent.AddEventListener(subAgentCostObserver)
+		defer underlyingAgent.RemoveEventListener(subAgentObserver)
+		defer underlyingAgent.RemoveEventListener(subAgentCostObserver)
 		log.Printf("[DELEGATION] Added event observers for sub-agent at depth %d", currentDepth)
 
 		// Phase 6 explicit-pass: sub-agents inherit NO skills from the

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -1186,9 +1186,13 @@ func runServer(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to initialize cost event database: %v", err)
 	}
 	defer costLedger.Close()
+	costledger.SetDefaultLedger(costLedger)
+	defer costledger.SetDefaultLedger(nil)
 	legacyCostPath := filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.jsonl")
 	if report, migrateErr := costLedger.MigrateLegacyJSONL(legacyCostPath); migrateErr != nil {
-		log.Fatalf("Failed to migrate legacy cost ledger: %v", migrateErr)
+		// SQLite is already initialized and remains authoritative. A damaged or
+		// unreadable compatibility file must not make every future startup fail.
+		log.Printf("[COST_LEDGER] Legacy migration skipped after error: %v", migrateErr)
 	} else if report.Imported > 0 || report.Duplicates > 0 || report.Quarantined > 0 {
 		log.Printf("[COST_LEDGER] Legacy migration imported=%d duplicates=%d quarantined=%d",
 			report.Imported, report.Duplicates, report.Quarantined)
@@ -4936,6 +4940,9 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 				// Build template vars by reading current plan and variables from workspace
 				phaseRunFolder := "iteration-0"
+				if req.ExecutionOptions != nil && strings.TrimSpace(req.ExecutionOptions.SelectedRunFolder) != "" {
+					phaseRunFolder = strings.TrimSpace(req.ExecutionOptions.SelectedRunFolder)
+				}
 				workflowPhaseRunFolder = phaseRunFolder
 				var phaseEnabledGroupNames []string
 				if req.ExecutionOptions != nil {

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -291,7 +291,7 @@ type StreamingAPI struct {
 	// Operator-state store: bot connector configs + per-user encrypted secrets.
 	chatStore chathistory.Store
 
-	// Global append-only cost ledger — one line per token_usage event.
+	// Global immutable cost event repository (SQLite in production).
 	costLedger *costledger.Ledger
 
 	// In-memory inspector event store. Holds the rolling debug-event
@@ -1174,14 +1174,27 @@ func runServer(cmd *cobra.Command, args []string) {
 	log.Printf("📡 EventStore retention: max %d events per session", maxSessionEvents)
 
 	// Initialize the operator-state store (bot connector configs + user
-	// secrets) and the global cost ledger.
+	// secrets) and the authoritative global cost event database.
 	chatStore, err := chathistory.NewWorkspaceAPIStore(getWorkspaceAPIURL())
 	if err != nil {
 		log.Fatalf("Failed to initialize workspace API operator store: %v", err)
 	}
 	defer chatStore.Close()
-	costLedger := costledger.NewLedger(getWorkspaceAPIURL())
+	costDBPath := filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.sqlite")
+	costLedger, err := costledger.NewSQLiteLedger(costDBPath)
+	if err != nil {
+		log.Fatalf("Failed to initialize cost event database: %v", err)
+	}
+	defer costLedger.Close()
+	legacyCostPath := filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.jsonl")
+	if report, migrateErr := costLedger.MigrateLegacyJSONL(legacyCostPath); migrateErr != nil {
+		log.Fatalf("Failed to migrate legacy cost ledger: %v", migrateErr)
+	} else if report.Imported > 0 || report.Duplicates > 0 || report.Quarantined > 0 {
+		log.Printf("[COST_LEDGER] Legacy migration imported=%d duplicates=%d quarantined=%d",
+			report.Imported, report.Duplicates, report.Quarantined)
+	}
 	fmt.Printf("💾 Operator store: workspace API (%s)\n", getWorkspaceAPIURL())
+	fmt.Printf("💵 Cost events: SQLite (%s)\n", costDBPath)
 
 	notificationManager := services.GetNotificationManager()
 	if notificationManager != nil {
@@ -2856,7 +2869,8 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 	isWorkflowPhase := req.AgentMode == "workflow_phase"
 	workflowPhaseID := req.PhaseID
 	workflowPhaseFolder := "" // The preset's SelectedFolder — used to auto-grant write access in FolderGuard
-	_ = workflowPhaseFolder   // used later in the function
+	workflowPhaseRunFolder := ""
+	_ = workflowPhaseFolder // used later in the function
 	if isWorkflowPhase {
 		logfWithContext(queryLogCtx, "[WORKFLOW_PHASE] Phase chat mode detected: phase=%s preset=%s session=%s", workflowPhaseID, req.PresetQueryID, sessionID)
 		if req.PresetQueryID == "" {
@@ -4922,6 +4936,7 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 				// Build template vars by reading current plan and variables from workspace
 				phaseRunFolder := "iteration-0"
+				workflowPhaseRunFolder = phaseRunFolder
 				var phaseEnabledGroupNames []string
 				if req.ExecutionOptions != nil {
 					phaseEnabledGroupNames = req.ExecutionOptions.EnabledGroupNames
@@ -5192,10 +5207,21 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Attach the in-memory event observer for real-time SSE/polling, plus
-		// the cost-ledger observer that persists every token_usage event to
-		// the global cost log.
+		// the cost observer that persists immutable per-call usage events.
 		eventObserver := events.NewEventObserverWithLogger(api.eventStore, sessionID, api.logger)
-		costObs := newCostObserver(api.costLedger, sessionID, currentUserID, req.AgentMode)
+		costObs := newCostObserver(
+			api.costLedger,
+			sessionID,
+			currentUserID,
+			req.AgentMode,
+			withCostModel(finalProvider, finalModelID),
+			withCostAttribution(
+				inferCostScope(req.AgentMode, workflowPhaseID),
+				costFirstNonEmpty(workflowPhaseFolder, req.SelectedFolder),
+				workflowPhaseRunFolder,
+				queryID,
+			),
+		)
 		var registeredRunningAgent *mcpagent.Agent
 		if underlyingAgent := llmAgent.GetUnderlyingAgent(); underlyingAgent != nil {
 			underlyingAgent.AddEventListener(eventObserver)

--- a/agent_go/cmd/server/virtual-tools/tool_costs.go
+++ b/agent_go/cmd/server/virtual-tools/tool_costs.go
@@ -111,12 +111,20 @@ func recordPricedToolCost(ctx context.Context, workspaceAPIURL, userID string, c
 	if cost.Estimated {
 		billingBasis = "token_estimate"
 	}
-	ledger, err := costledger.NewSQLiteLedger(filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.sqlite"))
-	if err != nil {
-		log.Printf("[TOOL_COST] failed to open cost event database for %s: %v", cost.ToolName, err)
-		return
+	ledger := costledger.DefaultLedger()
+	closeLedger := false
+	if ledger == nil {
+		var err error
+		ledger, err = costledger.NewSQLiteLedger(filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.sqlite"))
+		if err != nil {
+			log.Printf("[TOOL_COST] failed to open cost event database for %s: %v", cost.ToolName, err)
+			return
+		}
+		closeLedger = true
 	}
-	defer ledger.Close()
+	if closeLedger {
+		defer ledger.Close()
+	}
 	if err := ledger.Append(costledger.Entry{
 		Timestamp:         now,
 		UserID:            userID,

--- a/agent_go/cmd/server/virtual-tools/tool_costs.go
+++ b/agent_go/cmd/server/virtual-tools/tool_costs.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"log"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"mcp-agent-builder-go/agent_go/pkg/common"
 	"mcp-agent-builder-go/agent_go/pkg/costledger"
+	"mcp-agent-builder-go/agent_go/pkg/fsutil"
+	orchestratorevents "mcp-agent-builder-go/agent_go/pkg/orchestrator/events"
 	"mcp-agent-builder-go/agent_go/pkg/workspace"
 )
 
@@ -73,25 +77,67 @@ type toolCostUsageFileEntry struct {
 }
 
 func recordPricedToolCost(ctx context.Context, workspaceAPIURL, userID string, cost pricedToolCost) {
-	if strings.TrimSpace(workspaceAPIURL) == "" || cost.TotalCost <= 0 || len(cost.OutputPaths) == 0 {
+	if cost.TotalCost <= 0 {
 		return
 	}
 
 	now := time.Now().UTC()
-	ledger := costledger.NewLedger(workspaceAPIURL)
+	target := workflowCostTarget{}
+	hasTarget := false
+	for _, outputPath := range cost.OutputPaths {
+		if candidate, ok := inferWorkflowCostTarget(ctx, outputPath); ok {
+			target = candidate
+			hasTarget = true
+			break
+		}
+	}
+	scope := "tool"
+	if hasTarget {
+		scope = "workflow_execution"
+		if target.Scope == toolCostScopeEvaluation {
+			scope = "evaluation"
+		}
+	}
+	sessionID := ""
+	executionID := ""
+	if ctx != nil {
+		sessionID, _ = ctx.Value(common.WorkflowSessionIDKey).(string)
+		if strings.TrimSpace(sessionID) == "" {
+			sessionID, _ = ctx.Value(common.ChatSessionIDKey).(string)
+		}
+		executionID, _ = ctx.Value(orchestratorevents.ParentExecutionIDKey).(string)
+	}
+	billingBasis := "provider_actual"
+	if cost.Estimated {
+		billingBasis = "token_estimate"
+	}
+	ledger, err := costledger.NewSQLiteLedger(filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "costs.sqlite"))
+	if err != nil {
+		log.Printf("[TOOL_COST] failed to open cost event database for %s: %v", cost.ToolName, err)
+		return
+	}
+	defer ledger.Close()
 	if err := ledger.Append(costledger.Entry{
-		Timestamp:    now,
-		UserID:       userID,
-		Component:    "tool:" + cost.ToolName,
-		Provider:     cost.Provider,
-		ModelID:      cost.ModelID,
-		TotalCostUSD: cost.TotalCost,
+		Timestamp:         now,
+		UserID:            userID,
+		WorkflowID:        target.WorkspacePath,
+		RunID:             target.RunFolder,
+		ExecutionID:       executionID,
+		SessionID:         sessionID,
+		Scope:             scope,
+		Component:         "tool:" + cost.ToolName,
+		Provider:          cost.Provider,
+		ModelID:           cost.ModelID,
+		TotalCostUSD:      cost.TotalCost,
+		BillingBasis:      billingBasis,
+		PricingSource:     "tool_price_registry",
+		ToolName:          cost.ToolName,
+		OperationMetadata: cost.Metadata,
 	}); err != nil {
 		log.Printf("[TOOL_COST] failed to append global cost ledger entry for %s: %v", cost.ToolName, err)
 	}
 
-	target, ok := inferWorkflowCostTarget(ctx, cost.OutputPaths[0])
-	if !ok {
+	if strings.TrimSpace(workspaceAPIURL) == "" || !hasTarget {
 		return
 	}
 

--- a/agent_go/cmd/server/virtual-tools/tool_costs_test.go
+++ b/agent_go/cmd/server/virtual-tools/tool_costs_test.go
@@ -1,0 +1,41 @@
+package virtualtools
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"mcp-agent-builder-go/agent_go/pkg/costledger"
+)
+
+func TestRecordPricedToolCostPersistsWithoutOutputPath(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("WORKSPACE_DOCS_PATH", root)
+	recordPricedToolCost(context.Background(), "", "user-1", pricedToolCost{
+		ToolName:   "image_gen",
+		Capability: "image",
+		Provider:   "openai",
+		ModelID:    "gpt-image",
+		TotalCost:  0.08,
+		Estimated:  false,
+	})
+
+	ledger, err := costledger.NewSQLiteLedger(filepath.Join(root, "_system", "costs.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger() error = %v", err)
+	}
+	defer ledger.Close()
+	summary, err := ledger.Summarize("", "")
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Total.AccountingEventCount != 1 {
+		t.Fatalf("AccountingEventCount = %d, want 1", summary.Total.AccountingEventCount)
+	}
+	if summary.Total.CallCount != 0 {
+		t.Fatalf("CallCount = %d, want 0 for paid tool event", summary.Total.CallCount)
+	}
+	if summary.Total.ProviderActualCostUSD != 0.08 {
+		t.Fatalf("ProviderActualCostUSD = %v, want 0.08", summary.Total.ProviderActualCostUSD)
+	}
+}

--- a/agent_go/cmd/server/virtual-tools/tool_costs_test.go
+++ b/agent_go/cmd/server/virtual-tools/tool_costs_test.go
@@ -11,6 +11,15 @@ import (
 func TestRecordPricedToolCostPersistsWithoutOutputPath(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("WORKSPACE_DOCS_PATH", root)
+	ledger, err := costledger.NewSQLiteLedger(filepath.Join(root, "_system", "costs.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger() error = %v", err)
+	}
+	costledger.SetDefaultLedger(ledger)
+	defer func() {
+		costledger.SetDefaultLedger(nil)
+		ledger.Close()
+	}()
 	recordPricedToolCost(context.Background(), "", "user-1", pricedToolCost{
 		ToolName:   "image_gen",
 		Capability: "image",
@@ -20,11 +29,6 @@ func TestRecordPricedToolCostPersistsWithoutOutputPath(t *testing.T) {
 		Estimated:  false,
 	})
 
-	ledger, err := costledger.NewSQLiteLedger(filepath.Join(root, "_system", "costs.sqlite"))
-	if err != nil {
-		t.Fatalf("NewSQLiteLedger() error = %v", err)
-	}
-	defer ledger.Close()
 	summary, err := ledger.Summarize("", "")
 	if err != nil {
 		t.Fatalf("Summarize() error = %v", err)

--- a/agent_go/pkg/costledger/ledger.go
+++ b/agent_go/pkg/costledger/ledger.go
@@ -1,7 +1,6 @@
-// Package costledger persists a global append-only LLM cost log through the
-// workspace API and exposes a date-/model-aggregated summary view. There is no
-// per-session state here — just one line per token_usage event across every
-// agent run.
+// Package costledger persists immutable LLM and paid-tool cost events and
+// exposes date/model aggregates. SQLite is the authoritative production store;
+// the workspace-API JSONL implementation remains only for migration-era tests.
 package costledger
 
 import (
@@ -29,43 +28,63 @@ type workspaceAPIResponse struct {
 
 // Entry is a single cost record — one LLM call.
 type Entry struct {
-	Timestamp        time.Time `json:"ts"`
-	SessionID        string    `json:"session_id,omitempty"`
-	UserID           string    `json:"user_id,omitempty"`
-	AgentMode        string    `json:"agent_mode,omitempty"`
-	Component        string    `json:"component,omitempty"`
-	CorrelationID    string    `json:"correlation_id,omitempty"`
-	Provider         string    `json:"provider,omitempty"`
-	ModelID          string    `json:"model_id,omitempty"`
+	EventID        string    `json:"event_id,omitempty"`
+	IdempotencyKey string    `json:"idempotency_key,omitempty"`
+	Timestamp      time.Time `json:"ts"`
+	SessionID      string    `json:"session_id,omitempty"`
+	UserID         string    `json:"user_id,omitempty"`
+	WorkflowID     string    `json:"workflow_id,omitempty"`
+	RunID          string    `json:"run_id,omitempty"`
+	ExecutionID    string    `json:"execution_id,omitempty"`
+	Scope          string    `json:"scope,omitempty"`
+	AgentMode      string    `json:"agent_mode,omitempty"`
+	Component      string    `json:"component,omitempty"`
+	CorrelationID  string    `json:"correlation_id,omitempty"`
+	Provider       string    `json:"provider,omitempty"`
+	ModelID        string    `json:"model_id,omitempty"`
 	// EffectiveModelID is the model the CLI/provider ACTUALLY served
 	// the turn with — may drift from ModelID when the user picked an
 	// alias like "auto" or "cursor-cli", or when a /model swap happened
 	// mid-session. Empty when the provider doesn't surface it.
-	EffectiveModelID string    `json:"effective_model_id,omitempty"`
-	PromptTokens     int       `json:"prompt_tokens,omitempty"`
-	CompletionTokens int       `json:"completion_tokens,omitempty"`
-	ReasoningTokens  int       `json:"reasoning_tokens,omitempty"`
-	CacheReadTokens  int       `json:"cache_read_tokens,omitempty"`
-	CacheWriteTokens int       `json:"cache_write_tokens,omitempty"`
-	TotalCostUSD     float64   `json:"total_cost_usd,omitempty"`
+	EffectiveProvider string  `json:"effective_provider,omitempty"`
+	EffectiveModelID  string  `json:"effective_model_id,omitempty"`
+	TurnCount         int     `json:"turn_count,omitempty"`
+	LLMCallCount      int     `json:"llm_call_count,omitempty"`
+	PromptTokens      int     `json:"prompt_tokens,omitempty"`
+	CompletionTokens  int     `json:"completion_tokens,omitempty"`
+	ReasoningTokens   int     `json:"reasoning_tokens,omitempty"`
+	CacheReadTokens   int     `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens  int     `json:"cache_write_tokens,omitempty"`
+	TotalCostUSD      float64 `json:"total_cost_usd,omitempty"`
 	// CostUSDSource flags whether TotalCostUSD came from the provider
 	// ("provider", e.g. claude's total_cost_usd) or was computed
 	// downstream from tokens × registry rates ("estimated"). For
 	// subscription-billed CLIs (Cursor, Codex Pro) "estimated" is a
 	// SHADOW cost — what the same workload would cost via the
 	// underlying per-token API, NOT the flat-plan bill.
-	CostUSDSource string `json:"cost_usd_source,omitempty"`
+	CostUSDSource     string                 `json:"cost_usd_source,omitempty"`
+	Currency          string                 `json:"currency,omitempty"`
+	BillingBasis      string                 `json:"billing_basis,omitempty"`
+	PricingSource     string                 `json:"pricing_source,omitempty"`
+	PricingVersion    string                 `json:"pricing_version,omitempty"`
+	ToolName          string                 `json:"tool_name,omitempty"`
+	OperationMetadata map[string]interface{} `json:"operation_metadata,omitempty"`
 }
 
 // Aggregate is the rolled-up token + cost total for a date/model bucket.
 type Aggregate struct {
-	PromptTokens     int     `json:"prompt_tokens"`
-	CompletionTokens int     `json:"completion_tokens"`
-	ReasoningTokens  int     `json:"reasoning_tokens"`
-	CacheReadTokens  int     `json:"cache_read_tokens"`
-	CacheWriteTokens int     `json:"cache_write_tokens"`
-	TotalCostUSD     float64 `json:"total_cost_usd"`
-	CallCount        int     `json:"call_count"`
+	PromptTokens          int     `json:"prompt_tokens"`
+	CompletionTokens      int     `json:"completion_tokens"`
+	ReasoningTokens       int     `json:"reasoning_tokens"`
+	CacheReadTokens       int     `json:"cache_read_tokens"`
+	CacheWriteTokens      int     `json:"cache_write_tokens"`
+	TotalCostUSD          float64 `json:"total_cost_usd"`
+	CallCount             int     `json:"call_count"`
+	AccountingEventCount  int     `json:"accounting_event_count"`
+	UnpricedCallCount     int     `json:"unpriced_call_count"`
+	ProviderActualCostUSD float64 `json:"provider_actual_cost_usd"`
+	TokenEstimateCostUSD  float64 `json:"token_estimate_cost_usd"`
+	SubscriptionShadowUSD float64 `json:"subscription_shadow_cost_usd"`
 }
 
 func (a *Aggregate) add(e Entry) {
@@ -75,7 +94,19 @@ func (a *Aggregate) add(e Entry) {
 	a.CacheReadTokens += e.CacheReadTokens
 	a.CacheWriteTokens += e.CacheWriteTokens
 	a.TotalCostUSD += e.TotalCostUSD
-	a.CallCount++
+	a.CallCount += e.LLMCallCount
+	a.AccountingEventCount++
+	if e.LLMCallCount > 0 && e.BillingBasis == "unpriced" {
+		a.UnpricedCallCount += e.LLMCallCount
+	}
+	switch e.BillingBasis {
+	case "provider_actual":
+		a.ProviderActualCostUSD += e.TotalCostUSD
+	case "subscription_shadow":
+		a.SubscriptionShadowUSD += e.TotalCostUSD
+	case "token_estimate":
+		a.TokenEstimateCostUSD += e.TotalCostUSD
+	}
 }
 
 // DateAggregate is one row in the per-date rollup. It embeds Aggregate
@@ -90,20 +121,36 @@ type DateAggregate struct {
 
 // Summary is the aggregated view returned by Summarize.
 type Summary struct {
-	From    string                    `json:"from,omitempty"`
-	To      string                    `json:"to,omitempty"`
-	Total   Aggregate                 `json:"total"`
-	ByDate  map[string]*DateAggregate `json:"by_date"`  // YYYY-MM-DD UTC
-	ByModel map[string]*Aggregate     `json:"by_model"` // model_id
+	From     string                    `json:"from,omitempty"`
+	To       string                    `json:"to,omitempty"`
+	Total    Aggregate                 `json:"total"`
+	ByDate   map[string]*DateAggregate `json:"by_date"`  // YYYY-MM-DD UTC
+	ByModel  map[string]*Aggregate     `json:"by_model"` // model_id
+	Coverage Coverage                  `json:"coverage"`
 }
 
-// Ledger appends token_usage records to _system/costs.jsonl through the
-// workspace API and can produce aggregated summaries. Safe for concurrent
-// appends within a single process via an internal mutex.
+// Coverage reports whether the aggregate omitted or could not price evidence.
+type Coverage struct {
+	Source                string `json:"source"`
+	MalformedEventCount   int    `json:"malformed_event_count"`
+	QuarantinedEventCount int    `json:"quarantined_event_count"`
+}
+
+// Ledger writes immutable cost events and produces aggregate summaries. The
+// SQLite implementation is safe across independent Ledger instances and uses
+// idempotency keys to make retries harmless.
 type Ledger struct {
 	baseURL string
 	client  *http.Client
+	db      sqliteStore
 	mu      sync.Mutex
+}
+
+type sqliteStore interface {
+	append(Entry) error
+	summarize(from, to string) (*Summary, error)
+	migrateLegacyJSONL(path string) (MigrationReport, error)
+	close() error
 }
 
 // NewLedger creates a ledger that persists to _system/costs.jsonl via the
@@ -195,9 +242,16 @@ func (l *Ledger) writeFile(path string, content []byte) error {
 
 // Append writes one entry as a JSONL line. Missing Timestamp is filled in.
 func (l *Ledger) Append(e Entry) error {
+	if l == nil {
+		return fmt.Errorf("costledger: nil ledger")
+	}
+	if l.db != nil {
+		return l.db.append(e)
+	}
 	if e.Timestamp.IsZero() {
 		e.Timestamp = time.Now().UTC()
 	}
+	normalizeEntry(&e)
 	line, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("costledger: marshal entry: %w", err)
@@ -220,14 +274,21 @@ func (l *Ledger) Append(e Entry) error {
 // Summarize scans the ledger and rolls entries up by date and model. from/to
 // are inclusive date bounds in YYYY-MM-DD (UTC); empty strings mean unbounded.
 func (l *Ledger) Summarize(from, to string) (*Summary, error) {
+	if l == nil {
+		return nil, fmt.Errorf("costledger: nil ledger")
+	}
+	if l.db != nil {
+		return l.db.summarize(from, to)
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	summary := &Summary{
-		From:    from,
-		To:      to,
-		ByDate:  make(map[string]*DateAggregate),
-		ByModel: make(map[string]*Aggregate),
+		From:     from,
+		To:       to,
+		ByDate:   make(map[string]*DateAggregate),
+		ByModel:  make(map[string]*Aggregate),
+		Coverage: Coverage{Source: "legacy_jsonl"},
 	}
 
 	content, exists, err := l.readFile(ledgerWorkspacePath)
@@ -247,8 +308,10 @@ func (l *Ledger) Summarize(from, to string) (*Summary, error) {
 		}
 		var e Entry
 		if err := json.Unmarshal(line, &e); err != nil {
+			summary.Coverage.MalformedEventCount++
 			continue
 		}
+		normalizeEntry(&e)
 		date := e.Timestamp.UTC().Format("2006-01-02")
 		if from != "" && date < from {
 			continue
@@ -256,36 +319,58 @@ func (l *Ledger) Summarize(from, to string) (*Summary, error) {
 		if to != "" && date > to {
 			continue
 		}
-		summary.Total.add(e)
-		bucket, ok := summary.ByDate[date]
-		if !ok {
-			bucket = &DateAggregate{ByModel: make(map[string]*Aggregate)}
-			summary.ByDate[date] = bucket
-		}
-		bucket.Aggregate.add(e)
-		if e.ModelID != "" {
-			if bucket.ByModel == nil {
-				bucket.ByModel = make(map[string]*Aggregate)
-			}
-			dm, ok := bucket.ByModel[e.ModelID]
-			if !ok {
-				dm = &Aggregate{}
-				bucket.ByModel[e.ModelID] = dm
-			}
-			dm.add(e)
-
-			mb, ok := summary.ByModel[e.ModelID]
-			if !ok {
-				mb = &Aggregate{}
-				summary.ByModel[e.ModelID] = mb
-			}
-			mb.add(e)
-		}
+		addEntryToSummary(summary, date, e)
 	}
 	if err := sc.Err(); err != nil {
 		return nil, fmt.Errorf("costledger: scan %s: %w", ledgerWorkspacePath, err)
 	}
 	return summary, nil
+}
+
+// Close releases the SQLite connection. It is a no-op for the legacy API ledger.
+func (l *Ledger) Close() error {
+	if l == nil || l.db == nil {
+		return nil
+	}
+	return l.db.close()
+}
+
+// MigrateLegacyJSONL imports valid rows idempotently and quarantines malformed
+// rows. It is supported only by the SQLite ledger.
+func (l *Ledger) MigrateLegacyJSONL(path string) (MigrationReport, error) {
+	if l == nil || l.db == nil {
+		return MigrationReport{}, fmt.Errorf("costledger: legacy migration requires SQLite ledger")
+	}
+	return l.db.migrateLegacyJSONL(path)
+}
+
+func addEntryToSummary(summary *Summary, date string, e Entry) {
+	summary.Total.add(e)
+	bucket, ok := summary.ByDate[date]
+	if !ok {
+		bucket = &DateAggregate{ByModel: make(map[string]*Aggregate)}
+		summary.ByDate[date] = bucket
+	}
+	bucket.Aggregate.add(e)
+	modelID := e.EffectiveModelID
+	if modelID == "" {
+		modelID = e.ModelID
+	}
+	if modelID == "" {
+		return
+	}
+	dm, ok := bucket.ByModel[modelID]
+	if !ok {
+		dm = &Aggregate{}
+		bucket.ByModel[modelID] = dm
+	}
+	dm.add(e)
+	mb, ok := summary.ByModel[modelID]
+	if !ok {
+		mb = &Aggregate{}
+		summary.ByModel[modelID] = mb
+	}
+	mb.add(e)
 }
 
 // SortedDates returns the date keys from a summary in ascending order.

--- a/agent_go/pkg/costledger/ledger.go
+++ b/agent_go/pkg/costledger/ledger.go
@@ -146,6 +146,27 @@ type Ledger struct {
 	mu      sync.Mutex
 }
 
+var (
+	defaultLedgerMu sync.RWMutex
+	defaultLedger   *Ledger
+)
+
+// SetDefaultLedger publishes the process-wide production ledger used by paid
+// virtual tools. The server owns its lifecycle; callers must not close it.
+func SetDefaultLedger(ledger *Ledger) {
+	defaultLedgerMu.Lock()
+	defaultLedger = ledger
+	defaultLedgerMu.Unlock()
+}
+
+// DefaultLedger returns the process-wide ledger, when the server initialized
+// one. Tests and standalone tools may leave it unset and open their own store.
+func DefaultLedger() *Ledger {
+	defaultLedgerMu.RLock()
+	defer defaultLedgerMu.RUnlock()
+	return defaultLedger
+}
+
 type sqliteStore interface {
 	append(Entry) error
 	summarize(from, to string) (*Summary, error)

--- a/agent_go/pkg/costledger/ledger_test.go
+++ b/agent_go/pkg/costledger/ledger_test.go
@@ -155,6 +155,20 @@ func TestSQLiteLedgerSeparatesCallsFromToolEventsAndUTCDateBounds(t *testing.T) 
 	}
 }
 
+func TestSQLiteLedgerRejectsInvalidDateBounds(t *testing.T) {
+	ledger, err := NewSQLiteLedger(filepath.Join(t.TempDir(), "costs.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ledger.Close()
+	if _, err := ledger.Summarize("2026-07-14", "2026-07-13"); err == nil {
+		t.Fatal("reversed date bounds should be rejected")
+	}
+	if _, err := ledger.Summarize("not-a-date", ""); err == nil {
+		t.Fatal("invalid date should be rejected")
+	}
+}
+
 func TestLedgerAppendAndSummarizeViaWorkspaceAPI(t *testing.T) {
 	server := newLedgerTestServer(t)
 	defer server.Close()

--- a/agent_go/pkg/costledger/ledger_test.go
+++ b/agent_go/pkg/costledger/ledger_test.go
@@ -1,13 +1,158 @@
 package costledger
 
 import (
+	"fmt"
+	"math"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
 
 func newLedgerTestServer(t *testing.T) *httptest.Server {
 	return NewTestServer(t)
+}
+
+func TestSQLiteLedgerConcurrentAppendsAreIdempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "costs.sqlite")
+	first, err := NewSQLiteLedger(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger(first) error = %v", err)
+	}
+	defer first.Close()
+	second, err := NewSQLiteLedger(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger(second) error = %v", err)
+	}
+	defer second.Close()
+
+	const eventCount = 50
+	var wg sync.WaitGroup
+	errCh := make(chan error, eventCount*2)
+	for i := 0; i < eventCount; i++ {
+		entry := Entry{
+			EventID:          fmt.Sprintf("event-%d", i),
+			IdempotencyKey:   fmt.Sprintf("call-%d", i),
+			Timestamp:        time.Date(2026, 7, 13, 10, 0, i, 0, time.UTC),
+			Provider:         "codex-cli",
+			ModelID:          "auto",
+			EffectiveModelID: "gpt-5.6-sol",
+			LLMCallCount:     1,
+			PromptTokens:     100,
+			TotalCostUSD:     0.01,
+			BillingBasis:     "subscription_shadow",
+		}
+		for _, ledger := range []*Ledger{first, second} {
+			wg.Add(1)
+			go func(ledger *Ledger, entry Entry) {
+				defer wg.Done()
+				if err := ledger.Append(entry); err != nil {
+					errCh <- err
+				}
+			}(ledger, entry)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent Append error = %v", err)
+	}
+
+	summary, err := first.Summarize("", "")
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Total.CallCount != eventCount {
+		t.Fatalf("CallCount = %d, want %d", summary.Total.CallCount, eventCount)
+	}
+	if summary.Total.AccountingEventCount != eventCount {
+		t.Fatalf("AccountingEventCount = %d, want %d", summary.Total.AccountingEventCount, eventCount)
+	}
+	if got := summary.ByModel["gpt-5.6-sol"]; got == nil || got.CallCount != eventCount {
+		t.Fatalf("effective model aggregate = %#v, want %d calls", got, eventCount)
+	}
+	if math.Abs(summary.Total.SubscriptionShadowUSD-0.5) > 1e-9 {
+		t.Fatalf("SubscriptionShadowUSD = %v, want 0.5", summary.Total.SubscriptionShadowUSD)
+	}
+}
+
+func TestSQLiteLedgerMigrationQuarantinesMalformedRowsAndIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	legacyPath := filepath.Join(root, "costs.jsonl")
+	valid := `{"ts":"2026-07-13T23:59:59Z","provider":"anthropic","model_id":"claude-sonnet","prompt_tokens":10,"total_cost_usd":0.02,"cost_usd_source":"estimated"}`
+	if err := os.WriteFile(legacyPath, []byte(valid+"\n{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	ledger, err := NewSQLiteLedger(filepath.Join(root, "costs.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger() error = %v", err)
+	}
+	defer ledger.Close()
+
+	report, err := ledger.MigrateLegacyJSONL(legacyPath)
+	if err != nil {
+		t.Fatalf("MigrateLegacyJSONL(first) error = %v", err)
+	}
+	if report.Imported != 1 || report.Quarantined != 1 {
+		t.Fatalf("first report = %#v, want 1 imported and 1 quarantined", report)
+	}
+	report, err = ledger.MigrateLegacyJSONL(legacyPath)
+	if err != nil {
+		t.Fatalf("MigrateLegacyJSONL(second) error = %v", err)
+	}
+	if report.Duplicates != 1 || report.Imported != 0 || report.Quarantined != 0 {
+		t.Fatalf("second report = %#v, want one duplicate only", report)
+	}
+
+	summary, err := ledger.Summarize("2026-07-13", "2026-07-13")
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary.Total.CallCount != 1 || summary.Coverage.QuarantinedEventCount != 1 {
+		t.Fatalf("summary = %#v, want one call and one quarantined row", summary)
+	}
+	if summary.Total.TokenEstimateCostUSD != 0.02 {
+		t.Fatalf("TokenEstimateCostUSD = %v, want 0.02", summary.Total.TokenEstimateCostUSD)
+	}
+}
+
+func TestSQLiteLedgerSeparatesCallsFromToolEventsAndUTCDateBounds(t *testing.T) {
+	ledger, err := NewSQLiteLedger(filepath.Join(t.TempDir(), "costs.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteLedger() error = %v", err)
+	}
+	defer ledger.Close()
+	entries := []Entry{
+		{
+			EventID: "llm", IdempotencyKey: "llm", Timestamp: time.Date(2026, 7, 13, 23, 59, 59, 0, time.UTC),
+			Provider: "openai", ModelID: "gpt-5.6-sol", LLMCallCount: 2, BillingBasis: "unpriced",
+		},
+		{
+			EventID: "tool", IdempotencyKey: "tool", Timestamp: time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC),
+			Component: "tool:image_gen", ToolName: "image_gen", TotalCostUSD: 0.04, BillingBasis: "provider_actual",
+		},
+	}
+	for _, entry := range entries {
+		if err := ledger.Append(entry); err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	}
+	dayOne, err := ledger.Summarize("2026-07-13", "2026-07-13")
+	if err != nil {
+		t.Fatalf("Summarize(day one) error = %v", err)
+	}
+	if dayOne.Total.CallCount != 2 || dayOne.Total.AccountingEventCount != 1 || dayOne.Total.UnpricedCallCount != 2 {
+		t.Fatalf("day one total = %#v", dayOne.Total)
+	}
+	dayTwo, err := ledger.Summarize("2026-07-14", "2026-07-14")
+	if err != nil {
+		t.Fatalf("Summarize(day two) error = %v", err)
+	}
+	if dayTwo.Total.CallCount != 0 || dayTwo.Total.AccountingEventCount != 1 || dayTwo.Total.ProviderActualCostUSD != 0.04 {
+		t.Fatalf("day two total = %#v", dayTwo.Total)
+	}
 }
 
 func TestLedgerAppendAndSummarizeViaWorkspaceAPI(t *testing.T) {

--- a/agent_go/pkg/costledger/sqlite.go
+++ b/agent_go/pkg/costledger/sqlite.go
@@ -109,7 +109,7 @@ func (s *sqliteLedger) append(e Entry) error {
 	if err != nil {
 		return fmt.Errorf("costledger: marshal operation metadata: %w", err)
 	}
-	_, err = s.db.Exec(`
+	const insertEvent = `
 INSERT OR IGNORE INTO cost_events (
     event_id, idempotency_key, occurred_at, user_id, workflow_id, session_id,
     run_id, execution_id, scope, agent_mode, component, correlation_id,
@@ -117,7 +117,8 @@ INSERT OR IGNORE INTO cost_events (
     turn_count, llm_call_count, prompt_tokens, completion_tokens, reasoning_tokens,
     cache_read_tokens, cache_write_tokens, total_cost_usd, currency, billing_basis,
     pricing_source, pricing_version, tool_name, operation_metadata_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	args := []interface{}{
 		e.EventID, e.IdempotencyKey, e.Timestamp.UTC().Format(time.RFC3339Nano),
 		e.UserID, e.WorkflowID, e.SessionID, e.RunID, e.ExecutionID, e.Scope,
 		e.AgentMode, e.Component, e.CorrelationID, e.Provider, e.ModelID,
@@ -125,27 +126,52 @@ INSERT OR IGNORE INTO cost_events (
 		e.PromptTokens, e.CompletionTokens, e.ReasoningTokens, e.CacheReadTokens,
 		e.CacheWriteTokens, e.TotalCostUSD, e.Currency, e.BillingBasis,
 		e.PricingSource, e.PricingVersion, e.ToolName, string(metadata),
-	)
-	if err != nil {
-		return fmt.Errorf("costledger: insert SQLite event: %w", err)
 	}
-	return nil
+	for attempt := 0; ; attempt++ {
+		_, err = s.db.Exec(insertEvent, args...)
+		if err == nil {
+			return nil
+		}
+		if attempt >= 2 || !isSQLiteBusy(err) {
+			return fmt.Errorf("costledger: insert SQLite event: %w", err)
+		}
+		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+	}
 }
 
 func (s *sqliteLedger) summarize(from, to string) (*Summary, error) {
+	fromInclusive, toExclusive, err := costDateBounds(from, to)
+	if err != nil {
+		return nil, err
+	}
 	summary := &Summary{
 		From: from, To: to,
 		ByDate: make(map[string]*DateAggregate), ByModel: make(map[string]*Aggregate),
 		Coverage: Coverage{Source: "sqlite"},
 	}
-	rows, err := s.db.Query(`
+	query := `
 SELECT event_id, idempotency_key, occurred_at, user_id, workflow_id, session_id,
        run_id, execution_id, scope, agent_mode, component, correlation_id,
        requested_provider, requested_model_id, effective_provider, effective_model_id,
        turn_count, llm_call_count, prompt_tokens, completion_tokens, reasoning_tokens,
        cache_read_tokens, cache_write_tokens, total_cost_usd, currency, billing_basis,
        pricing_source, pricing_version, tool_name, operation_metadata_json
-FROM cost_events ORDER BY occurred_at`)
+FROM cost_events`
+	where := make([]string, 0, 2)
+	args := make([]interface{}, 0, 2)
+	if fromInclusive != "" {
+		where = append(where, "occurred_at >= ?")
+		args = append(args, fromInclusive)
+	}
+	if toExclusive != "" {
+		where = append(where, "occurred_at < ?")
+		args = append(args, toExclusive)
+	}
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += " ORDER BY occurred_at"
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("costledger: query SQLite events: %w", err)
 	}
@@ -171,9 +197,6 @@ FROM cost_events ORDER BY occurred_at`)
 		}
 		e.Timestamp = ts
 		date := ts.UTC().Format("2006-01-02")
-		if from != "" && date < from || to != "" && date > to {
-			continue
-		}
 		addEntryToSummary(summary, date, e)
 	}
 	if err := rows.Err(); err != nil {
@@ -183,6 +206,47 @@ FROM cost_events ORDER BY occurred_at`)
 		return nil, fmt.Errorf("costledger: count quarantined events: %w", err)
 	}
 	return summary, nil
+}
+
+func costDateBounds(from, to string) (string, string, error) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	parse := func(name, value string) (time.Time, error) {
+		parsed, err := time.Parse("2006-01-02", value)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("costledger: invalid %s date %q (expected YYYY-MM-DD): %w", name, value, err)
+		}
+		return parsed.UTC(), nil
+	}
+	fromInclusive := ""
+	if from != "" {
+		parsed, err := parse("from", from)
+		if err != nil {
+			return "", "", err
+		}
+		fromInclusive = parsed.Format(time.RFC3339Nano)
+	}
+	toExclusive := ""
+	if to != "" {
+		parsed, err := parse("to", to)
+		if err != nil {
+			return "", "", err
+		}
+		toExclusive = parsed.AddDate(0, 0, 1).Format(time.RFC3339Nano)
+	}
+	if fromInclusive != "" && toExclusive != "" && fromInclusive >= toExclusive {
+		return "", "", fmt.Errorf("costledger: from date %q must not be after to date %q", from, to)
+	}
+	return fromInclusive, toExclusive, nil
+}
+
+func isSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "sqlite_busy") || strings.Contains(message, "database is locked") ||
+		strings.Contains(message, "database table is locked")
 }
 
 func (s *sqliteLedger) migrateLegacyJSONL(path string) (MigrationReport, error) {

--- a/agent_go/pkg/costledger/sqlite.go
+++ b/agent_go/pkg/costledger/sqlite.go
@@ -1,0 +1,313 @@
+package costledger
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const sqliteSchema = `
+CREATE TABLE IF NOT EXISTS cost_events (
+    event_id TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL UNIQUE,
+    occurred_at TEXT NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    workflow_id TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    run_id TEXT NOT NULL DEFAULT '',
+    execution_id TEXT NOT NULL DEFAULT '',
+    scope TEXT NOT NULL DEFAULT 'unknown',
+    agent_mode TEXT NOT NULL DEFAULT '',
+    component TEXT NOT NULL DEFAULT '',
+    correlation_id TEXT NOT NULL DEFAULT '',
+    requested_provider TEXT NOT NULL DEFAULT '',
+    requested_model_id TEXT NOT NULL DEFAULT '',
+    effective_provider TEXT NOT NULL DEFAULT '',
+    effective_model_id TEXT NOT NULL DEFAULT '',
+    turn_count INTEGER NOT NULL DEFAULT 0,
+    llm_call_count INTEGER NOT NULL DEFAULT 0,
+    prompt_tokens INTEGER NOT NULL DEFAULT 0,
+    completion_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd REAL NOT NULL DEFAULT 0,
+    currency TEXT NOT NULL DEFAULT 'USD',
+    billing_basis TEXT NOT NULL DEFAULT 'unpriced',
+    pricing_source TEXT NOT NULL DEFAULT '',
+    pricing_version TEXT NOT NULL DEFAULT '',
+    tool_name TEXT NOT NULL DEFAULT '',
+    operation_metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_cost_events_occurred_at ON cost_events(occurred_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_effective_model ON cost_events(effective_model_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_cost_events_workflow_scope ON cost_events(workflow_id, scope, occurred_at);
+CREATE TABLE IF NOT EXISTS cost_event_quarantine (
+    source_hash TEXT PRIMARY KEY,
+    source_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    raw_record TEXT NOT NULL,
+    parse_error TEXT NOT NULL,
+    quarantined_at TEXT NOT NULL
+);`
+
+type sqliteLedger struct {
+	db *sql.DB
+}
+
+// MigrationReport describes one idempotent legacy JSONL import.
+type MigrationReport struct {
+	Imported    int `json:"imported"`
+	Duplicates  int `json:"duplicates"`
+	Quarantined int `json:"quarantined"`
+}
+
+// NewSQLiteLedger opens the authoritative local cost event database.
+func NewSQLiteLedger(dbPath string) (*Ledger, error) {
+	dbPath = strings.TrimSpace(dbPath)
+	if dbPath == "" {
+		return nil, fmt.Errorf("costledger: SQLite path is required")
+	}
+	absPath, err := filepath.Abs(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("costledger: resolve SQLite path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return nil, fmt.Errorf("costledger: create SQLite directory: %w", err)
+	}
+	u := &url.URL{Scheme: "file", Path: absPath}
+	dsn := u.String() + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("costledger: open SQLite database: %w", err)
+	}
+	db.SetMaxOpenConns(8)
+	db.SetMaxIdleConns(4)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("costledger: ping SQLite database: %w", err)
+	}
+	if _, err := db.Exec(sqliteSchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("costledger: initialize SQLite schema: %w", err)
+	}
+	return &Ledger{db: &sqliteLedger{db: db}}, nil
+}
+
+func (s *sqliteLedger) append(e Entry) error {
+	normalizeEntry(&e)
+	metadata, err := json.Marshal(e.OperationMetadata)
+	if err != nil {
+		return fmt.Errorf("costledger: marshal operation metadata: %w", err)
+	}
+	_, err = s.db.Exec(`
+INSERT OR IGNORE INTO cost_events (
+    event_id, idempotency_key, occurred_at, user_id, workflow_id, session_id,
+    run_id, execution_id, scope, agent_mode, component, correlation_id,
+    requested_provider, requested_model_id, effective_provider, effective_model_id,
+    turn_count, llm_call_count, prompt_tokens, completion_tokens, reasoning_tokens,
+    cache_read_tokens, cache_write_tokens, total_cost_usd, currency, billing_basis,
+    pricing_source, pricing_version, tool_name, operation_metadata_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.EventID, e.IdempotencyKey, e.Timestamp.UTC().Format(time.RFC3339Nano),
+		e.UserID, e.WorkflowID, e.SessionID, e.RunID, e.ExecutionID, e.Scope,
+		e.AgentMode, e.Component, e.CorrelationID, e.Provider, e.ModelID,
+		e.EffectiveProvider, e.EffectiveModelID, e.TurnCount, e.LLMCallCount,
+		e.PromptTokens, e.CompletionTokens, e.ReasoningTokens, e.CacheReadTokens,
+		e.CacheWriteTokens, e.TotalCostUSD, e.Currency, e.BillingBasis,
+		e.PricingSource, e.PricingVersion, e.ToolName, string(metadata),
+	)
+	if err != nil {
+		return fmt.Errorf("costledger: insert SQLite event: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteLedger) summarize(from, to string) (*Summary, error) {
+	summary := &Summary{
+		From: from, To: to,
+		ByDate: make(map[string]*DateAggregate), ByModel: make(map[string]*Aggregate),
+		Coverage: Coverage{Source: "sqlite"},
+	}
+	rows, err := s.db.Query(`
+SELECT event_id, idempotency_key, occurred_at, user_id, workflow_id, session_id,
+       run_id, execution_id, scope, agent_mode, component, correlation_id,
+       requested_provider, requested_model_id, effective_provider, effective_model_id,
+       turn_count, llm_call_count, prompt_tokens, completion_tokens, reasoning_tokens,
+       cache_read_tokens, cache_write_tokens, total_cost_usd, currency, billing_basis,
+       pricing_source, pricing_version, tool_name, operation_metadata_json
+FROM cost_events ORDER BY occurred_at`)
+	if err != nil {
+		return nil, fmt.Errorf("costledger: query SQLite events: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var e Entry
+		var occurredAt, metadataJSON string
+		if err := rows.Scan(
+			&e.EventID, &e.IdempotencyKey, &occurredAt, &e.UserID, &e.WorkflowID,
+			&e.SessionID, &e.RunID, &e.ExecutionID, &e.Scope, &e.AgentMode,
+			&e.Component, &e.CorrelationID, &e.Provider, &e.ModelID,
+			&e.EffectiveProvider, &e.EffectiveModelID, &e.TurnCount, &e.LLMCallCount,
+			&e.PromptTokens, &e.CompletionTokens, &e.ReasoningTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.TotalCostUSD, &e.Currency,
+			&e.BillingBasis, &e.PricingSource, &e.PricingVersion, &e.ToolName,
+			&metadataJSON,
+		); err != nil {
+			return nil, fmt.Errorf("costledger: scan SQLite event: %w", err)
+		}
+		ts, err := time.Parse(time.RFC3339Nano, occurredAt)
+		if err != nil {
+			return nil, fmt.Errorf("costledger: parse stored timestamp %q: %w", occurredAt, err)
+		}
+		e.Timestamp = ts
+		date := ts.UTC().Format("2006-01-02")
+		if from != "" && date < from || to != "" && date > to {
+			continue
+		}
+		addEntryToSummary(summary, date, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("costledger: iterate SQLite events: %w", err)
+	}
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM cost_event_quarantine`).Scan(&summary.Coverage.QuarantinedEventCount); err != nil {
+		return nil, fmt.Errorf("costledger: count quarantined events: %w", err)
+	}
+	return summary, nil
+}
+
+func (s *sqliteLedger) migrateLegacyJSONL(path string) (MigrationReport, error) {
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return MigrationReport{}, nil
+	}
+	if err != nil {
+		return MigrationReport{}, fmt.Errorf("costledger: open legacy JSONL: %w", err)
+	}
+	defer file.Close()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return MigrationReport{}, fmt.Errorf("costledger: begin legacy migration: %w", err)
+	}
+	defer tx.Rollback()
+	report := MigrationReport{}
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		raw := append([]byte(nil), scanner.Bytes()...)
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		hash := fmt.Sprintf("%x", sha256.Sum256(raw))
+		var e Entry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			result, qErr := tx.Exec(`INSERT OR IGNORE INTO cost_event_quarantine
+                (source_hash, source_path, line_number, raw_record, parse_error, quarantined_at)
+                VALUES (?, ?, ?, ?, ?, ?)`, hash, path, lineNumber, string(raw), err.Error(), time.Now().UTC().Format(time.RFC3339Nano))
+			if qErr != nil {
+				return MigrationReport{}, fmt.Errorf("costledger: quarantine malformed row %d: %w", lineNumber, qErr)
+			}
+			if affected, _ := result.RowsAffected(); affected > 0 {
+				report.Quarantined++
+			}
+			continue
+		}
+		e.EventID = "legacy-" + hash
+		e.IdempotencyKey = "legacy-jsonl:" + hash
+		normalizeEntry(&e)
+		metadata, err := json.Marshal(e.OperationMetadata)
+		if err != nil {
+			return MigrationReport{}, fmt.Errorf("costledger: marshal legacy metadata row %d: %w", lineNumber, err)
+		}
+		result, err := tx.Exec(`
+INSERT OR IGNORE INTO cost_events (
+    event_id, idempotency_key, occurred_at, user_id, workflow_id, session_id,
+    run_id, execution_id, scope, agent_mode, component, correlation_id,
+    requested_provider, requested_model_id, effective_provider, effective_model_id,
+    turn_count, llm_call_count, prompt_tokens, completion_tokens, reasoning_tokens,
+    cache_read_tokens, cache_write_tokens, total_cost_usd, currency, billing_basis,
+    pricing_source, pricing_version, tool_name, operation_metadata_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			e.EventID, e.IdempotencyKey, e.Timestamp.UTC().Format(time.RFC3339Nano),
+			e.UserID, e.WorkflowID, e.SessionID, e.RunID, e.ExecutionID, e.Scope,
+			e.AgentMode, e.Component, e.CorrelationID, e.Provider, e.ModelID,
+			e.EffectiveProvider, e.EffectiveModelID, e.TurnCount, e.LLMCallCount,
+			e.PromptTokens, e.CompletionTokens, e.ReasoningTokens, e.CacheReadTokens,
+			e.CacheWriteTokens, e.TotalCostUSD, e.Currency, e.BillingBasis,
+			e.PricingSource, e.PricingVersion, e.ToolName, string(metadata),
+		)
+		if err != nil {
+			return MigrationReport{}, fmt.Errorf("costledger: migrate legacy row %d: %w", lineNumber, err)
+		}
+		if affected, _ := result.RowsAffected(); affected > 0 {
+			report.Imported++
+		} else {
+			report.Duplicates++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return MigrationReport{}, fmt.Errorf("costledger: scan legacy JSONL: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return MigrationReport{}, fmt.Errorf("costledger: commit legacy migration: %w", err)
+	}
+	return report, nil
+}
+
+func (s *sqliteLedger) close() error {
+	return s.db.Close()
+}
+
+func normalizeEntry(e *Entry) {
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	} else {
+		e.Timestamp = e.Timestamp.UTC()
+	}
+	if e.Currency == "" {
+		e.Currency = "USD"
+	}
+	if e.Scope == "" {
+		e.Scope = "unknown"
+	}
+	if e.BillingBasis == "" {
+		switch e.CostUSDSource {
+		case "provider":
+			e.BillingBasis = "provider_actual"
+		case "estimated":
+			e.BillingBasis = "token_estimate"
+		default:
+			if e.TotalCostUSD > 0 {
+				e.BillingBasis = "token_estimate"
+			} else {
+				e.BillingBasis = "unpriced"
+			}
+		}
+	}
+	if e.LLMCallCount == 0 && !strings.HasPrefix(e.Component, "tool:") &&
+		(e.Provider != "" || e.ModelID != "" || e.PromptTokens > 0 || e.CompletionTokens > 0) {
+		e.LLMCallCount = 1
+	}
+	if e.IdempotencyKey == "" {
+		copy := *e
+		copy.EventID = ""
+		copy.IdempotencyKey = ""
+		data, _ := json.Marshal(copy)
+		e.IdempotencyKey = fmt.Sprintf("event:%x", sha256.Sum256(data))
+	}
+	if e.EventID == "" {
+		e.EventID = e.IdempotencyKey
+	}
+}


### PR DESCRIPTION
Refs #139

## What changed

- add an immutable SQLite cost-event repository with WAL, idempotency keys, concurrent-writer safety, date/model summaries, and malformed legacy-row quarantine
- migrate valid `_system/costs.jsonl` rows idempotently at server startup without deleting the legacy evidence
- persist one row per `LLMGenerationEnd` instead of treating cumulative conversation totals as new calls
- retain requested and effective models, explicit workflow/session/run/execution scope, actual LLM-call count, and billing basis (`provider_actual`, `token_estimate`, `subscription_shadow`, `unpriced`)
- keep cumulative `TokenUsage` only as a compatibility fallback and suppress it once per-call evidence exists
- route paid media/tool costs through the same SQLite repository, including operations with no output file
- remove event listeners for short-lived delegated agents while retaining main-agent observers required by reused synthetic turns

## Root cause

The old global ledger read and rewrote the complete JSONL file for every append. Independent writers could race, malformed lines were silently skipped, cumulative agent snapshots were counted as new calls, and tool costs followed a separate writer. The dashboard therefore could overcount calls/costs or lose events.

## User impact

The global cost API now reads transactional immutable events. Retried observer deliveries are harmless, actual LLM calls are distinct from paid-tool events, effective models are used for model rollups, and unpriced or quarantined evidence is visible in coverage fields.

## Verification

- `go test ./pkg/costledger ./cmd/server/virtual-tools ./cmd/server -run "TestLedger|TestSQLite|TestCostObserver|TestRecordPricedToolCost"`
- `go test -race ./pkg/costledger ./cmd/server/virtual-tools ./cmd/server -run "TestSQLiteLedgerConcurrent|TestSQLiteLedgerMigration|TestCostObserverRecordsPerCall|TestRecordPricedToolCost"`
- pre-commit: gitleaks, golangci-lint, agent build, workspace build, Electron directory build

`go test ./...` reaches all packages but current `main` has three unrelated stale provider-default assertions: `TestProviderProfileOverridesStaleExplicitChatLLM`, `TestResolveDelegationTierConfigExpandsProviderProfile`, and `TestWorkshopResolveLLMConfigExpandsCodingAgentMode`.

## Follow-up scope

This is the canonical storage/write foundation. A follow-up PR should move workflow/Pulse/org read paths from legacy daily JSON files to scoped paginated SQLite queries, then remove those compatibility writers after a verification window.