### PR TITLE
Harden schedule and Pulse run lifecycle

### DIFF
--- a/agent_go/cmd/server/activity_status_tool.go
+++ b/agent_go/cmd/server/activity_status_tool.go
@@ -130,7 +130,7 @@ func (api *StreamingAPI) listRunningScheduleActivities(ctx context.Context, curr
 			continue
 		}
 		for _, sched := range wf.Manifest.Schedules {
-			state := api.scheduler.GetRuntimeState(sched.ID)
+			state := api.scheduler.GetRuntimeStateForWorkflow(wf.WorkspacePath, sched.ID)
 			if !strings.EqualFold(state.LastStatus, "running") {
 				continue
 			}
@@ -158,7 +158,7 @@ func (api *StreamingAPI) listRunningScheduleActivities(ctx context.Context, curr
 			return nil, fmt.Errorf("failed to read multi-agent schedules: %w", err)
 		} else if exists && f != nil {
 			for _, sched := range MergeBuiltinSchedules(f.Schedules) {
-				state := api.scheduler.GetRuntimeState(sched.ID)
+				state := api.scheduler.GetRuntimeStateForUser(currentUserID, sched.ID)
 				if !strings.EqualFold(state.LastStatus, "running") {
 					continue
 				}

--- a/agent_go/cmd/server/multiagent_schedule_store.go
+++ b/agent_go/cmd/server/multiagent_schedule_store.go
@@ -121,6 +121,14 @@ func DiscoverMultiAgentSchedules(ctx context.Context) ([]DiscoveredMultiAgentSch
 
 // ReadMultiAgentScheduleRuns reads run history for a user's multi-agent schedules.
 func ReadMultiAgentScheduleRuns(ctx context.Context, userID string) ([]ScheduleRunEntry, error) {
+	path := multiAgentScheduleRunsPath(userID)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+	return readMultiAgentScheduleRunsUnlocked(ctx, userID)
+}
+
+func readMultiAgentScheduleRunsUnlocked(ctx context.Context, userID string) ([]ScheduleRunEntry, error) {
 	content, exists, err := readFileFromWorkspace(ctx, multiAgentScheduleRunsPath(userID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read multiagent-schedule-runs.json: %w", err)
@@ -138,6 +146,14 @@ func ReadMultiAgentScheduleRuns(ctx context.Context, userID string) ([]ScheduleR
 
 // WriteMultiAgentScheduleRuns writes run history for a user's multi-agent schedules.
 func WriteMultiAgentScheduleRuns(ctx context.Context, userID string, runs []ScheduleRunEntry) error {
+	path := multiAgentScheduleRunsPath(userID)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+	return writeMultiAgentScheduleRunsUnlocked(ctx, userID, runs)
+}
+
+func writeMultiAgentScheduleRunsUnlocked(ctx context.Context, userID string, runs []ScheduleRunEntry) error {
 	data, err := json.MarshalIndent(runs, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal multiagent-schedule-runs.json: %w", err)
@@ -147,9 +163,17 @@ func WriteMultiAgentScheduleRuns(ctx context.Context, userID string, runs []Sche
 
 // AppendMultiAgentScheduleRun adds a run entry for a user's multi-agent schedule.
 func AppendMultiAgentScheduleRun(ctx context.Context, userID string, run *ScheduleRunEntry) error {
-	runs, err := ReadMultiAgentScheduleRuns(ctx, userID)
+	if run == nil {
+		return fmt.Errorf("multi-agent schedule run is required")
+	}
+	path := multiAgentScheduleRunsPath(userID)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	runs, err := readMultiAgentScheduleRunsUnlocked(ctx, userID)
 	if err != nil {
-		runs = []ScheduleRunEntry{}
+		return err
 	}
 
 	runs = append([]ScheduleRunEntry{*run}, runs...) // prepend (newest first)
@@ -158,12 +182,17 @@ func AppendMultiAgentScheduleRun(ctx context.Context, userID string, run *Schedu
 		runs = runs[:maxScheduleRuns]
 	}
 
-	return WriteMultiAgentScheduleRuns(ctx, userID, runs)
+	return writeMultiAgentScheduleRunsUnlocked(ctx, userID, runs)
 }
 
 // UpdateMultiAgentScheduleRun updates a run entry for a user's multi-agent schedule.
 func UpdateMultiAgentScheduleRun(ctx context.Context, userID string, runID string, status string, errMsg string, durationMs *int64, sessionID string) error {
-	runs, err := ReadMultiAgentScheduleRuns(ctx, userID)
+	path := multiAgentScheduleRunsPath(userID)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	runs, err := readMultiAgentScheduleRunsUnlocked(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -176,15 +205,15 @@ func UpdateMultiAgentScheduleRun(ctx context.Context, userID string, runID strin
 			if sessionID != "" {
 				runs[i].SessionID = sessionID
 			}
-			if status == "success" || status == "error" {
+			if isTerminalScheduleRunStatus(status) {
 				now := time.Now().UTC()
 				runs[i].CompletedAt = &now
 			}
-			return WriteMultiAgentScheduleRuns(ctx, userID, runs)
+			return writeMultiAgentScheduleRunsUnlocked(ctx, userID, runs)
 		}
 	}
 
-	return nil
+	return fmt.Errorf("multi-agent schedule run %q not found in %s", runID, path)
 }
 
 // ListMultiAgentScheduleRuns returns runs for a specific schedule ID with pagination.

--- a/agent_go/cmd/server/multiagent_schedule_tools.go
+++ b/agent_go/cmd/server/multiagent_schedule_tools.go
@@ -226,7 +226,7 @@ func createMultiAgentScheduleExecutors(api *StreamingAPI, currentUserID string) 
 					sb.WriteString(fmt.Sprintf("  - query: %s\n", s.Query))
 				}
 				if api.scheduler != nil {
-					st := api.scheduler.GetRuntimeState(s.ID)
+					st := api.scheduler.GetRuntimeStateForUser(userID, s.ID)
 					if st.LastStatus != "" {
 						lastRun := ""
 						if st.LastRunAt != nil {

--- a/agent_go/cmd/server/runtime_state_consistency_test.go
+++ b/agent_go/cmd/server/runtime_state_consistency_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -147,27 +148,29 @@ func TestInactiveCleanupEvictsRuntimeCoordinatorRecord(t *testing.T) {
 func TestScheduleStopInvalidatesLateCompletion(t *testing.T) {
 	canceled := false
 	startedAt := time.Now().Add(-time.Minute)
+	runtimeKey := workflowScheduleRuntimeKey("/tmp/workflow", "schedule-1")
 	svc := &SchedulerService{
 		runtimeStates: map[string]*ScheduleRuntimeState{
-			"schedule-1": {
-				LastStatus: "running", LastRunAt: &startedAt, runGeneration: 4,
-				runCancel: func() { canceled = true },
+			runtimeKey: {
+				ActiveRunID: "run-1", LastStatus: "running", LastRunAt: &startedAt,
 			},
 		},
+		runCancels: map[string]context.CancelFunc{"run-1": func() { canceled = true }},
 	}
 
 	svc.StopRunningJob("schedule-1")
-	state := svc.GetRuntimeState("schedule-1")
+	state := svc.getRuntimeStateByKey(runtimeKey)
 	if state.LastStatus != "stopped" || state.LastError != "stopped by user" {
 		t.Fatalf("stopped state = %#v", state)
 	}
 	if !canceled {
 		t.Fatal("StopRunningJob did not cancel the run context")
 	}
-	if svc.finishScheduleRun("schedule-1", 4, "success", "", 100, nil) {
-		t.Fatal("late generation was allowed to commit")
+	sctx := &ScheduleContext{WorkspacePath: "/tmp/workflow", Schedule: WorkflowSchedule{ID: "schedule-1"}}
+	if _, err := svc.runJob(context.Background(), sctx, "run-1"); !errors.Is(err, errWorkshopSequenceInterrupted) {
+		t.Fatalf("late run error = %v, want errWorkshopSequenceInterrupted", err)
 	}
-	state = svc.GetRuntimeState("schedule-1")
+	state = svc.getRuntimeStateByKey(runtimeKey)
 	if state.LastStatus != "stopped" {
 		t.Fatalf("late completion overwrote stopped state with %q", state.LastStatus)
 	}
@@ -180,7 +183,7 @@ func TestScheduleRuntimeReadReturnsSnapshot(t *testing.T) {
 		"schedule-1": {LastStatus: "running", LastRunAt: &lastRun, LastDurationMs: &duration},
 	}}
 
-	snapshot := svc.getRuntimeStateSnapshot("schedule-1")
+	snapshot := svc.getRuntimeStateByKey("schedule-1")
 	snapshot.LastStatus = "stopped"
 	*snapshot.LastRunAt = time.Time{}
 	*snapshot.LastDurationMs = 999

--- a/agent_go/cmd/server/schedule_runs.go
+++ b/agent_go/cmd/server/schedule_runs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,7 +23,7 @@ type ScheduleRunEntry struct {
 	ScheduleID  string     `json:"schedule_id"`
 	RunFolder   string     `json:"run_folder,omitempty"`
 	SessionID   string     `json:"session_id,omitempty"`
-	Status      string     `json:"status"` // running, success, error
+	Status      string     `json:"status"` // running, success, error, stopped, partial, interrupted
 	Error       string     `json:"error,omitempty"`
 	DurationMs  *int64     `json:"duration_ms,omitempty"`
 	GroupNames  []string   `json:"group_names,omitempty"`
@@ -32,12 +33,27 @@ type ScheduleRunEntry struct {
 
 const maxScheduleRuns = 200
 
+var scheduleRunFileLocks sync.Map
+
+func scheduleRunFileLock(path string) *sync.Mutex {
+	lock, _ := scheduleRunFileLocks.LoadOrStore(path, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
 func scheduleRunsPath(workspacePath string) string {
 	return workspacePath + "/schedule-runs.json"
 }
 
 // ReadScheduleRuns reads all run entries from <workspace>/schedule-runs.json.
 func ReadScheduleRuns(ctx context.Context, workspacePath string) ([]ScheduleRunEntry, error) {
+	path := scheduleRunsPath(workspacePath)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+	return readScheduleRunsUnlocked(ctx, workspacePath)
+}
+
+func readScheduleRunsUnlocked(ctx context.Context, workspacePath string) ([]ScheduleRunEntry, error) {
 	content, exists, err := readFileFromWorkspace(ctx, scheduleRunsPath(workspacePath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read schedule-runs.json: %w", err)
@@ -55,6 +71,14 @@ func ReadScheduleRuns(ctx context.Context, workspacePath string) ([]ScheduleRunE
 
 // WriteScheduleRuns writes run entries to <workspace>/schedule-runs.json.
 func WriteScheduleRuns(ctx context.Context, workspacePath string, runs []ScheduleRunEntry) error {
+	path := scheduleRunsPath(workspacePath)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+	return writeScheduleRunsUnlocked(ctx, workspacePath, runs)
+}
+
+func writeScheduleRunsUnlocked(ctx context.Context, workspacePath string, runs []ScheduleRunEntry) error {
 	data, err := json.MarshalIndent(runs, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal schedule runs: %w", err)
@@ -64,10 +88,17 @@ func WriteScheduleRuns(ctx context.Context, workspacePath string, runs []Schedul
 
 // AppendScheduleRun adds a run entry, keeping at most maxScheduleRuns entries (trimming oldest).
 func AppendScheduleRun(ctx context.Context, workspacePath string, run *ScheduleRunEntry) error {
-	runs, err := ReadScheduleRuns(ctx, workspacePath)
+	if run == nil {
+		return fmt.Errorf("schedule run is required")
+	}
+	path := scheduleRunsPath(workspacePath)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	runs, err := readScheduleRunsUnlocked(ctx, workspacePath)
 	if err != nil {
-		// If file is corrupt, start fresh
-		runs = []ScheduleRunEntry{}
+		return err
 	}
 
 	runs = append([]ScheduleRunEntry{*run}, runs...) // prepend (newest first)
@@ -76,12 +107,17 @@ func AppendScheduleRun(ctx context.Context, workspacePath string, run *ScheduleR
 		runs = runs[:maxScheduleRuns]
 	}
 
-	return WriteScheduleRuns(ctx, workspacePath, runs)
+	return writeScheduleRunsUnlocked(ctx, workspacePath, runs)
 }
 
 // UpdateScheduleRun finds a run by ID and updates its fields.
 func UpdateScheduleRun(ctx context.Context, workspacePath string, runID string, status string, errMsg string, durationMs *int64, runFolder string, sessionID string) error {
-	runs, err := ReadScheduleRuns(ctx, workspacePath)
+	path := scheduleRunsPath(workspacePath)
+	lock := scheduleRunFileLock(path)
+	lock.Lock()
+	defer lock.Unlock()
+
+	runs, err := readScheduleRunsUnlocked(ctx, workspacePath)
 	if err != nil {
 		return err
 	}
@@ -97,15 +133,24 @@ func UpdateScheduleRun(ctx context.Context, workspacePath string, runID string, 
 			if sessionID != "" {
 				runs[i].SessionID = sessionID
 			}
-			if status == "success" || status == "error" {
+			if isTerminalScheduleRunStatus(status) {
 				now := time.Now().UTC()
 				runs[i].CompletedAt = &now
 			}
-			return WriteScheduleRuns(ctx, workspacePath, runs)
+			return writeScheduleRunsUnlocked(ctx, workspacePath, runs)
 		}
 	}
 
-	return nil // run not found, ignore
+	return fmt.Errorf("schedule run %q not found in %s", runID, path)
+}
+
+func isTerminalScheduleRunStatus(status string) bool {
+	switch status {
+	case "success", "error", "stopped", "partial", "failed", "interrupted":
+		return true
+	default:
+		return false
+	}
 }
 
 // ListScheduleRuns returns runs for a specific schedule ID with pagination.

--- a/agent_go/cmd/server/schedule_runs_test.go
+++ b/agent_go/cmd/server/schedule_runs_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type scheduleRunWorkspaceStub struct {
+	mu    sync.Mutex
+	files map[string]string
+}
+
+func newScheduleRunWorkspaceStub(t *testing.T) (*scheduleRunWorkspaceStub, *httptest.Server) {
+	t.Helper()
+	stub := &scheduleRunWorkspaceStub{files: make(map[string]string)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/documents/")
+		stub.mu.Lock()
+		defer stub.mu.Unlock()
+		switch r.Method {
+		case http.MethodGet:
+			content, ok := stub.files[path]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"data":    map[string]any{"content": content},
+			})
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			var payload struct {
+				Content string `json:"content"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			stub.files[path] = payload.Content
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("WORKSPACE_API_URL", server.URL)
+	return stub, server
+}
+
+func TestAppendScheduleRunPreservesConcurrentEntries(t *testing.T) {
+	_, _ = newScheduleRunWorkspaceStub(t)
+	const count = 40
+
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			run := &ScheduleRunEntry{
+				ID:         string(rune('A' + index)),
+				ScheduleID: "schedule-1",
+				Status:     "running",
+				StartedAt:  time.Now().UTC(),
+			}
+			if err := AppendScheduleRun(context.Background(), "Workflow/test", run); err != nil {
+				t.Errorf("AppendScheduleRun(%d): %v", index, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	runs, err := ReadScheduleRuns(context.Background(), "Workflow/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != count {
+		t.Fatalf("len(runs) = %d, want %d", len(runs), count)
+	}
+}
+
+func TestAppendScheduleRunDoesNotEraseCorruptHistory(t *testing.T) {
+	stub, _ := newScheduleRunWorkspaceStub(t)
+	stub.files["Workflow/test/schedule-runs.json"] = "{not valid json"
+
+	err := AppendScheduleRun(context.Background(), "Workflow/test", &ScheduleRunEntry{
+		ID:         "run-2",
+		ScheduleID: "schedule-1",
+		Status:     "running",
+		StartedAt:  time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("AppendScheduleRun() error = nil, want corrupt-history error")
+	}
+	if got := stub.files["Workflow/test/schedule-runs.json"]; got != "{not valid json" {
+		t.Fatalf("corrupt history was overwritten: %q", got)
+	}
+}
+
+func TestUpdateScheduleRunRejectsMissingRunAndCompletesStoppedRun(t *testing.T) {
+	_, _ = newScheduleRunWorkspaceStub(t)
+	ctx := context.Background()
+	run := &ScheduleRunEntry{
+		ID:         "run-1",
+		ScheduleID: "schedule-1",
+		Status:     "running",
+		StartedAt:  time.Now().UTC(),
+	}
+	if err := AppendScheduleRun(ctx, "Workflow/test", run); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateScheduleRun(ctx, "Workflow/test", "missing", "success", "", nil, "", ""); err == nil {
+		t.Fatal("UpdateScheduleRun(missing) error = nil")
+	}
+	if err := UpdateScheduleRun(ctx, "Workflow/test", "run-1", "stopped", "stopped by user", nil, "", "session-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	runs, err := ReadScheduleRuns(ctx, "Workflow/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runs[0].Status != "stopped" || runs[0].CompletedAt == nil {
+		t.Fatalf("updated run = %+v, want stopped with completed_at", runs[0])
+	}
+}

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -752,6 +752,7 @@ func (s *SchedulerService) GetRuntimeStateForWorkflow(workspacePath, scheduleID 
 
 func (s *SchedulerService) GetRuntimeStateForUser(userID, scheduleID string) ScheduleRuntimeState {
 	merged := s.getRuntimeStateByKey(multiAgentScheduleRuntimeKey(userID, scheduleID))
+	_ = s.reconcileMultiAgentScheduleRuns(context.Background(), userID, scheduleID)
 	runs, err := ReadMultiAgentScheduleRuns(context.Background(), userID)
 	if err == nil {
 		return mergeRuntimeStateWithRuns(merged, scheduleID, runs)
@@ -822,6 +823,48 @@ func (s *SchedulerService) reconcileWorkflowScheduleRuns(ctx context.Context, wo
 		return nil
 	}
 	return WriteScheduleRuns(ctx, workspacePath, runs)
+}
+
+func (s *SchedulerService) reconcileMultiAgentScheduleRuns(ctx context.Context, userID, scheduleID string) error {
+	if s == nil || s.api == nil || strings.TrimSpace(userID) == "" {
+		return nil
+	}
+
+	runs, err := ReadMultiAgentScheduleRuns(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	changed := false
+	for i := range runs {
+		if runs[i].Status != "running" {
+			continue
+		}
+		if scheduleID != "" && runs[i].ScheduleID != scheduleID {
+			continue
+		}
+
+		status, errMsg, shouldFinalize := s.reconciledScheduleRunStatus(&runs[i], now)
+		if !shouldFinalize {
+			continue
+		}
+
+		runs[i].Status = status
+		runs[i].Error = errMsg
+		durationMs := now.Sub(runs[i].StartedAt).Milliseconds()
+		if durationMs < 0 {
+			durationMs = 0
+		}
+		runs[i].DurationMs = &durationMs
+		runs[i].CompletedAt = &now
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+	return WriteMultiAgentScheduleRuns(ctx, userID, runs)
 }
 
 func (s *SchedulerService) reconciledScheduleRunStatus(run *ScheduleRunEntry, now time.Time) (string, string, bool) {
@@ -998,12 +1041,7 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
 		return "", err
 	}
-	state.LastStatus = "running"
-	state.ActiveRunID = runID
-	state.LastRunAt = &startTime
-	state.LastError = ""
-	state.runGeneration++
-	runGeneration := state.runGeneration
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
 	s.runtimeStatesMu.Unlock()
 	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
@@ -1011,7 +1049,6 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 		s.logf(sctx, "[SCHEDULER] Warning: failed to record manual schedule execution for %s: %v", scheduleID, err)
 	}
 
-	runCtx := s.registerScheduleRunContext(runID)
 	go func() {
 		if _, err := s.runJob(runCtx, sctx, runID); err != nil {
 			scheduleLogf("[SCHEDULER] Triggered job %s failed: %v", scheduleID, err)
@@ -1025,8 +1062,8 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string) (string, error) {
 	ctx := context.Background()
 
-	f, exists, err := ReadMultiAgentSchedules(ctx, userID)
-	if err != nil || !exists {
+	f, _, err := ReadMultiAgentSchedules(ctx, userID)
+	if err != nil {
 		return "", fmt.Errorf("failed to read multi-agent schedules for user %s: %w", userID, err)
 	}
 
@@ -1059,17 +1096,11 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
 		return "", err
 	}
-	state.LastStatus = "running"
-	state.ActiveRunID = runID
-	state.LastRunAt = &startTime
-	state.LastError = ""
-	state.runGeneration++
-	runGeneration := state.runGeneration
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
 	s.runtimeStatesMu.Unlock()
 
 	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
-	runCtx := s.registerScheduleRunContext(runID)
 	go func() {
 		if _, err := s.runJob(runCtx, sctx, runID); err != nil {
 			scheduleLogf("[SCHEDULER] Triggered multi-agent job %s failed: %v", scheduleID, err)
@@ -1395,15 +1426,9 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		s.logf(freshCtx, "[SCHEDULER] ⏭️ Durable run lease rejected schedule %s: %v", schedID, err)
 		return
 	}
-	state.LastStatus = "running"
-	state.ActiveRunID = runID
-	state.LastRunAt = &startTime
-	state.LastError = ""
-	state.runGeneration++
-	freshCtx.runGeneration = state.runGeneration
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
 	s.runtimeStatesMu.Unlock()
 	s.recordScheduleFireDecision(ctx, freshCtx, "started", "cron fire accepted", runID, startTime)
-	runCtx := s.registerScheduleRunContext(runID)
 
 	if freshCtx.SourceType == "workflow" {
 		if err := RecordWorkflowScheduleExecution(context.Background(), freshCtx.WorkspacePath, freshCtx.Schedule, startTime); err != nil {
@@ -3198,6 +3223,16 @@ func (s *SchedulerService) updateRuntimeState(scheduleID string, update func(*Sc
 		update(state)
 	}
 	return *state
+}
+
+// activateScheduleRunLocked publishes the active run and its cancellation
+// handle as one runtime-state operation. Caller must hold runtimeStatesMu.
+func (s *SchedulerService) activateScheduleRunLocked(state *ScheduleRuntimeState, runID string, startedAt time.Time) context.Context {
+	state.LastStatus = "running"
+	state.ActiveRunID = runID
+	state.LastRunAt = &startedAt
+	state.LastError = ""
+	return s.registerScheduleRunContext(runID)
 }
 
 func (s *SchedulerService) registerScheduleRunContext(runID string) context.Context {

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -105,8 +105,6 @@ type ScheduleRuntimeState struct {
 	LastDurationMs      *int64     `json:"last_duration_ms,omitempty"`
 	RunCount            int        `json:"run_count"`
 	ConsecutiveFailures int        `json:"consecutive_failures"`
-	runGeneration       uint64
-	runCancel           context.CancelFunc
 }
 
 // registeredJob is a schedule registered for wall-clock evaluation.
@@ -778,10 +776,30 @@ func (s *SchedulerService) getRuntimeStateByKey(key string) ScheduleRuntimeState
 	s.runtimeStatesMu.RLock()
 	var merged ScheduleRuntimeState
 	if state, ok := s.runtimeStates[key]; ok {
-		merged = *state
+		merged = cloneScheduleRuntimeState(state)
 	}
 	s.runtimeStatesMu.RUnlock()
 	return merged
+}
+
+func cloneScheduleRuntimeState(state *ScheduleRuntimeState) ScheduleRuntimeState {
+	if state == nil {
+		return ScheduleRuntimeState{}
+	}
+	copy := *state
+	if state.LastRunAt != nil {
+		value := *state.LastRunAt
+		copy.LastRunAt = &value
+	}
+	if state.NextRunAt != nil {
+		value := *state.NextRunAt
+		copy.NextRunAt = &value
+	}
+	if state.LastDurationMs != nil {
+		value := *state.LastDurationMs
+		copy.LastDurationMs = &value
+	}
+	return copy
 }
 
 func (s *SchedulerService) runtimeKeysForScheduleID(scheduleID string) []string {
@@ -1499,6 +1517,16 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext, ru
 		})
 		return "", errors.Join(errWorkshopSequenceInterrupted, err)
 	}
+	if strings.TrimSpace(runID) == "" {
+		return "", errors.Join(errWorkshopSequenceInterrupted, errors.New("scheduled run is missing its run id"))
+	}
+	s.runtimeStatesMu.RLock()
+	activeState := s.runtimeStates[runtimeKey]
+	ownsActiveRun := activeState != nil && activeState.LastStatus == "running" && activeState.ActiveRunID == runID
+	s.runtimeStatesMu.RUnlock()
+	if !ownsActiveRun {
+		return "", errors.Join(errWorkshopSequenceInterrupted, fmt.Errorf("scheduled run %s no longer owns %s", runID, runtimeKey))
+	}
 
 	// Clear session/error fields — status is already "running" (set atomically by caller)
 	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
@@ -1534,7 +1562,7 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext, ru
 	})
 
 	// Execute
-	sessionID, runFolder, execErr := s.executeJob(runCtx, sctx, runID)
+	sessionID, runFolder, execErr := s.executeJob(ctx, sctx, runID)
 
 	// Calculate results
 	durationMs := time.Since(startTime).Milliseconds()
@@ -3460,45 +3488,6 @@ func (s *SchedulerService) getRuntimeStateLocked(scheduleID string) *ScheduleRun
 	state := &ScheduleRuntimeState{}
 	s.runtimeStates[scheduleID] = state
 	return state
-}
-
-func (s *SchedulerService) setScheduleSessionID(scheduleID string, generation uint64, sessionID string) bool {
-	s.runtimeStatesMu.Lock()
-	defer s.runtimeStatesMu.Unlock()
-	state := s.getRuntimeStateLocked(scheduleID)
-	if state.LastStatus != "running" || state.runGeneration != generation {
-		return false
-	}
-	state.LastSessionID = sessionID
-	return true
-}
-
-func (s *SchedulerService) scheduleRunInvalidated(scheduleID string, generation uint64) bool {
-	s.runtimeStatesMu.RLock()
-	defer s.runtimeStatesMu.RUnlock()
-	state := s.runtimeStates[scheduleID]
-	return state == nil || state.LastStatus != "running" || state.runGeneration != generation
-}
-
-func (s *SchedulerService) finishScheduleRun(scheduleID string, generation uint64, status, errMsg string, durationMs int64, nextRun *time.Time) bool {
-	s.runtimeStatesMu.Lock()
-	defer s.runtimeStatesMu.Unlock()
-	state := s.getRuntimeStateLocked(scheduleID)
-	if state.LastStatus != "running" || state.runGeneration != generation {
-		return false
-	}
-	state.LastStatus = status
-	state.LastError = errMsg
-	state.LastDurationMs = &durationMs
-	state.NextRunAt = nextRun
-	state.RunCount++
-	state.runCancel = nil
-	if status == "error" {
-		state.ConsecutiveFailures++
-	} else {
-		state.ConsecutiveFailures = 0
-	}
-	return true
 }
 
 func runningWorkflowScheduleInSetLocked(runtimeStates map[string]*ScheduleRuntimeState, scheduleIDs []string, ignoreScheduleID string) (string, string) {

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -129,6 +129,7 @@ type SchedulerService struct {
 	// schedule, including disabled and calendar schedules with no future items.
 	scheduleFingerprints map[string]string
 
+	stateStoreMu sync.RWMutex
 	stateStore   *schedulerstate.Store
 	runCancelsMu sync.Mutex
 	runCancels   map[string]context.CancelFunc
@@ -210,19 +211,23 @@ func (s *SchedulerService) InvalidateWorkflowManifestCache() {
 // and starts the wall-clock tick loop.
 func (s *SchedulerService) Start(ctx context.Context) error {
 	scheduleLogf("[SCHEDULER] Starting manifest-based scheduler service...")
+	s.stateStoreMu.Lock()
 	if s.stateStore == nil {
 		storePath := filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "schedule-state.sqlite")
 		store, err := schedulerstate.Open(storePath)
 		if err != nil {
+			s.stateStoreMu.Unlock()
 			return fmt.Errorf("initialize schedule state store: %w", err)
 		}
 		s.stateStore = store
 	}
 	if interrupted, err := s.stateStore.InterruptActiveRuns(ctx, "interrupted: server restarted", time.Now().UTC()); err != nil {
+		s.stateStoreMu.Unlock()
 		return fmt.Errorf("reconcile interrupted schedule runs: %w", err)
 	} else if interrupted > 0 {
 		scheduleLogf("[SCHEDULER] Marked %d durable schedule run(s) interrupted after restart", interrupted)
 	}
+	s.stateStoreMu.Unlock()
 
 	// Discover all workflows by scanning workspace-docs/Workflow/*/workflow.json
 	workflows := s.discoverWorkflows(ctx)
@@ -507,12 +512,14 @@ func (s *SchedulerService) Stop() {
 	s.jobs = make(map[string]*registeredJob)
 	s.scheduleFingerprints = make(map[string]string)
 	s.mu.Unlock()
+	s.stateStoreMu.Lock()
 	if s.stateStore != nil {
 		if err := s.stateStore.Close(); err != nil {
 			scheduleLogf("[SCHEDULER] Failed to close schedule state store: %v", err)
 		}
 		s.stateStore = nil
 	}
+	s.stateStoreMu.Unlock()
 	scheduleLogf("[SCHEDULER] Stopped")
 }
 
@@ -526,7 +533,6 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	if s.scheduleFingerprints == nil {
 		s.scheduleFingerprints = make(map[string]string)
 	}
-	s.scheduleFingerprints[runtimeKey] = scheduleConfigFingerprint(sctx)
 
 	// Remove existing registration if any.
 	delete(s.jobs, runtimeKey)
@@ -556,6 +562,7 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	}
 
 	if !sched.Enabled {
+		s.scheduleFingerprints[runtimeKey] = scheduleConfigFingerprint(sctx)
 		return nil
 	}
 
@@ -613,6 +620,7 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
 		state.NextRunAt = nextRun
 	})
+	s.scheduleFingerprints[runtimeKey] = scheduleConfigFingerprint(sctx)
 
 	nextRunStr := "unknown"
 	if nextRun != nil {
@@ -687,6 +695,12 @@ func (s *SchedulerService) removeJobByKey(key string) error {
 	s.userIndexMu.Lock()
 	delete(s.userIndex, key)
 	s.userIndexMu.Unlock()
+
+	s.runtimeStatesMu.Lock()
+	if state := s.runtimeStates[key]; state == nil || state.ActiveRunID == "" {
+		delete(s.runtimeStates, key)
+	}
+	s.runtimeStatesMu.Unlock()
 
 	return nil
 }
@@ -1026,7 +1040,8 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 		return "", err
 	}
 
-	// Prevent concurrent runs — check and mark atomically under the write lock
+	// Reserve the in-memory run and cancellation handle atomically, then claim
+	// the durable lease without holding the global runtime-state mutex.
 	runtimeKey := workflowScheduleRuntimeKey(workspacePath, scheduleID)
 	runID := uuid.NewString()
 	s.runtimeStatesMu.Lock()
@@ -1036,13 +1051,17 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", "schedule is already running", "", startTime)
 		return "", fmt.Errorf("job is already running (session: %s)", state.LastSessionID)
 	}
+	previousState := *state
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
+	s.runtimeStatesMu.Unlock()
 	if err := s.claimScheduleRun(ctx, sctx, runID, startTime); err != nil {
-		s.runtimeStatesMu.Unlock()
+		s.rollbackScheduleRunActivation(runtimeKey, runID, previousState)
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
 		return "", err
 	}
-	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
-	s.runtimeStatesMu.Unlock()
+	if s.abortCanceledScheduleRunBeforeStart(runCtx, sctx, runtimeKey, runID) {
+		return "", context.Canceled
+	}
 	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
 	if err := RecordWorkflowScheduleExecution(context.Background(), workspacePath, *sched, startTime); err != nil {
@@ -1091,13 +1110,17 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", "schedule is already running", "", startTime)
 		return "", fmt.Errorf("job is already running (session: %s)", state.LastSessionID)
 	}
+	previousState := *state
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
+	s.runtimeStatesMu.Unlock()
 	if err := s.claimScheduleRun(ctx, sctx, runID, startTime); err != nil {
-		s.runtimeStatesMu.Unlock()
+		s.rollbackScheduleRunActivation(runtimeKey, runID, previousState)
 		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
 		return "", err
 	}
-	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
-	s.runtimeStatesMu.Unlock()
+	if s.abortCanceledScheduleRunBeforeStart(runCtx, sctx, runtimeKey, runID) {
+		return "", context.Canceled
+	}
 
 	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
@@ -1136,11 +1159,16 @@ func (s *SchedulerService) stopRunningJob(runtimeKey, scheduleID string) {
 	state.LastError = "stopped by user"
 	state.ActiveRunID = ""
 	s.runtimeStatesMu.Unlock()
-	if runID == "" && s.stateStore != nil {
+	if runID == "" {
 		lockKey := scheduleStateLockKeyFromRuntimeKey(runtimeKey)
-		if active, err := s.stateStore.ActiveRunByLockKey(context.Background(), lockKey); err == nil {
-			runID = active.RunID
+		s.stateStoreMu.RLock()
+		store := s.stateStore
+		if store != nil {
+			if active, err := store.ActiveRunByLockKey(context.Background(), lockKey); err == nil {
+				runID = active.RunID
+			}
 		}
+		s.stateStoreMu.RUnlock()
 	}
 	if runID != "" {
 		s.cancelScheduleRunContext(runID)
@@ -1396,11 +1424,14 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		}
 	}
 
-	// Prevent concurrent runs — check and mark atomically under the write lock
+	// Reserve in memory before the durable claim so Stop can cancel even while
+	// SQLite is claiming the lease. The database call itself runs without the
+	// global runtime-state mutex.
 	startTime := time.Now().UTC()
 	runID := uuid.NewString()
+	runtimeKey = scheduleRuntimeKey(freshCtx)
 	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(scheduleRuntimeKey(freshCtx))
+	state := s.getRuntimeStateLocked(runtimeKey)
 	if state.LastStatus == "running" {
 		s.runtimeStatesMu.Unlock()
 		s.sessionLogf(freshCtx, state.LastSessionID, "[SCHEDULER] ⏭️ Schedule %s is already running (session: %s), skipping", schedID, state.LastSessionID)
@@ -1420,14 +1451,18 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 			return
 		}
 	}
+	previousState := *state
+	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
+	s.runtimeStatesMu.Unlock()
 	if err := s.claimScheduleRun(ctx, freshCtx, runID, startTime); err != nil {
-		s.runtimeStatesMu.Unlock()
+		s.rollbackScheduleRunActivation(runtimeKey, runID, previousState)
 		s.recordScheduleFireDecision(ctx, freshCtx, "skipped_busy", err.Error(), "", startTime)
 		s.logf(freshCtx, "[SCHEDULER] ⏭️ Durable run lease rejected schedule %s: %v", schedID, err)
 		return
 	}
-	runCtx := s.activateScheduleRunLocked(state, runID, startTime)
-	s.runtimeStatesMu.Unlock()
+	if s.abortCanceledScheduleRunBeforeStart(runCtx, freshCtx, runtimeKey, runID) {
+		return
+	}
 	s.recordScheduleFireDecision(ctx, freshCtx, "started", "cron fire accepted", runID, startTime)
 
 	if freshCtx.SourceType == "workflow" {
@@ -1623,6 +1658,7 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext, ru
 		RunID: runID, To: terminalState, Reason: "scheduled run finished with status " + status,
 		SessionID: sessionID, ErrorMessage: errMsg, At: time.Now().UTC(),
 	})
+	s.cleanupRemovedScheduleRuntimeState(runtimeKey)
 
 	return sessionID, execErr
 }
@@ -3235,6 +3271,50 @@ func (s *SchedulerService) activateScheduleRunLocked(state *ScheduleRuntimeState
 	return s.registerScheduleRunContext(runID)
 }
 
+func (s *SchedulerService) rollbackScheduleRunActivation(runtimeKey, runID string, previous ScheduleRuntimeState) {
+	s.runtimeStatesMu.Lock()
+	if current := s.runtimeStates[runtimeKey]; current != nil && current.ActiveRunID == runID {
+		*current = previous
+	}
+	s.runtimeStatesMu.Unlock()
+	s.releaseScheduleRunContext(runID)
+}
+
+func (s *SchedulerService) abortCanceledScheduleRunBeforeStart(ctx context.Context, sctx *ScheduleContext, runtimeKey, runID string) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		if state.ActiveRunID != runID {
+			return
+		}
+		state.ActiveRunID = ""
+		state.LastStatus = "stopped"
+		state.LastError = "stopped before execution started"
+	})
+	s.transitionScheduleRun(context.Background(), sctx, schedulerstate.Transition{
+		RunID: runID, To: schedulerstate.StateStopped, Reason: "stopped before execution started",
+		ErrorMessage: "stopped before execution started", At: time.Now().UTC(),
+	})
+	s.releaseScheduleRunContext(runID)
+	s.cleanupRemovedScheduleRuntimeState(runtimeKey)
+	return true
+}
+
+func (s *SchedulerService) cleanupRemovedScheduleRuntimeState(runtimeKey string) {
+	s.mu.Lock()
+	_, known := s.scheduleFingerprints[runtimeKey]
+	s.mu.Unlock()
+	if known {
+		return
+	}
+	s.runtimeStatesMu.Lock()
+	if state := s.runtimeStates[runtimeKey]; state == nil || state.ActiveRunID == "" {
+		delete(s.runtimeStates, runtimeKey)
+	}
+	s.runtimeStatesMu.Unlock()
+}
+
 func (s *SchedulerService) registerScheduleRunContext(runID string) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.runCancelsMu.Lock()
@@ -3269,6 +3349,8 @@ func (s *SchedulerService) releaseScheduleRunContext(runID string) {
 }
 
 func (s *SchedulerService) claimScheduleRun(ctx context.Context, sctx *ScheduleContext, runID string, startedAt time.Time) error {
+	s.stateStoreMu.RLock()
+	defer s.stateStoreMu.RUnlock()
 	if s.stateStore == nil {
 		return nil
 	}
@@ -3289,20 +3371,65 @@ func (s *SchedulerService) claimScheduleRun(ctx context.Context, sctx *ScheduleC
 }
 
 func (s *SchedulerService) transitionScheduleRun(ctx context.Context, sctx *ScheduleContext, transition schedulerstate.Transition) {
-	if s.stateStore == nil || strings.TrimSpace(transition.RunID) == "" {
+	if strings.TrimSpace(transition.RunID) == "" {
 		return
 	}
-	if err := s.stateStore.Transition(ctx, transition); err != nil {
+	s.stateStoreMu.RLock()
+	defer s.stateStoreMu.RUnlock()
+	if s.stateStore == nil {
+		return
+	}
+	transitionCtx := ctx
+	if transitionCtx == nil {
+		transitionCtx = context.Background()
+	}
+	attempts := 1
+	if schedulerstate.IsTerminal(transition.To) {
+		transitionCtx = context.WithoutCancel(transitionCtx)
+		attempts = 3
+	}
+	var transitionErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(transitionCtx, 5*time.Second)
+		transitionErr = s.stateStore.Transition(attemptCtx, transition)
+		cancel()
+		if transitionErr == nil {
+			return
+		}
+		if attempt+1 < attempts {
+			time.Sleep(time.Duration(attempt+1) * 50 * time.Millisecond)
+		}
+	}
+	if schedulerstate.IsTerminal(transition.To) {
+		recoveryCtx, cancel := context.WithTimeout(transitionCtx, 5*time.Second)
+		recoveryErr := s.stateStore.ForceTerminal(recoveryCtx, transition)
+		cancel()
+		if recoveryErr == nil {
+			if sctx != nil {
+				s.logf(sctx, "[SCHEDULER_STATE] recovered terminal transition run=%s to=%s after error: %v", transition.RunID, transition.To, transitionErr)
+			} else {
+				scheduleLogf("[SCHEDULER_STATE] recovered terminal transition run=%s to=%s after error: %v", transition.RunID, transition.To, transitionErr)
+			}
+			return
+		}
+		transitionErr = errors.Join(transitionErr, recoveryErr)
+	}
+	if transitionErr != nil {
 		if sctx != nil {
-			s.logf(sctx, "[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, err)
+			s.logf(sctx, "[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, transitionErr)
 		} else {
-			scheduleLogf("[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, err)
+			scheduleLogf("[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, transitionErr)
 		}
 	}
 }
 
 func (s *SchedulerService) recordScheduleFireDecision(ctx context.Context, sctx *ScheduleContext, decision, reason, runID string, firedAt time.Time) {
-	if s.stateStore == nil || sctx == nil {
+	if sctx == nil {
+		return
+	}
+	s.stateStoreMu.RLock()
+	defer s.stateStoreMu.RUnlock()
+	if s.stateStore == nil {
 		return
 	}
 	scopeType, scopeID, _ := scheduleStateScope(sctx)

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/robfig/cron/v3"
 	virtualtools "mcp-agent-builder-go/agent_go/cmd/server/virtual-tools"
 	"mcp-agent-builder-go/agent_go/pkg/fsutil"
+	"mcp-agent-builder-go/agent_go/pkg/schedulerstate"
 	"mcp-agent-builder-go/agent_go/pkg/workflowtypes"
 )
 
@@ -31,7 +33,50 @@ type ScheduleContext struct {
 	UserID        string // Set for multi-agent schedules (derived from _users/{userID}/ path)
 	SourceType    string // "workflow" or "multi-agent"
 	TriggerSource string // "cron" (default) or "manual"; encoded into the session ID
-	runGeneration uint64 // identifies the in-memory run that owns runtime-state updates
+	CalendarItem  *CalendarScheduleItem
+}
+
+const scheduleScopeSeparator = "\x1f"
+
+func workflowScheduleRuntimeKey(workspacePath, scheduleID string) string {
+	return strings.Join([]string{"workflow", filepath.Clean(strings.TrimSpace(workspacePath)), strings.TrimSpace(scheduleID)}, scheduleScopeSeparator)
+}
+
+func multiAgentScheduleRuntimeKey(userID, scheduleID string) string {
+	return strings.Join([]string{"multi-agent", strings.TrimSpace(userID), strings.TrimSpace(scheduleID)}, scheduleScopeSeparator)
+}
+
+func scheduleRuntimeKey(sctx *ScheduleContext) string {
+	if sctx == nil {
+		return ""
+	}
+	if sctx.SourceType == "multi-agent" {
+		return multiAgentScheduleRuntimeKey(sctx.UserID, sctx.Schedule.ID)
+	}
+	return workflowScheduleRuntimeKey(sctx.WorkspacePath, sctx.Schedule.ID)
+}
+
+func scheduleRuntimeKeyHasID(key, scheduleID string) bool {
+	return strings.HasSuffix(key, scheduleScopeSeparator+strings.TrimSpace(scheduleID))
+}
+
+func scheduleStateLockKeyFromRuntimeKey(runtimeKey string) string {
+	parts := strings.Split(runtimeKey, scheduleScopeSeparator)
+	if len(parts) < 3 || parts[0] != "workflow" {
+		return runtimeKey
+	}
+	return strings.Join(parts[:2], scheduleScopeSeparator)
+}
+
+func scheduleStateScope(sctx *ScheduleContext) (scopeType, scopeID, lockKey string) {
+	if sctx != nil && sctx.SourceType == "multi-agent" {
+		scopeID = strings.TrimSpace(sctx.UserID)
+		return "multi-agent", scopeID, strings.Join([]string{"multi-agent", scopeID, strings.TrimSpace(sctx.Schedule.ID)}, scheduleScopeSeparator)
+	}
+	if sctx != nil {
+		scopeID = filepath.Clean(strings.TrimSpace(sctx.WorkspacePath))
+	}
+	return "workflow", scopeID, strings.Join([]string{"workflow", scopeID}, scheduleScopeSeparator)
 }
 
 // newScheduleSessionID mints the session ID for a scheduled run. Encoding the
@@ -51,6 +96,7 @@ func (s *SchedulerService) newScheduleSessionID(sctx *ScheduleContext) string {
 
 // ScheduleRuntimeState holds in-memory runtime state for a schedule (not persisted in manifest).
 type ScheduleRuntimeState struct {
+	ActiveRunID         string     `json:"active_run_id,omitempty"`
 	LastStatus          string     `json:"last_status,omitempty"`
 	LastRunAt           *time.Time `json:"last_run_at,omitempty"`
 	NextRunAt           *time.Time `json:"next_run_at,omitempty"`
@@ -78,7 +124,14 @@ type registeredJob struct {
 type SchedulerService struct {
 	api  *StreamingAPI
 	mu   sync.Mutex
-	jobs map[string]*registeredJob // scheduleID → job
+	jobs map[string]*registeredJob // scoped schedule key → job
+	// scheduleFingerprints tracks the persisted config loaded for each scoped
+	// schedule, including disabled and calendar schedules with no future items.
+	scheduleFingerprints map[string]string
+
+	stateStore   *schedulerstate.Store
+	runCancelsMu sync.Mutex
+	runCancels   map[string]context.CancelFunc
 
 	// In-memory runtime state per schedule (survives within server lifetime, reset on restart)
 	runtimeStates   map[string]*ScheduleRuntimeState
@@ -108,11 +161,13 @@ func (s *SchedulerService) sessionLogf(sctx *ScheduleContext, sessionID string, 
 // NewSchedulerService creates a new manifest-based SchedulerService.
 func NewSchedulerService(api *StreamingAPI) *SchedulerService {
 	return &SchedulerService{
-		api:            api,
-		jobs:           make(map[string]*registeredJob),
-		runtimeStates:  make(map[string]*ScheduleRuntimeState),
-		workspaceIndex: make(map[string]string),
-		userIndex:      make(map[string]string),
+		api:                  api,
+		jobs:                 make(map[string]*registeredJob),
+		scheduleFingerprints: make(map[string]string),
+		runCancels:           make(map[string]context.CancelFunc),
+		runtimeStates:        make(map[string]*ScheduleRuntimeState),
+		workspaceIndex:       make(map[string]string),
+		userIndex:            make(map[string]string),
 	}
 }
 
@@ -155,6 +210,19 @@ func (s *SchedulerService) InvalidateWorkflowManifestCache() {
 // and starts the wall-clock tick loop.
 func (s *SchedulerService) Start(ctx context.Context) error {
 	scheduleLogf("[SCHEDULER] Starting manifest-based scheduler service...")
+	if s.stateStore == nil {
+		storePath := filepath.Join(fsutil.WorkspaceDocsRoot(), "_system", "schedule-state.sqlite")
+		store, err := schedulerstate.Open(storePath)
+		if err != nil {
+			return fmt.Errorf("initialize schedule state store: %w", err)
+		}
+		s.stateStore = store
+	}
+	if interrupted, err := s.stateStore.InterruptActiveRuns(ctx, "interrupted: server restarted", time.Now().UTC()); err != nil {
+		return fmt.Errorf("reconcile interrupted schedule runs: %w", err)
+	} else if interrupted > 0 {
+		scheduleLogf("[SCHEDULER] Marked %d durable schedule run(s) interrupted after restart", interrupted)
+	}
 
 	// Discover all workflows by scanning workspace-docs/Workflow/*/workflow.json
 	workflows := s.discoverWorkflows(ctx)
@@ -294,11 +362,13 @@ func (s *SchedulerService) tickLoop(ctx context.Context) {
 					next := job.cronSched.Next(job.lastFired)
 					if !next.After(t) {
 						toFire = append(toFire, job)
+						job.lastFired = t.Truncate(time.Minute)
 					}
 					parts = append(parts, fmt.Sprintf("%s next=%s", sid, job.cronSched.Next(t).UTC().Format(time.RFC3339)))
 				} else if job.runAt != nil {
 					if !job.runAt.After(t) && job.lastFired.Before(*job.runAt) {
 						toFire = append(toFire, job)
+						job.lastFired = t.Truncate(time.Minute)
 					}
 					parts = append(parts, fmt.Sprintf("%s at=%s", sid, job.runAt.UTC().Format(time.RFC3339)))
 				}
@@ -309,7 +379,6 @@ func (s *SchedulerService) tickLoop(ctx context.Context) {
 				t.Format(time.RFC3339), gap.Round(time.Second), len(parts), len(toFire), strings.Join(parts, ", "))
 
 			for _, job := range toFire {
-				job.lastFired = t.Truncate(time.Minute)
 				go s.triggerSchedule(job.sctx)
 			}
 
@@ -325,30 +394,35 @@ func (s *SchedulerService) rescanMultiAgentSchedules(ctx context.Context) {
 		return
 	}
 
-	// Build set of all discovered schedule IDs
+	// Build set of all discovered scoped schedule keys.
 	discovered := make(map[string]bool)
 
 	for _, ma := range maScheds {
 		for _, sched := range MergeBuiltinSchedules(ma.ScheduleFile.Schedules) {
-			discovered[sched.ID] = true
+			sctx := buildMultiAgentScheduleContext(ma.UserID, sched, ma.ScheduleFile.Capabilities)
+			key := scheduleRuntimeKey(sctx)
+			discovered[key] = true
 
-			// Check if already loaded with same enabled state
+			fingerprint := scheduleConfigFingerprint(sctx)
 			s.mu.Lock()
-			_, isLoaded := s.jobs[sched.ID]
+			loadedFingerprint, isKnown := s.scheduleFingerprints[key]
 			s.mu.Unlock()
 
-			if sched.Enabled && !isLoaded {
-				// New or re-enabled schedule
-				sctx := buildMultiAgentScheduleContext(ma.UserID, sched, ma.ScheduleFile.Capabilities)
+			if sched.Enabled && (!isKnown || loadedFingerprint != fingerprint) {
+				// New, re-enabled, or changed schedule.
 				if err := s.LoadSchedule(sctx); err != nil {
 					scheduleLogf("[SCHEDULER] Rescan: failed to load multi-agent schedule %s: %v", sched.ID, err)
 				} else {
-					scheduleLogf("[SCHEDULER] Rescan: loaded new multi-agent schedule %s (%s) for user %s", sched.ID, sched.Name, ma.UserID)
+					scheduleLogf("[SCHEDULER] Rescan: loaded new or changed multi-agent schedule %s (%s) for user %s", sched.ID, sched.Name, ma.UserID)
 				}
-			} else if !sched.Enabled && isLoaded {
-				// Disabled — remove
-				_ = s.RemoveJob(sched.ID)
-				scheduleLogf("[SCHEDULER] Rescan: removed disabled multi-agent schedule %s", sched.ID)
+			} else if !sched.Enabled && (!isKnown || loadedFingerprint != fingerprint) {
+				// Newly disabled or changed while disabled. LoadSchedule removes any
+				// live registration and remembers this exact disabled config.
+				if err := s.LoadSchedule(sctx); err != nil {
+					scheduleLogf("[SCHEDULER] Rescan: failed to disable multi-agent schedule %s: %v", sched.ID, err)
+				} else {
+					scheduleLogf("[SCHEDULER] Rescan: removed disabled multi-agent schedule %s", sched.ID)
+				}
 			}
 		}
 	}
@@ -356,16 +430,16 @@ func (s *SchedulerService) rescanMultiAgentSchedules(ctx context.Context) {
 	// Remove schedules that were deleted from files
 	s.userIndexMu.RLock()
 	toRemove := []string{}
-	for schedID := range s.userIndex {
-		if !discovered[schedID] {
-			toRemove = append(toRemove, schedID)
+	for key := range s.userIndex {
+		if !discovered[key] {
+			toRemove = append(toRemove, key)
 		}
 	}
 	s.userIndexMu.RUnlock()
 
-	for _, schedID := range toRemove {
-		_ = s.RemoveJob(schedID)
-		scheduleLogf("[SCHEDULER] Rescan: removed deleted multi-agent schedule %s", schedID)
+	for _, key := range toRemove {
+		_ = s.removeJobByKey(key)
+		scheduleLogf("[SCHEDULER] Rescan: removed deleted multi-agent schedule %s", key)
 	}
 }
 
@@ -422,9 +496,23 @@ func buildMultiAgentScheduleContext(userID string, sched WorkflowSchedule, caps 
 
 // Stop shuts down the scheduler.
 func (s *SchedulerService) Stop() {
+	s.runCancelsMu.Lock()
+	runCancels := s.runCancels
+	s.runCancels = make(map[string]context.CancelFunc)
+	s.runCancelsMu.Unlock()
+	for _, cancel := range runCancels {
+		cancel()
+	}
 	s.mu.Lock()
 	s.jobs = make(map[string]*registeredJob)
+	s.scheduleFingerprints = make(map[string]string)
 	s.mu.Unlock()
+	if s.stateStore != nil {
+		if err := s.stateStore.Close(); err != nil {
+			scheduleLogf("[SCHEDULER] Failed to close schedule state store: %v", err)
+		}
+		s.stateStore = nil
+	}
 	scheduleLogf("[SCHEDULER] Stopped")
 }
 
@@ -434,13 +522,24 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	defer s.mu.Unlock()
 
 	sched := sctx.Schedule
+	runtimeKey := scheduleRuntimeKey(sctx)
+	if s.scheduleFingerprints == nil {
+		s.scheduleFingerprints = make(map[string]string)
+	}
+	s.scheduleFingerprints[runtimeKey] = scheduleConfigFingerprint(sctx)
 
 	// Remove existing registration if any.
-	delete(s.jobs, sched.ID)
+	delete(s.jobs, runtimeKey)
+	calendarPrefix := runtimeKey + "__cal__"
+	for key := range s.jobs {
+		if strings.HasPrefix(key, calendarPrefix) {
+			delete(s.jobs, key)
+		}
+	}
 
 	// Update workspace index
 	s.workspaceIndexMu.Lock()
-	s.workspaceIndex[sched.ID] = sctx.WorkspacePath
+	s.workspaceIndex[runtimeKey] = sctx.WorkspacePath
 	s.workspaceIndexMu.Unlock()
 
 	if sctx.SourceType == "workflow" {
@@ -452,7 +551,7 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	// Update user index for multi-agent schedules
 	if sctx.UserID != "" {
 		s.userIndexMu.Lock()
-		s.userIndex[sched.ID] = sctx.UserID
+		s.userIndex[runtimeKey] = sctx.UserID
 		s.userIndexMu.Unlock()
 	}
 
@@ -478,7 +577,8 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 			itemCopy := item
 			itemSctx := sctxCopy
 			itemSctx.Schedule = scheduleWithCalendarItem(sched, itemCopy)
-			calID := fmt.Sprintf("%s__cal__%s_%s", sched.ID, item.Date, item.Time)
+			itemSctx.CalendarItem = &itemCopy
+			calID := fmt.Sprintf("%s__cal__%s_%s", runtimeKey, item.Date, item.Time)
 			s.jobs[calID] = &registeredJob{
 				sctx:  &itemSctx,
 				runAt: &runAt,
@@ -501,7 +601,7 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 		// Wrap with timezone-aware location
 		cronSched = &tzSchedule{inner: cronSched, loc: loc}
 
-		s.jobs[sched.ID] = &registeredJob{
+		s.jobs[runtimeKey] = &registeredJob{
 			sctx:      &sctxCopy,
 			cronSched: cronSched,
 			lastFired: time.Now().Add(-30 * time.Second), // don't fire immediately on registration
@@ -510,10 +610,9 @@ func (s *SchedulerService) LoadSchedule(sctx *ScheduleContext) error {
 	}
 
 	// Initialize runtime state with next run.
-	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(sched.ID)
-	state.NextRunAt = nextRun
-	s.runtimeStatesMu.Unlock()
+	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.NextRunAt = nextRun
+	})
 
 	nextRunStr := "unknown"
 	if nextRun != nil {
@@ -549,14 +648,14 @@ func (s *SchedulerService) ReloadSchedule(ctx context.Context, workspacePath str
 	}
 
 	// Schedule not found — remove it
-	return s.RemoveJob(scheduleID)
+	return s.removeJobByKey(workflowScheduleRuntimeKey(workspacePath, scheduleID))
 }
 
 // ReloadMultiAgentSchedule reloads a multi-agent schedule after it's been updated.
 func (s *SchedulerService) ReloadMultiAgentSchedule(ctx context.Context, userID string, scheduleID string) error {
 	f, exists, err := ReadMultiAgentSchedules(ctx, userID)
 	if err != nil || !exists {
-		return s.RemoveJob(scheduleID)
+		return s.removeJobByKey(multiAgentScheduleRuntimeKey(userID, scheduleID))
 	}
 
 	for _, sched := range MergeBuiltinSchedules(f.Schedules) {
@@ -565,15 +664,15 @@ func (s *SchedulerService) ReloadMultiAgentSchedule(ctx context.Context, userID 
 		}
 	}
 
-	return s.RemoveJob(scheduleID)
+	return s.removeJobByKey(multiAgentScheduleRuntimeKey(userID, scheduleID))
 }
 
-// RemoveJob removes a schedule from the tick loop.
-func (s *SchedulerService) RemoveJob(id string) error {
+func (s *SchedulerService) removeJobByKey(key string) error {
 	s.mu.Lock()
-	delete(s.jobs, id)
-	// Also remove calendar sub-jobs (keyed as id__cal__date_time)
-	prefix := id + "__cal__"
+	delete(s.jobs, key)
+	delete(s.scheduleFingerprints, key)
+	// Also remove calendar sub-jobs.
+	prefix := key + "__cal__"
 	for k := range s.jobs {
 		if strings.HasPrefix(k, prefix) {
 			delete(s.jobs, k)
@@ -582,67 +681,105 @@ func (s *SchedulerService) RemoveJob(id string) error {
 	s.mu.Unlock()
 
 	s.workspaceIndexMu.Lock()
-	delete(s.workspaceIndex, id)
+	delete(s.workspaceIndex, key)
 	s.workspaceIndexMu.Unlock()
 
 	s.userIndexMu.Lock()
-	delete(s.userIndex, id)
+	delete(s.userIndex, key)
 	s.userIndexMu.Unlock()
 
 	return nil
 }
 
-// GetRuntimeState returns the in-memory runtime state for a schedule.
+// RemoveJob removes a schedule only when its ID resolves to one loaded scope.
+// Scoped callers should use ReloadSchedule/ReloadMultiAgentSchedule or the
+// dedicated helpers below so a copied schedule cannot remove another scope.
+func (s *SchedulerService) RemoveJob(scheduleID string) error {
+	keys := s.loadedScheduleKeys(scheduleID)
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(keys) > 1 {
+		return fmt.Errorf("schedule ID %q is ambiguous across %d scopes", scheduleID, len(keys))
+	}
+	return s.removeJobByKey(keys[0])
+}
+
+func (s *SchedulerService) RemoveWorkflowJob(workspacePath, scheduleID string) error {
+	return s.removeJobByKey(workflowScheduleRuntimeKey(workspacePath, scheduleID))
+}
+
+func (s *SchedulerService) RemoveMultiAgentJob(userID, scheduleID string) error {
+	return s.removeJobByKey(multiAgentScheduleRuntimeKey(userID, scheduleID))
+}
+
+func (s *SchedulerService) loadedScheduleKeys(scheduleID string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, 1)
+	for key, job := range s.jobs {
+		if strings.Contains(key, "__cal__") || job == nil || job.sctx == nil || job.sctx.Schedule.ID != scheduleID {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// GetRuntimeState is the legacy unscoped lookup. It returns state only when the
+// schedule ID resolves to one loaded scope; scoped callers must use the methods
+// below so copied workflows and per-user built-ins cannot collide.
 func (s *SchedulerService) GetRuntimeState(scheduleID string) ScheduleRuntimeState {
-	merged := s.getRuntimeStateSnapshot(scheduleID)
-
-	if userID := s.GetUserForSchedule(scheduleID); userID != "" {
-		runs, err := ReadMultiAgentScheduleRuns(context.Background(), userID)
-		if err == nil {
-			return mergeRuntimeStateWithRuns(merged, scheduleID, runs)
-		}
-		return merged
+	keys := s.runtimeKeysForScheduleID(scheduleID)
+	if len(keys) == 1 {
+		return s.getRuntimeStateByKey(keys[0])
 	}
+	// Preserve tests and pre-migration in-memory state that used a bare key.
+	return s.getRuntimeStateByKey(scheduleID)
+}
 
-	if workspacePath := s.GetWorkspaceForSchedule(scheduleID); workspacePath != "" {
-		_ = s.reconcileWorkflowScheduleRuns(context.Background(), workspacePath, scheduleID)
-		runs, err := ReadScheduleRuns(context.Background(), workspacePath)
-		if err == nil {
-			return mergeRuntimeStateWithRuns(merged, scheduleID, runs)
-		}
+func (s *SchedulerService) GetRuntimeStateForWorkflow(workspacePath, scheduleID string) ScheduleRuntimeState {
+	key := workflowScheduleRuntimeKey(workspacePath, scheduleID)
+	merged := s.getRuntimeStateByKey(key)
+	_ = s.reconcileWorkflowScheduleRuns(context.Background(), workspacePath, scheduleID)
+	runs, err := ReadScheduleRuns(context.Background(), workspacePath)
+	if err == nil {
+		return mergeRuntimeStateWithRuns(merged, scheduleID, runs)
 	}
-
 	return merged
 }
 
-func (s *SchedulerService) getRuntimeStateSnapshot(scheduleID string) ScheduleRuntimeState {
-	s.runtimeStatesMu.RLock()
-	defer s.runtimeStatesMu.RUnlock()
-	if state, ok := s.runtimeStates[scheduleID]; ok && state != nil {
-		return cloneScheduleRuntimeState(state)
+func (s *SchedulerService) GetRuntimeStateForUser(userID, scheduleID string) ScheduleRuntimeState {
+	merged := s.getRuntimeStateByKey(multiAgentScheduleRuntimeKey(userID, scheduleID))
+	runs, err := ReadMultiAgentScheduleRuns(context.Background(), userID)
+	if err == nil {
+		return mergeRuntimeStateWithRuns(merged, scheduleID, runs)
 	}
-	return ScheduleRuntimeState{}
+	return merged
 }
 
-func cloneScheduleRuntimeState(state *ScheduleRuntimeState) ScheduleRuntimeState {
-	if state == nil {
-		return ScheduleRuntimeState{}
+func (s *SchedulerService) getRuntimeStateByKey(key string) ScheduleRuntimeState {
+	s.runtimeStatesMu.RLock()
+	var merged ScheduleRuntimeState
+	if state, ok := s.runtimeStates[key]; ok {
+		merged = *state
 	}
-	copy := *state
-	copy.runCancel = nil
-	if state.LastRunAt != nil {
-		value := *state.LastRunAt
-		copy.LastRunAt = &value
+	s.runtimeStatesMu.RUnlock()
+	return merged
+}
+
+func (s *SchedulerService) runtimeKeysForScheduleID(scheduleID string) []string {
+	s.runtimeStatesMu.RLock()
+	defer s.runtimeStatesMu.RUnlock()
+	keys := make([]string, 0, 1)
+	for key := range s.runtimeStates {
+		if scheduleRuntimeKeyHasID(key, scheduleID) {
+			keys = append(keys, key)
+		}
 	}
-	if state.NextRunAt != nil {
-		value := *state.NextRunAt
-		copy.NextRunAt = &value
-	}
-	if state.LastDurationMs != nil {
-		value := *state.LastDurationMs
-		copy.LastDurationMs = &value
-	}
-	return copy
+	sort.Strings(keys)
+	return keys
 }
 
 func (s *SchedulerService) reconcileWorkflowScheduleRuns(ctx context.Context, workspacePath, scheduleID string) error {
@@ -733,6 +870,13 @@ func mergeRuntimeStateWithRuns(state ScheduleRuntimeState, scheduleID string, ru
 	if state.RunCount < len(filtered) {
 		state.RunCount = len(filtered)
 	}
+	// File history records the workflow result before Pulse finishes. Preserve
+	// the live in-memory state for that same run so the UI cannot report success
+	// and admit another trigger while Pulse still owns the session.
+	if state.LastStatus == "running" &&
+		(state.LastSessionID == "" || latest.SessionID == "" || latest.SessionID == state.LastSessionID) {
+		return state
+	}
 
 	shouldAdoptLatest := state.LastRunAt == nil || latest.StartedAt.After(*state.LastRunAt)
 	sameRun := state.LastRunAt != nil && latest.StartedAt.Equal(*state.LastRunAt)
@@ -769,14 +913,34 @@ func mergeRuntimeStateWithRuns(state ScheduleRuntimeState, scheduleID string, ru
 func (s *SchedulerService) GetWorkspaceForSchedule(scheduleID string) string {
 	s.workspaceIndexMu.RLock()
 	defer s.workspaceIndexMu.RUnlock()
-	return s.workspaceIndex[scheduleID]
+	match := ""
+	for key, workspacePath := range s.workspaceIndex {
+		if !scheduleRuntimeKeyHasID(key, scheduleID) {
+			continue
+		}
+		if match != "" && match != workspacePath {
+			return ""
+		}
+		match = workspacePath
+	}
+	return match
 }
 
 // GetUserForSchedule returns the user ID for a multi-agent schedule ID.
 func (s *SchedulerService) GetUserForSchedule(scheduleID string) string {
 	s.userIndexMu.RLock()
 	defer s.userIndexMu.RUnlock()
-	return s.userIndex[scheduleID]
+	match := ""
+	for key, userID := range s.userIndex {
+		if !scheduleRuntimeKeyHasID(key, scheduleID) {
+			continue
+		}
+		if match != "" && match != userID {
+			return ""
+		}
+		match = userID
+	}
+	return match
 }
 
 // TriggerNow triggers a schedule immediately (for manual trigger API).
@@ -798,6 +962,9 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 	if sched == nil {
 		return "", fmt.Errorf("schedule %s not found in manifest at %s", scheduleID, workspacePath)
 	}
+	sctx := buildScheduleContext(workspacePath, manifest, *sched)
+	sctx.TriggerSource = "manual"
+	startTime := time.Now().UTC()
 
 	// Match the cron-fired path: do not start a manual trigger when this workflow
 	// workspace already has an active execution, regardless of whether that run was
@@ -807,38 +974,46 @@ func (s *SchedulerService) TriggerNow(workspacePath string, scheduleID string) (
 		if strings.TrimSpace(triggeredBy) == "" {
 			triggeredBy = "unknown"
 		}
-		return "", fmt.Errorf(
+		err := fmt.Errorf(
 			"workflow already has an active %s run (session: %s)",
 			triggeredBy,
 			activeExec.SessionID,
 		)
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
+		return "", err
 	}
 
 	// Prevent concurrent runs — check and mark atomically under the write lock
-	startTime := time.Now().UTC()
+	runtimeKey := workflowScheduleRuntimeKey(workspacePath, scheduleID)
+	runID := uuid.NewString()
 	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(scheduleID)
+	state := s.getRuntimeStateLocked(runtimeKey)
 	if state.LastStatus == "running" {
 		s.runtimeStatesMu.Unlock()
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", "schedule is already running", "", startTime)
 		return "", fmt.Errorf("job is already running (session: %s)", state.LastSessionID)
 	}
+	if err := s.claimScheduleRun(ctx, sctx, runID, startTime); err != nil {
+		s.runtimeStatesMu.Unlock()
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
+		return "", err
+	}
 	state.LastStatus = "running"
+	state.ActiveRunID = runID
 	state.LastRunAt = &startTime
 	state.LastError = ""
 	state.runGeneration++
 	runGeneration := state.runGeneration
 	s.runtimeStatesMu.Unlock()
-
-	sctx := buildScheduleContext(workspacePath, manifest, *sched)
-	sctx.TriggerSource = "manual"
-	sctx.runGeneration = runGeneration
+	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
 	if err := RecordWorkflowScheduleExecution(context.Background(), workspacePath, *sched, startTime); err != nil {
 		s.logf(sctx, "[SCHEDULER] Warning: failed to record manual schedule execution for %s: %v", scheduleID, err)
 	}
 
+	runCtx := s.registerScheduleRunContext(runID)
 	go func() {
-		if _, err := s.runJob(context.Background(), sctx); err != nil {
+		if _, err := s.runJob(runCtx, sctx, runID); err != nil {
 			scheduleLogf("[SCHEDULER] Triggered job %s failed: %v", scheduleID, err)
 		}
 	}()
@@ -868,25 +1043,35 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 	}
 
 	startTime := time.Now().UTC()
+	sctx := buildMultiAgentScheduleContext(userID, *sched, f.Capabilities)
+	sctx.TriggerSource = "manual"
+	runtimeKey := multiAgentScheduleRuntimeKey(userID, scheduleID)
+	runID := uuid.NewString()
 	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(scheduleID)
+	state := s.getRuntimeStateLocked(runtimeKey)
 	if state.LastStatus == "running" {
 		s.runtimeStatesMu.Unlock()
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", "schedule is already running", "", startTime)
 		return "", fmt.Errorf("job is already running (session: %s)", state.LastSessionID)
 	}
+	if err := s.claimScheduleRun(ctx, sctx, runID, startTime); err != nil {
+		s.runtimeStatesMu.Unlock()
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", err.Error(), "", startTime)
+		return "", err
+	}
 	state.LastStatus = "running"
+	state.ActiveRunID = runID
 	state.LastRunAt = &startTime
 	state.LastError = ""
 	state.runGeneration++
 	runGeneration := state.runGeneration
 	s.runtimeStatesMu.Unlock()
 
-	sctx := buildMultiAgentScheduleContext(userID, *sched, f.Capabilities)
-	sctx.TriggerSource = "manual"
-	sctx.runGeneration = runGeneration
+	s.recordScheduleFireDecision(ctx, sctx, "started", "manual trigger accepted", runID, startTime)
 
+	runCtx := s.registerScheduleRunContext(runID)
 	go func() {
-		if _, err := s.runJob(context.Background(), sctx); err != nil {
+		if _, err := s.runJob(runCtx, sctx, runID); err != nil {
 			scheduleLogf("[SCHEDULER] Triggered multi-agent job %s failed: %v", scheduleID, err)
 		}
 	}()
@@ -895,34 +1080,49 @@ func (s *SchedulerService) TriggerMultiAgentNow(userID string, scheduleID string
 }
 
 // StopRunningJob stops a running scheduled job by canceling its session.
+func (s *SchedulerService) StopRunningJobForWorkflow(workspacePath, scheduleID string) {
+	s.stopRunningJob(workflowScheduleRuntimeKey(workspacePath, scheduleID), scheduleID)
+}
+
+func (s *SchedulerService) StopRunningJobForUser(userID, scheduleID string) {
+	s.stopRunningJob(multiAgentScheduleRuntimeKey(userID, scheduleID), scheduleID)
+}
+
 func (s *SchedulerService) StopRunningJob(scheduleID string) {
-	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(scheduleID)
-	if state.LastStatus != "running" {
-		s.runtimeStatesMu.Unlock()
+	keys := s.runtimeKeysForScheduleID(scheduleID)
+	if len(keys) != 1 {
 		return
 	}
+	s.stopRunningJob(keys[0], scheduleID)
+}
+
+func (s *SchedulerService) stopRunningJob(runtimeKey, scheduleID string) {
+	s.runtimeStatesMu.Lock()
+	state := s.getRuntimeStateLocked(runtimeKey)
 	sessionID := state.LastSessionID
-	cancel := state.runCancel
-	durationMs := int64(0)
-	if state.LastRunAt != nil {
-		durationMs = time.Since(*state.LastRunAt).Milliseconds()
-	}
+	runID := state.ActiveRunID
 	state.LastStatus = "stopped"
 	state.LastError = "stopped by user"
-	state.LastDurationMs = &durationMs
-	state.runGeneration++ // invalidates every late write from the stopped run
-	state.runCancel = nil
+	state.ActiveRunID = ""
 	s.runtimeStatesMu.Unlock()
-
-	scheduleLogf("[SCHEDULER] Stopping running job %s (session: %s)", scheduleID, sessionID)
-	if cancel != nil {
-		cancel()
+	if runID == "" && s.stateStore != nil {
+		lockKey := scheduleStateLockKeyFromRuntimeKey(runtimeKey)
+		if active, err := s.stateStore.ActiveRunByLockKey(context.Background(), lockKey); err == nil {
+			runID = active.RunID
+		}
+	}
+	if runID != "" {
+		s.cancelScheduleRunContext(runID)
+		s.transitionScheduleRun(context.Background(), nil, schedulerstate.Transition{
+			RunID: runID, To: schedulerstate.StateStopped, Reason: "stopped by user", SessionID: sessionID,
+			ErrorMessage: "stopped by user", At: time.Now().UTC(),
+		})
 	}
 	if sessionID == "" {
-		scheduleLogf("[SCHEDULER] Stopped job %s before its session was registered", scheduleID)
 		return
 	}
+
+	scheduleLogf("[SCHEDULER] Stopping running job %s (session: %s)", scheduleID, sessionID)
 	if isScheduledSession(sessionID) {
 		s.api.markSessionTurnInterrupted(sessionID)
 	}
@@ -1026,13 +1226,15 @@ func (s *SchedulerService) cancelScheduledSessionWork(sessionID, closeReason str
 // triggerSchedule is called by the tick loop when a schedule is due.
 func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 	schedID := sctx.Schedule.ID
+	runtimeKey := scheduleRuntimeKey(sctx)
 	now := time.Now()
+	ctx := context.Background()
 	s.logf(sctx, "[SCHEDULER] ⏰ Cron fired for %s (%s) at %s", schedID, sctx.Schedule.Name, now.Format(time.RFC3339))
 
 	// Late-fire detection: compare to the next_run we recorded last time. Drift > 60s
 	// usually means a missed-fire catch-up after macOS sleep/wake, or scheduler stall.
 	s.runtimeStatesMu.RLock()
-	if st, ok := s.runtimeStates[schedID]; ok && st.NextRunAt != nil {
+	if st, ok := s.runtimeStates[runtimeKey]; ok && st.NextRunAt != nil {
 		expected := *st.NextRunAt
 		drift := now.Sub(expected)
 		if drift > 60*time.Second {
@@ -1055,6 +1257,7 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		} else {
 			s.logf(sctx, "[SCHEDULER] ⏸️ Global scheduler pause active, skipping %s", schedID)
 		}
+		s.recordScheduleFireDecision(ctx, sctx, "skipped_paused", "global scheduler pause is active", "", now.UTC())
 		return
 	}
 
@@ -1065,6 +1268,7 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		f, exists, err := ReadMultiAgentSchedules(context.Background(), sctx.UserID)
 		if err != nil || !exists {
 			s.logf(sctx, "[SCHEDULER] ❌ Failed to reload multi-agent schedules for user %s: %v", sctx.UserID, err)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "failed to reload multi-agent schedule", "", now.UTC())
 			return
 		}
 		var currentSched *WorkflowSchedule
@@ -1077,18 +1281,28 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		}
 		if currentSched == nil {
 			s.logf(sctx, "[SCHEDULER] ❌ Multi-agent schedule %s not found for user %s, skipping", schedID, sctx.UserID)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "schedule no longer exists", "", now.UTC())
 			return
 		}
 		if !currentSched.Enabled {
 			s.logf(sctx, "[SCHEDULER] ⏭️ Multi-agent schedule %s is disabled, skipping", schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "skipped_disabled", "schedule is disabled", "", now.UTC())
 			return
 		}
-		freshCtx = buildMultiAgentScheduleContext(sctx.UserID, *currentSched, f.Capabilities)
+		resolvedSchedule, calendarItem, ok := scheduleWithReloadedCalendarItem(*currentSched, sctx.CalendarItem)
+		if !ok {
+			s.logf(sctx, "[SCHEDULER] Calendar item for %s no longer exists, skipping", schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "calendar item no longer exists", "", now.UTC())
+			return
+		}
+		freshCtx = buildMultiAgentScheduleContext(sctx.UserID, resolvedSchedule, f.Capabilities)
+		freshCtx.CalendarItem = calendarItem
 	} else {
 		// Reload manifest for latest config
 		manifest, found, err := ReadWorkflowManifest(context.Background(), sctx.WorkspacePath)
 		if err != nil || !found {
 			s.logf(sctx, "[SCHEDULER] ❌ Failed to reload manifest for %s: %v", schedID, err)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "failed to reload workflow manifest", "", now.UTC())
 			return
 		}
 
@@ -1107,6 +1321,7 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 		}
 		if currentSched == nil {
 			s.logf(sctx, "[SCHEDULER] ❌ Schedule %s not found in manifest, skipping", schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "schedule no longer exists", "", now.UTC())
 			return
 		}
 		if !currentSched.Enabled {
@@ -1114,6 +1329,7 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 				s.logf(sctx, "[SCHEDULER] Warning: failed to sync disabled execution history for %s: %v", schedID, err)
 			}
 			s.logf(sctx, "[SCHEDULER] ⏭️ Schedule %s is disabled, skipping", schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "skipped_disabled", "schedule is disabled", "", now.UTC())
 			return
 		}
 
@@ -1124,44 +1340,70 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 			}
 			s.logf(sctx, "[SCHEDULER] ⏭️ Workflow %s already has an active %s run (session: %s), skipping schedule %s",
 				sctx.WorkspacePath, triggeredBy, activeExec.SessionID, schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "skipped_busy", "workflow already has an active execution", "", now.UTC())
 			return
 		}
 
-		freshCtx = buildScheduleContext(sctx.WorkspacePath, manifest, *currentSched)
+		resolvedSchedule, calendarItem, ok := scheduleWithReloadedCalendarItem(*currentSched, sctx.CalendarItem)
+		if !ok {
+			s.logf(sctx, "[SCHEDULER] Calendar item for %s no longer exists, skipping", schedID)
+			s.recordScheduleFireDecision(ctx, sctx, "failed_to_start", "calendar item no longer exists", "", now.UTC())
+			return
+		}
+		freshCtx = buildScheduleContext(sctx.WorkspacePath, manifest, resolvedSchedule)
+		freshCtx.CalendarItem = calendarItem
 	}
+	freshCtx.TriggerSource = "cron"
 
 	// Built-in pre-fire check: if the built-in registered a gating function and
 	// it returns false, skip this tick entirely. No LLM session is spawned.
 	if check, ok := PreFireChecks[freshCtx.Schedule.ID]; ok {
 		if !check(freshCtx.UserID) {
 			s.logf(freshCtx, "[SCHEDULER] ⏭️ Pre-fire check returned false for %s (user %s) — skipping", freshCtx.Schedule.ID, freshCtx.UserID)
+			s.recordScheduleFireDecision(ctx, freshCtx, "skipped_prefire", "pre-fire check returned false", "", now.UTC())
 			return
 		}
 	}
 
 	// Prevent concurrent runs — check and mark atomically under the write lock
 	startTime := time.Now().UTC()
+	runID := uuid.NewString()
 	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(schedID)
+	state := s.getRuntimeStateLocked(scheduleRuntimeKey(freshCtx))
 	if state.LastStatus == "running" {
 		s.runtimeStatesMu.Unlock()
 		s.sessionLogf(freshCtx, state.LastSessionID, "[SCHEDULER] ⏭️ Schedule %s is already running (session: %s), skipping", schedID, state.LastSessionID)
+		s.recordScheduleFireDecision(ctx, freshCtx, "skipped_busy", "schedule is already running", "", startTime)
 		return
 	}
 	if freshCtx.SourceType == "workflow" {
-		if otherID, otherSession := runningWorkflowScheduleInSetLocked(s.runtimeStates, workflowScheduleIDs, schedID); otherID != "" {
+		workflowRuntimeKeys := make([]string, 0, len(workflowScheduleIDs))
+		for _, workflowScheduleID := range workflowScheduleIDs {
+			workflowRuntimeKeys = append(workflowRuntimeKeys, workflowScheduleRuntimeKey(freshCtx.WorkspacePath, workflowScheduleID))
+		}
+		if otherKey, otherSession := runningWorkflowScheduleInSetLocked(s.runtimeStates, workflowRuntimeKeys, scheduleRuntimeKey(freshCtx)); otherKey != "" {
 			s.runtimeStatesMu.Unlock()
 			s.logf(freshCtx, "[SCHEDULER] ⏭️ Workflow %s already has running schedule %s (session: %s), skipping schedule %s",
-				freshCtx.WorkspacePath, otherID, otherSession, schedID)
+				freshCtx.WorkspacePath, otherKey, otherSession, schedID)
+			s.recordScheduleFireDecision(ctx, freshCtx, "skipped_busy", "another schedule owns the workflow", "", startTime)
 			return
 		}
 	}
+	if err := s.claimScheduleRun(ctx, freshCtx, runID, startTime); err != nil {
+		s.runtimeStatesMu.Unlock()
+		s.recordScheduleFireDecision(ctx, freshCtx, "skipped_busy", err.Error(), "", startTime)
+		s.logf(freshCtx, "[SCHEDULER] ⏭️ Durable run lease rejected schedule %s: %v", schedID, err)
+		return
+	}
 	state.LastStatus = "running"
+	state.ActiveRunID = runID
 	state.LastRunAt = &startTime
 	state.LastError = ""
 	state.runGeneration++
 	freshCtx.runGeneration = state.runGeneration
 	s.runtimeStatesMu.Unlock()
+	s.recordScheduleFireDecision(ctx, freshCtx, "started", "cron fire accepted", runID, startTime)
+	runCtx := s.registerScheduleRunContext(runID)
 
 	if freshCtx.SourceType == "workflow" {
 		if err := RecordWorkflowScheduleExecution(context.Background(), freshCtx.WorkspacePath, freshCtx.Schedule, startTime); err != nil {
@@ -1170,7 +1412,7 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 	}
 
 	s.logf(freshCtx, "[SCHEDULER] 🚀 Starting %s (%s)", schedID, freshCtx.Schedule.Name)
-	if _, err := s.runJob(context.Background(), freshCtx); err != nil {
+	if _, err := s.runJob(runCtx, freshCtx, runID); err != nil {
 		s.logf(freshCtx, "[SCHEDULER] ❌ %s failed: %v", schedID, err)
 	} else {
 		s.logf(freshCtx, "[SCHEDULER] ✅ %s completed", schedID)
@@ -1178,40 +1420,36 @@ func (s *SchedulerService) triggerSchedule(sctx *ScheduleContext) {
 }
 
 // runJob executes a scheduled job: updates runtime state, creates run history, executes, updates results.
-func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (string, error) {
+func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext, runID string) (string, error) {
+	defer s.releaseScheduleRunContext(runID)
 	schedID := sctx.Schedule.ID
+	runtimeKey := scheduleRuntimeKey(sctx)
 	startTime := time.Now().UTC()
 	s.logf(sctx, "[SCHEDULER] runJob starting for %s (%s) at %s, groups=%v",
 		schedID, sctx.Schedule.Name, startTime.Format(time.RFC3339), sctx.Schedule.GroupNames)
+	if err := ctx.Err(); err != nil {
+		s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+			state.ActiveRunID = ""
+			state.LastStatus = "stopped"
+			state.LastError = "stopped by user before execution started"
+		})
+		s.transitionScheduleRun(context.Background(), sctx, schedulerstate.Transition{
+			RunID: runID, To: schedulerstate.StateStopped, Reason: "stopped before workflow execution started",
+			ErrorMessage: "stopped by user", At: time.Now().UTC(),
+		})
+		return "", errors.Join(errWorkshopSequenceInterrupted, err)
+	}
 
-	// Bind this goroutine to the exact run generation that started it. Stop or a
-	// later restart invalidates the generation, so this run cannot overwrite the
-	// newer state when it eventually returns.
-	runCtx, runCancel := context.WithCancel(ctx)
-	defer runCancel()
-	s.runtimeStatesMu.Lock()
-	state := s.getRuntimeStateLocked(schedID)
-	if sctx.runGeneration == 0 {
-		if state.LastStatus == "running" {
-			s.runtimeStatesMu.Unlock()
-			return "", errWorkshopSequenceInterrupted
-		}
-		state.LastStatus = "running"
-		state.LastRunAt = &startTime
-		state.runGeneration++
-		sctx.runGeneration = state.runGeneration
-	}
-	if state.LastStatus != "running" || state.runGeneration != sctx.runGeneration {
-		s.runtimeStatesMu.Unlock()
-		return "", errWorkshopSequenceInterrupted
-	}
-	state.LastSessionID = ""
-	state.LastError = ""
-	state.runCancel = runCancel
-	s.runtimeStatesMu.Unlock()
+	// Clear session/error fields — status is already "running" (set atomically by caller)
+	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.LastSessionID = ""
+		state.LastError = ""
+	})
 
 	// Create run history entry (file-based)
-	runID := uuid.New().String()
+	if strings.TrimSpace(runID) == "" {
+		runID = uuid.New().String()
+	}
 	run := &ScheduleRunEntry{
 		ID:         runID,
 		ScheduleID: schedID,
@@ -1228,6 +1466,12 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 			s.logf(sctx, "[SCHEDULER] Failed to create run entry for %s: %v", schedID, err)
 		}
 	}
+	s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+		RunID:  runID,
+		To:     schedulerstate.StateWorkflowRunning,
+		Reason: "workflow execution starting",
+		At:     time.Now().UTC(),
+	})
 
 	// Execute
 	sessionID, runFolder, execErr := s.executeJob(runCtx, sctx, runID)
@@ -1238,7 +1482,7 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 
 	status := "success"
 	errMsg := ""
-	userInterrupted := errors.Is(execErr, errWorkshopSequenceInterrupted) || s.scheduleRunInvalidated(schedID, sctx.runGeneration)
+	userInterrupted := errors.Is(execErr, errWorkshopSequenceInterrupted) || errors.Is(execErr, context.Canceled)
 	if userInterrupted {
 		status = "stopped"
 		if execErr != nil {
@@ -1255,6 +1499,16 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	} else {
 		s.sessionLogf(sctx, sessionID, "[SCHEDULER] %s completed in %dms, session: %s, folder: %s", schedID, durationMs, sessionID, runFolder)
 	}
+	s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+		RunID:        runID,
+		To:           schedulerstate.StateWorkflowFinished,
+		Reason:       "workflow execution finished with status " + status,
+		SessionID:    sessionID,
+		SessionKind:  "workflow",
+		RunFolder:    runFolder,
+		ErrorMessage: errMsg,
+		At:           time.Now().UTC(),
+	})
 
 	// Keep the runtime state as "running" until all post-run side effects finish.
 	// Pulse runs as several resumed builder-chat turns after the workflow result
@@ -1262,10 +1516,13 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 	// frequent cron can start the next workflow run while Pulse is between steps.
 	// That makes the next Pulse turn fail with workflow_busy (commonly after the
 	// LLM/cost/time report), so cadence/backup/publish/notify never run.
-	s.setScheduleSessionID(schedID, sctx.runGeneration, sessionID)
+	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.LastSessionID = sessionID
+	})
 
 	// Update run history entry for the actual workflow/task run. Post-run Pulse
 	// may continue after this, but it does not change the recorded run result.
+	pulseResult := postRunMonitorNotRun
 	if sctx.SourceType == "multi-agent" {
 		if err := UpdateMultiAgentScheduleRun(ctx, sctx.UserID, runID, status, errMsg, &durationMs, sessionID); err != nil {
 			s.sessionLogf(sctx, sessionID, "[SCHEDULER] Failed to update multi-agent run entry for %s: %v", schedID, err)
@@ -1292,17 +1549,55 @@ func (s *SchedulerService) runJob(ctx context.Context, sctx *ScheduleContext) (s
 		if !userInterrupted && runFolder != "" && sctx.Schedule.WorkshopMode != "optimizer" {
 			if manifest, found, mErr := ReadWorkflowManifest(ctx, sctx.WorkspacePath); mErr == nil && found && manifest.MonitorEnabled() {
 				// Pass the run's sessionID so Pulse resumes the SAME chat (not a fresh one).
-				s.runPostRunMonitor(ctx, sctx, manifest, status, runFolder, sessionID)
+				s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+					RunID: runID, To: schedulerstate.StatePulseGate, Reason: "Pulse enabled for workflow", SessionID: sessionID, SessionKind: "pulse", At: time.Now().UTC(),
+				})
+				pulseResult = s.runPostRunMonitor(ctx, sctx, manifest, status, runFolder, sessionID, runID)
 			}
 		}
 	}
 
 	// Now the whole scheduled job, including post-run side effects, is done.
-	if !s.finishScheduleRun(schedID, sctx.runGeneration, status, errMsg, durationMs, nextRun) {
-		stateSnapshot := s.getRuntimeStateSnapshot(schedID)
-		s.sessionLogf(sctx, sessionID, "[SCHEDULER] Ignoring late completion for %s generation %d; current generation=%d status=%s",
-			schedID, sctx.runGeneration, stateSnapshot.runGeneration, stateSnapshot.LastStatus)
+	terminalState := schedulerstate.StateCompleted
+	if userInterrupted {
+		terminalState = schedulerstate.StateStopped
+	} else if status == "error" {
+		terminalState = schedulerstate.StateFailed
+	} else if pulseResult == postRunMonitorPartial {
+		terminalState = schedulerstate.StatePartial
+	} else if pulseResult == postRunMonitorStopped {
+		terminalState = schedulerstate.StateStopped
 	}
+	overallStatus := status
+	overallError := errMsg
+	if terminalState == schedulerstate.StateStopped {
+		overallStatus = "stopped"
+		if overallError == "" {
+			overallError = "stopped by user"
+		}
+	} else if terminalState == schedulerstate.StatePartial {
+		overallStatus = "partial"
+		if overallError == "" {
+			overallError = "Pulse completed partially"
+		}
+	}
+	s.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.ActiveRunID = ""
+		state.LastStatus = overallStatus
+		state.LastError = overallError
+		state.LastDurationMs = &durationMs
+		state.NextRunAt = nextRun
+		state.RunCount++
+		if overallStatus == "error" {
+			state.ConsecutiveFailures++
+		} else {
+			state.ConsecutiveFailures = 0
+		}
+	})
+	s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+		RunID: runID, To: terminalState, Reason: "scheduled run finished with status " + status,
+		SessionID: sessionID, ErrorMessage: errMsg, At: time.Now().UTC(),
+	})
 
 	return sessionID, execErr
 }
@@ -1441,7 +1736,17 @@ Scheduled task:
 // never changes the run's recorded status — failures here are logged and
 // swallowed. Pulse's behavior is defined by the post-run-monitor reference doc;
 // this just hands it the run context.
-func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *ScheduleContext, manifest *WorkflowManifest, runStatus, runFolder, runSessionID string) {
+type postRunMonitorResult string
+
+const (
+	postRunMonitorNotRun    postRunMonitorResult = "not_run"
+	postRunMonitorCompleted postRunMonitorResult = "completed"
+	postRunMonitorPartial   postRunMonitorResult = "partial"
+	postRunMonitorStopped   postRunMonitorResult = "stopped"
+)
+
+func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *ScheduleContext, manifest *WorkflowManifest, runStatus, runFolder, runSessionID, scheduleRunID string) (pulseResult postRunMonitorResult) {
+	pulseResult = postRunMonitorPartial
 	defer func() {
 		if r := recover(); r != nil {
 			s.logf(sctx, "[PULSE] post-run pulse panic (recovered): %v", r)
@@ -1485,6 +1790,10 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 	recoveryNotes := []string{}
 	runStep := func(st postRunMonitorStep) postRunMonitorStepRunResult {
 		if st.label == "finalize" {
+			s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+				RunID: scheduleRunID, To: schedulerstate.StatePulseFinalizing, Reason: "Pulse finalizer starting",
+				SessionID: sessionID, SessionKind: "pulse", At: time.Now().UTC(),
+			})
 			if _, err := markPulseFinalCommandState(ctx, sctx.WorkspacePath, pulseFinalCommandDashboard, pulseRunID, "running", "Preparing the Pulse dashboard and user questions"); err != nil {
 				s.sessionLogf(sctx, sessionID, "[PULSE] failed to mark dashboard running: %v", err)
 			}
@@ -1511,7 +1820,7 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 		if err := s.waitForWorkshopIdleWithInactivityTimeout(ctx, sessionID, st.idleMaxInactivity()); err != nil {
 			s.sessionLogf(sctx, sessionID, "[PULSE] step %q idle wait failed: %v", st.label, err)
 			outcome := postRunMonitorStepWaitFailed
-			if errors.Is(err, errWorkshopSequenceInterrupted) {
+			if errors.Is(err, errWorkshopSequenceInterrupted) || errors.Is(err, context.Canceled) {
 				outcome = postRunMonitorStepInterrupted
 			} else if errors.Is(err, errWorkshopIdleWaitTimeout) {
 				outcome = postRunMonitorStepTimedOut
@@ -1566,6 +1875,7 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 			return false
 		}
 		reason := fmt.Sprintf("Pulse stopped by user during %s", st.label)
+		pulseResult = postRunMonitorStopped
 		s.sessionLogf(sctx, sessionID, "[PULSE] %s; no later module, recovery, finalizer, publish, or notification turn will run", reason)
 		_ = finalizeUnresolvedPulseFinalCommands(ctx, sctx.WorkspacePath, pulseRunID, "skipped", reason)
 		return true
@@ -1612,6 +1922,12 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 		}
 		if result.outcome == postRunMonitorStepCompleted {
 			steps = s.selectedPostRunMonitorModuleSteps(ctx, sctx, pulseRunID)
+			if len(steps) > 0 && !isPostRunMonitorFinalStep(steps[0].label) {
+				s.transitionScheduleRun(ctx, sctx, schedulerstate.Transition{
+					RunID: scheduleRunID, To: schedulerstate.StatePulseModules, Reason: "Pulse Gate recorded due modules",
+					SessionID: sessionID, SessionKind: "pulse", At: time.Now().UTC(),
+				})
+			}
 			s.sessionLogf(sctx, sessionID, "[PULSE] selected %d post-gate steps for %s", len(steps), sctx.Schedule.ID)
 		} else {
 			handleStepFailure(gateStep, result, true)
@@ -1644,8 +1960,10 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 		}
 	}
 	if len(recoveryNotes) > 0 {
+		pulseResult = postRunMonitorPartial
 		s.sessionLogf(sctx, sessionID, "[PULSE] pulse finalized partially for %s after %d failed/timed-out step(s)", sctx.Schedule.ID, len(recoveryNotes))
 	} else {
+		pulseResult = postRunMonitorCompleted
 		s.sessionLogf(sctx, sessionID, "[PULSE] pulse completed for %s", sctx.Schedule.ID)
 	}
 	// Pulse owns its own notification: per its reference doc it calls notify_user
@@ -1654,6 +1972,7 @@ func (s *SchedulerService) runPostRunMonitor(ctx context.Context, sctx *Schedule
 	// that avoids a double-send and lets the agent author the exact, nuanced sentence.
 	// The Bug/Goal verdict lives in builder/improve.html (pills + headline) — the
 	// single source of truth, no separate file.
+	return pulseResult
 }
 
 type postRunMonitorStep struct{ label, query string }
@@ -1996,7 +2315,9 @@ func (s *SchedulerService) executeWorkshopJob(ctx context.Context, sctx *Schedul
 
 	sessionID := s.newScheduleSessionID(sctx)
 
-	s.setScheduleSessionID(sctx.Schedule.ID, sctx.runGeneration, sessionID)
+	s.updateRuntimeState(scheduleRuntimeKey(sctx), func(state *ScheduleRuntimeState) {
+		state.LastSessionID = sessionID
+	})
 
 	if runID != "" {
 		_ = UpdateScheduleRun(ctx, sctx.WorkspacePath, runID, "running", "", nil, runFolder, sessionID)
@@ -2286,7 +2607,9 @@ func (s *SchedulerService) executeMultiAgentJob(ctx context.Context, sctx *Sched
 
 	sessionID := s.newScheduleSessionID(sctx)
 
-	s.setScheduleSessionID(sctx.Schedule.ID, sctx.runGeneration, sessionID)
+	s.updateRuntimeState(scheduleRuntimeKey(sctx), func(state *ScheduleRuntimeState) {
+		state.LastSessionID = sessionID
+	})
 
 	if runID != "" {
 		_ = UpdateMultiAgentScheduleRun(ctx, sctx.UserID, runID, "running", "", nil, sessionID)
@@ -2378,7 +2701,8 @@ func (s *SchedulerService) executeMultiAgentJob(ctx context.Context, sctx *Sched
 		return sessionID, "", nil
 	}
 
-	// Single-query path (legacy/fallback) — unchanged behavior.
+	// Single-query path. Use the same tmux/background-aware bounded wait as
+	// sequence turns so an abandoned coding CLI cannot hold a schedule forever.
 	if resumed := s.maybeResumeLatestMultiAgentThread(ctx, sctx, reqMap, sessionID); resumed != "" {
 		s.sessionLogf(sctx, sessionID, "[SCHEDULER] Resuming previous multi-agent schedule thread %s for %s", resumed, sctx.Schedule.ID)
 	}
@@ -2394,9 +2718,9 @@ func (s *SchedulerService) executeMultiAgentJob(ctx context.Context, sctx *Sched
 
 	s.stampScheduleNameOnSession(sessionID, sctx)
 
-	// Wait for session to complete (no workflow orchestrator, just wait for agent to finish)
-	if err := s.waitForSessionComplete(ctx, sessionID); err != nil {
-		s.sessionLogf(sctx, sessionID, "[SCHEDULER] ⚠️ Multi-agent session wait interrupted for %s: %v", sctx.Schedule.ID, err)
+	if err := s.waitForWorkshopIdle(ctx, sessionID); err != nil {
+		s.sessionLogf(sctx, sessionID, "[SCHEDULER] Multi-agent session wait failed for %s: %v", sctx.Schedule.ID, err)
+		return sessionID, "", fmt.Errorf("multi-agent session idle wait failed: %w", err)
 	}
 
 	return sessionID, "", nil
@@ -2420,23 +2744,6 @@ func (s *SchedulerService) stampScheduleNameOnSession(sessionID string, sctx *Sc
 		}
 		if sess.TriggeredBy == "" {
 			sess.TriggeredBy = "cron"
-		}
-	}
-}
-
-// waitForSessionComplete polls until a simple/multi-agent session is no longer busy.
-func (s *SchedulerService) waitForSessionComplete(ctx context.Context, sessionID string) error {
-	ticker := time.NewTicker(3 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if !s.api.sessionIsBusy(sessionID) {
-				return nil
-			}
 		}
 	}
 }
@@ -2877,6 +3184,112 @@ func (api *StreamingAPI) refreshSessionTmuxSnapshotsForIdleCheck(ctx context.Con
 	return nil
 }
 
+// updateRuntimeState owns the complete read-modify-write operation. Callers must
+// never retain a runtime-state pointer after the mutex is released.
+func (s *SchedulerService) updateRuntimeState(scheduleID string, update func(*ScheduleRuntimeState)) ScheduleRuntimeState {
+	s.runtimeStatesMu.Lock()
+	defer s.runtimeStatesMu.Unlock()
+	state, ok := s.runtimeStates[scheduleID]
+	if !ok {
+		state = &ScheduleRuntimeState{}
+		s.runtimeStates[scheduleID] = state
+	}
+	if update != nil {
+		update(state)
+	}
+	return *state
+}
+
+func (s *SchedulerService) registerScheduleRunContext(runID string) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.runCancelsMu.Lock()
+	if s.runCancels == nil {
+		s.runCancels = make(map[string]context.CancelFunc)
+	}
+	if previous := s.runCancels[runID]; previous != nil {
+		previous()
+	}
+	s.runCancels[runID] = cancel
+	s.runCancelsMu.Unlock()
+	return ctx
+}
+
+func (s *SchedulerService) cancelScheduleRunContext(runID string) {
+	s.runCancelsMu.Lock()
+	cancel := s.runCancels[runID]
+	s.runCancelsMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *SchedulerService) releaseScheduleRunContext(runID string) {
+	s.runCancelsMu.Lock()
+	cancel := s.runCancels[runID]
+	delete(s.runCancels, runID)
+	s.runCancelsMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *SchedulerService) claimScheduleRun(ctx context.Context, sctx *ScheduleContext, runID string, startedAt time.Time) error {
+	if s.stateStore == nil {
+		return nil
+	}
+	scopeType, scopeID, lockKey := scheduleStateScope(sctx)
+	triggerSource := strings.TrimSpace(sctx.TriggerSource)
+	if triggerSource == "" {
+		triggerSource = "cron"
+	}
+	return s.stateStore.BeginRun(ctx, schedulerstate.Run{
+		RunID:         runID,
+		ScopeType:     scopeType,
+		ScopeID:       scopeID,
+		LockKey:       lockKey,
+		ScheduleID:    sctx.Schedule.ID,
+		TriggerSource: triggerSource,
+		StartedAt:     startedAt,
+	})
+}
+
+func (s *SchedulerService) transitionScheduleRun(ctx context.Context, sctx *ScheduleContext, transition schedulerstate.Transition) {
+	if s.stateStore == nil || strings.TrimSpace(transition.RunID) == "" {
+		return
+	}
+	if err := s.stateStore.Transition(ctx, transition); err != nil {
+		if sctx != nil {
+			s.logf(sctx, "[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, err)
+		} else {
+			scheduleLogf("[SCHEDULER_STATE] transition run=%s to=%s failed: %v", transition.RunID, transition.To, err)
+		}
+	}
+}
+
+func (s *SchedulerService) recordScheduleFireDecision(ctx context.Context, sctx *ScheduleContext, decision, reason, runID string, firedAt time.Time) {
+	if s.stateStore == nil || sctx == nil {
+		return
+	}
+	scopeType, scopeID, _ := scheduleStateScope(sctx)
+	triggerSource := strings.TrimSpace(sctx.TriggerSource)
+	if triggerSource == "" {
+		triggerSource = "cron"
+	}
+	if err := s.stateStore.RecordFireDecision(ctx, schedulerstate.FireDecision{
+		DecisionID:    uuid.NewString(),
+		ScopeType:     scopeType,
+		ScopeID:       scopeID,
+		ScheduleID:    sctx.Schedule.ID,
+		TriggerSource: triggerSource,
+		Decision:      decision,
+		Reason:        reason,
+		RunID:         runID,
+		FiredAt:       firedAt,
+	}); err != nil {
+		s.logf(sctx, "[SCHEDULER_STATE] record fire decision=%s failed: %v", decision, err)
+	}
+}
+
 // getRuntimeStateLocked returns or creates runtime state. Caller MUST hold runtimeStatesMu write lock.
 func (s *SchedulerService) getRuntimeStateLocked(scheduleID string) *ScheduleRuntimeState {
 	if state, ok := s.runtimeStates[scheduleID]; ok {
@@ -3098,6 +3511,39 @@ func scheduleWithCalendarItem(sched WorkflowSchedule, item CalendarScheduleItem)
 		sched.Messages = item.Messages
 	}
 	return sched
+}
+
+func scheduleWithReloadedCalendarItem(sched WorkflowSchedule, requested *CalendarScheduleItem) (WorkflowSchedule, *CalendarScheduleItem, bool) {
+	if requested == nil {
+		return sched, nil, true
+	}
+	for i := range sched.CalendarItems {
+		item := sched.CalendarItems[i]
+		matches := requested.ID != "" && item.ID == requested.ID
+		if requested.ID == "" {
+			matches = item.Date == requested.Date && item.Time == requested.Time
+		}
+		if !matches {
+			continue
+		}
+		itemCopy := item
+		return scheduleWithCalendarItem(sched, itemCopy), &itemCopy, true
+	}
+	return sched, nil, false
+}
+
+func scheduleConfigFingerprint(sctx *ScheduleContext) string {
+	if sctx == nil {
+		return ""
+	}
+	payload, err := json.Marshal(struct {
+		Schedule     WorkflowSchedule     `json:"schedule"`
+		Capabilities WorkflowCapabilities `json:"capabilities"`
+	}{Schedule: sctx.Schedule, Capabilities: sctx.Capabilities})
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(payload))
 }
 
 func ValidateScheduleTimezone(timezone string) error {

--- a/agent_go/cmd/server/scheduler_routes.go
+++ b/agent_go/cmd/server/scheduler_routes.go
@@ -1175,6 +1175,7 @@ func getScheduledJobRunsHandler(svc *SchedulerService) http.HandlerFunc {
 		// Check if it's a multi-agent schedule
 		userID := svc.GetUserForSchedule(id)
 		if userID != "" {
+			_ = svc.reconcileMultiAgentScheduleRuns(r.Context(), userID, id)
 			runs, total, err = ListMultiAgentScheduleRuns(r.Context(), userID, id, limit, offset)
 		} else {
 			// Find workspace path for workflow schedule
@@ -1186,6 +1187,7 @@ func getScheduledJobRunsHandler(svc *SchedulerService) http.HandlerFunc {
 					return
 				}
 				if result.SourceType == "multi-agent" {
+					_ = svc.reconcileMultiAgentScheduleRuns(r.Context(), result.UserID, id)
 					runs, total, err = ListMultiAgentScheduleRuns(r.Context(), result.UserID, id, limit, offset)
 				} else {
 					workspacePath = result.WorkspacePath

--- a/agent_go/cmd/server/scheduler_routes.go
+++ b/agent_go/cmd/server/scheduler_routes.go
@@ -167,6 +167,16 @@ func buildMultiAgentJobResponse(userID string, sched WorkflowSchedule, state Sch
 	}
 }
 
+func runtimeStateForScheduleResult(svc *SchedulerService, result *ScheduleSearchResult, scheduleID string) ScheduleRuntimeState {
+	if svc == nil || result == nil {
+		return ScheduleRuntimeState{}
+	}
+	if result.SourceType == "multi-agent" {
+		return svc.GetRuntimeStateForUser(result.UserID, scheduleID)
+	}
+	return svc.GetRuntimeStateForWorkflow(result.WorkspacePath, scheduleID)
+}
+
 // buildMultiAgentJobResponsesWithOrgPulse builds job responses for a user's
 // merged multi-agent schedules, applying the effective Org Pulse enabled state.
 //
@@ -184,13 +194,13 @@ func buildMultiAgentJobResponsesWithOrgPulse(svc *SchedulerService, userID strin
 	for _, sched := range merged {
 		if sched.Enabled && sched.ID != builtinOrgPulseID && IsOrgPulseSchedule(sched) {
 			orgPulseOn = true
-			orgPulseRun = svc.GetRuntimeState(sched.ID)
+			orgPulseRun = svc.GetRuntimeStateForUser(userID, sched.ID)
 		}
 	}
 
 	var out []ScheduledJobResponse
 	for _, sched := range merged {
-		state := svc.GetRuntimeState(sched.ID)
+		state := svc.GetRuntimeStateForUser(userID, sched.ID)
 		resp := buildMultiAgentJobResponse(userID, sched, state)
 		if resp.ID == builtinOrgPulseID && !resp.Enabled && orgPulseOn {
 			resp.Enabled = true
@@ -430,7 +440,7 @@ func listScheduledJobsHandler(svc *SchedulerService) http.HandlerFunc {
 						continue
 					}
 
-					state := svc.GetRuntimeState(sched.ID)
+					state := svc.GetRuntimeStateForWorkflow(dw.WorkspacePath, sched.ID)
 					missed := missedResolver.get(dw.WorkspacePath, sched)
 					allJobs = append(allJobs, buildJobResponse(dw.WorkspacePath, dw.Manifest, sched, state, missed))
 				}
@@ -552,7 +562,7 @@ func createScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				}
 			}
 
-			state := svc.GetRuntimeState(newSched.ID)
+			state := svc.GetRuntimeStateForUser(userID, newSched.ID)
 			resp := buildMultiAgentJobResponse(userID, newSched, state)
 
 			w.Header().Set("Content-Type", "application/json")
@@ -618,7 +628,7 @@ func createScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			}
 		}
 
-		state := svc.GetRuntimeState(newSched.ID)
+		state := svc.GetRuntimeStateForWorkflow(req.WorkspacePath, newSched.ID)
 		missedResolver := newWorkflowMissedStatusResolver(r.Context())
 		resp := buildJobResponse(req.WorkspacePath, manifest, newSched, state, missedResolver.get(req.WorkspacePath, newSched))
 
@@ -642,7 +652,7 @@ func getScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			return
 		}
 
-		state := svc.GetRuntimeState(id)
+		state := runtimeStateForScheduleResult(svc, result, id)
 		var resp ScheduledJobResponse
 		if result.SourceType == "multi-agent" {
 			resp = buildMultiAgentJobResponse(result.UserID, result.ScheduleFile.Schedules[result.Index], state)
@@ -729,7 +739,7 @@ func updateScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				scheduleLogf("[SCHEDULER] Failed to reload multi-agent schedule %s after update: %v", id, err)
 			}
 
-			state := svc.GetRuntimeState(id)
+			state := svc.GetRuntimeStateForUser(result.UserID, id)
 			resp := buildMultiAgentJobResponse(result.UserID, *sched, state)
 
 			w.Header().Set("Content-Type", "application/json")
@@ -813,7 +823,7 @@ func updateScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			scheduleLogf("[SCHEDULER] Failed to reload schedule %s after update: %v", id, err)
 		}
 
-		state := svc.GetRuntimeState(id)
+		state := svc.GetRuntimeStateForWorkflow(workspacePath, id)
 		missedResolver := newWorkflowMissedStatusResolver(r.Context())
 		resp := buildJobResponse(workspacePath, manifest, *sched, state, missedResolver.get(workspacePath, *sched))
 
@@ -841,7 +851,7 @@ func deleteScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 					http.Error(w, "failed to write multi-agent schedules: "+writeErr.Error(), http.StatusInternalServerError)
 					return
 				}
-				_ = svc.RemoveJob(id)
+				_ = svc.RemoveMultiAgentJob(userID, id)
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
@@ -854,7 +864,7 @@ func deleteScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				http.Error(w, SlashManagedBuiltinError(id, "disable or change"), http.StatusConflict)
 				return
 			}
-			_ = svc.RemoveJob(id)
+			_ = svc.RemoveMultiAgentJob(result.UserID, id)
 			if IsDefaultBuiltinSchedule(id) {
 				result.ScheduleFile.Schedules[result.Index].Enabled = false
 				if err := WriteMultiAgentSchedules(r.Context(), result.UserID, result.ScheduleFile); err != nil {
@@ -870,7 +880,7 @@ func deleteScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				return
 			}
 		} else {
-			_ = svc.RemoveJob(id)
+			_ = svc.RemoveWorkflowJob(result.WorkspacePath, id)
 			manifest := result.Manifest
 			manifest.Schedules = append(manifest.Schedules[:result.Index], manifest.Schedules[result.Index+1:]...)
 			if err := WriteWorkflowManifest(r.Context(), result.WorkspacePath, manifest); err != nil {
@@ -907,7 +917,7 @@ func enableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				if err := svc.ReloadMultiAgentSchedule(r.Context(), userID, id); err != nil {
 					scheduleLogf("[SCHEDULER] Failed to reload built-in multi-agent schedule %s after enable: %v", id, err)
 				}
-				state := svc.GetRuntimeState(id)
+				state := svc.GetRuntimeStateForUser(userID, id)
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(buildMultiAgentJobResponse(userID, f.Schedules[idx], state))
 				return
@@ -931,7 +941,7 @@ func enableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			if err := svc.ReloadMultiAgentSchedule(r.Context(), result.UserID, id); err != nil {
 				scheduleLogf("[SCHEDULER] Failed to reload multi-agent schedule %s after enable: %v", id, err)
 			}
-			state := svc.GetRuntimeState(id)
+			state := svc.GetRuntimeStateForUser(result.UserID, id)
 			resp = buildMultiAgentJobResponse(result.UserID, result.ScheduleFile.Schedules[result.Index], state)
 		} else {
 			result.Manifest.Schedules[result.Index].Enabled = true
@@ -943,7 +953,7 @@ func enableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			if err := svc.ReloadSchedule(r.Context(), result.WorkspacePath, id); err != nil {
 				scheduleLogf("[SCHEDULER] Failed to reload schedule %s after enable: %v", id, err)
 			}
-			state := svc.GetRuntimeState(id)
+			state := svc.GetRuntimeStateForWorkflow(result.WorkspacePath, id)
 			missedResolver := newWorkflowMissedStatusResolver(r.Context())
 			sched := result.Manifest.Schedules[result.Index]
 			resp = buildJobResponse(result.WorkspacePath, result.Manifest, sched, state, missedResolver.get(result.WorkspacePath, sched))
@@ -974,8 +984,8 @@ func disableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 					http.Error(w, "failed to write multi-agent schedules: "+writeErr.Error(), http.StatusInternalServerError)
 					return
 				}
-				_ = svc.RemoveJob(id)
-				state := svc.GetRuntimeState(id)
+				_ = svc.RemoveMultiAgentJob(userID, id)
+				state := svc.GetRuntimeStateForUser(userID, id)
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(buildMultiAgentJobResponse(userID, f.Schedules[idx], state))
 				return
@@ -984,7 +994,7 @@ func disableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			return
 		}
 
-		state := svc.GetRuntimeState(id)
+		state := runtimeStateForScheduleResult(svc, result, id)
 		var resp ScheduledJobResponse
 
 		if result.SourceType == "multi-agent" {
@@ -992,7 +1002,7 @@ func disableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 				http.Error(w, SlashManagedBuiltinError(id, "change"), http.StatusConflict)
 				return
 			}
-			_ = svc.RemoveJob(id)
+			_ = svc.RemoveMultiAgentJob(result.UserID, id)
 			result.ScheduleFile.Schedules[result.Index].Enabled = false
 			if err := WriteMultiAgentSchedules(r.Context(), result.UserID, result.ScheduleFile); err != nil {
 				http.Error(w, "failed to write multi-agent schedules: "+err.Error(), http.StatusInternalServerError)
@@ -1000,7 +1010,7 @@ func disableScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			}
 			resp = buildMultiAgentJobResponse(result.UserID, result.ScheduleFile.Schedules[result.Index], state)
 		} else {
-			_ = svc.RemoveJob(id)
+			_ = svc.RemoveWorkflowJob(result.WorkspacePath, id)
 			result.Manifest.Schedules[result.Index].Enabled = false
 			if err := WriteWorkflowManifest(r.Context(), result.WorkspacePath, result.Manifest); err != nil {
 				http.Error(w, "failed to write manifest: "+err.Error(), http.StatusInternalServerError)
@@ -1031,63 +1041,23 @@ func triggerScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			return
 		}
 
-		// Check if it's a multi-agent schedule first
-		userID := svc.GetUserForSchedule(id)
-		if userID != "" {
-			result, err := svc.TriggerMultiAgentNow(userID, id)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+		result, err := findScheduleByIDAnyOrCurrentUserBuiltin(r.Context(), id)
+		if err != nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		if result.SourceType == "multi-agent" {
+			trigResult, triggerErr := svc.TriggerMultiAgentNow(result.UserID, id)
+			if triggerErr != nil {
+				http.Error(w, triggerErr.Error(), http.StatusInternalServerError)
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{"session_id": result})
+			json.NewEncoder(w).Encode(map[string]string{"session_id": trigResult})
 			return
 		}
 
-		// Find workspace path — first check in-memory index, then scan manifests
-		workspacePath := svc.GetWorkspaceForSchedule(id)
-		if workspacePath == "" {
-			// Try to find it — could be workflow or unloaded multi-agent
-			result, err := findScheduleByIDAny(r.Context(), id)
-			if err != nil {
-				if IsDefaultBuiltinSchedule(id) && !IsSlashManagedBuiltinSchedule(id) {
-					userID := GetUserIDFromContext(r.Context())
-					if _, _, writeErr := writeBuiltinMultiAgentScheduleOverride(r.Context(), userID, id, func(s *WorkflowSchedule) {
-						s.Enabled = true
-					}); writeErr != nil {
-						http.Error(w, "failed to write multi-agent schedules: "+writeErr.Error(), http.StatusInternalServerError)
-						return
-					}
-					trigResult, trigErr := svc.TriggerMultiAgentNow(userID, id)
-					if trigErr != nil {
-						http.Error(w, trigErr.Error(), http.StatusInternalServerError)
-						return
-					}
-					w.Header().Set("Content-Type", "application/json")
-					json.NewEncoder(w).Encode(map[string]string{"session_id": trigResult})
-					return
-				}
-				http.Error(w, "not found", http.StatusNotFound)
-				return
-			}
-			if result.SourceType == "multi-agent" {
-				if IsSlashManagedBuiltinSchedule(id) {
-					http.Error(w, SlashManagedBuiltinError(id, "run"), http.StatusConflict)
-					return
-				}
-				trigResult, err := svc.TriggerMultiAgentNow(result.UserID, id)
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(map[string]string{"session_id": trigResult})
-				return
-			}
-			workspacePath = result.WorkspacePath
-		}
-
-		trigResult, err := svc.TriggerNow(workspacePath, id)
+		trigResult, err := svc.TriggerNow(result.WorkspacePath, id)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -1106,43 +1076,54 @@ func stopScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 		}
 
 		id := mux.Vars(r)["id"]
+		result, err := findScheduleByIDAnyOrCurrentUserBuiltin(r.Context(), id)
+		if err != nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 
-		state := svc.GetRuntimeState(id)
+		state := runtimeStateForScheduleResult(svc, result, id)
 		if state.LastStatus != "running" {
 			http.Error(w, "job is not running", http.StatusBadRequest)
 			return
 		}
 
-		svc.StopRunningJob(id)
-
-		// StopRunningJob owns the runtime transition. The route only mirrors that
-		// terminal state into persisted run history.
-		stoppedState := svc.getRuntimeStateSnapshot(id)
-		durationMs := int64(0)
-		if stoppedState.LastDurationMs != nil {
-			durationMs = *stoppedState.LastDurationMs
+		runtimeKey := workflowScheduleRuntimeKey(result.WorkspacePath, id)
+		if result.SourceType == "multi-agent" {
+			runtimeKey = multiAgentScheduleRuntimeKey(result.UserID, id)
+			svc.StopRunningJobForUser(result.UserID, id)
+		} else {
+			svc.StopRunningJobForWorkflow(result.WorkspacePath, id)
 		}
 
-		// Update latest run entry — check multi-agent first, then workflow
-		userID := svc.GetUserForSchedule(id)
-		if userID != "" {
-			runs, err := ReadMultiAgentScheduleRuns(r.Context(), userID)
+		durationMs := int64(0)
+		svc.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+			if state.LastRunAt != nil {
+				durationMs = time.Since(*state.LastRunAt).Milliseconds()
+			}
+			state.LastStatus = "stopped"
+			state.LastError = "stopped by user"
+			state.LastDurationMs = &durationMs
+		})
+
+		// Update latest run entry in the same resolved scope.
+		if result.SourceType == "multi-agent" {
+			runs, err := ReadMultiAgentScheduleRuns(r.Context(), result.UserID)
 			if err == nil {
 				for i := range runs {
 					if runs[i].ScheduleID == id && runs[i].Status == "running" {
-						_ = UpdateMultiAgentScheduleRun(r.Context(), userID, runs[i].ID, "stopped", "stopped by user", &durationMs, "")
+						_ = UpdateMultiAgentScheduleRun(r.Context(), result.UserID, runs[i].ID, "stopped", "stopped by user", &durationMs, "")
 						break
 					}
 				}
 			}
 		} else {
-			workspacePath := svc.GetWorkspaceForSchedule(id)
-			if workspacePath != "" {
-				runs, err := ReadScheduleRuns(r.Context(), workspacePath)
+			if result.WorkspacePath != "" {
+				runs, err := ReadScheduleRuns(r.Context(), result.WorkspacePath)
 				if err == nil && len(runs) > 0 {
 					for i := range runs {
 						if runs[i].ScheduleID == id && runs[i].Status == "running" {
-							_ = UpdateScheduleRun(r.Context(), workspacePath, runs[i].ID, "stopped", "stopped by user", &durationMs, "", "")
+							_ = UpdateScheduleRun(r.Context(), result.WorkspacePath, runs[i].ID, "stopped", "stopped by user", &durationMs, "", "")
 							break
 						}
 					}
@@ -1150,15 +1131,7 @@ func stopScheduledJobHandler(svc *SchedulerService) http.HandlerFunc {
 			}
 		}
 
-		// Return updated state
-		result, err := findScheduleByIDAny(r.Context(), id)
-		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{"status": "stopped"})
-			return
-		}
-
-		updatedState := svc.GetRuntimeState(id)
+		updatedState := runtimeStateForScheduleResult(svc, result, id)
 		var resp ScheduledJobResponse
 		if result.SourceType == "multi-agent" {
 			resp = buildMultiAgentJobResponse(result.UserID, result.ScheduleFile.Schedules[result.Index], updatedState)

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -265,6 +265,44 @@ func TestScheduleRunPublicationRegistersCancelBeforeUnlock(t *testing.T) {
 	}
 }
 
+func TestStopBetweenReservationAndDurableClaimPreventsExecution(t *testing.T) {
+	store, err := schedulerstate.Open(filepath.Join(t.TempDir(), "schedule-state.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewSchedulerService(nil)
+	svc.stateStore = store
+	sctx := buildScheduleContext("Workflow/demo", &WorkflowManifest{ID: "demo"}, WorkflowSchedule{ID: "daily"})
+	runtimeKey := scheduleRuntimeKey(sctx)
+	runID := "stop-during-claim"
+	startedAt := time.Now().UTC()
+
+	svc.runtimeStatesMu.Lock()
+	state := svc.getRuntimeStateLocked(runtimeKey)
+	runCtx := svc.activateScheduleRunLocked(state, runID, startedAt)
+	svc.runtimeStatesMu.Unlock()
+
+	// This is the historical race window: Stop sees the reservation before the
+	// SQLite run row exists.
+	svc.stopRunningJob(runtimeKey, sctx.Schedule.ID)
+	if err := svc.claimScheduleRun(context.Background(), sctx, runID, startedAt); err != nil {
+		t.Fatalf("durable claim after stop: %v", err)
+	}
+	if !svc.abortCanceledScheduleRunBeforeStart(runCtx, sctx, runtimeKey, runID) {
+		t.Fatal("canceled reservation was allowed to start")
+	}
+
+	run, err := store.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != schedulerstate.StateStopped {
+		t.Fatalf("durable state = %s, want stopped", run.State)
+	}
+}
+
 func TestTriggerMultiAgentNowFindsBuiltinWithoutScheduleFile(t *testing.T) {
 	workspace := httptest.NewServer(&mockWorkspaceAPI{files: map[string]string{}})
 	defer workspace.Close()
@@ -370,6 +408,45 @@ func TestLoadScheduleReplacesCalendarRegistrations(t *testing.T) {
 	}
 	if matching != 1 {
 		t.Fatalf("calendar registrations = %d, want 1", matching)
+	}
+}
+
+func TestLoadScheduleDoesNotRememberInvalidCronFingerprint(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	sctx := buildMultiAgentScheduleContext("user-1", WorkflowSchedule{
+		ID: "daily", Enabled: true, CronExpression: "not-a-cron", Timezone: "UTC",
+	}, WorkflowCapabilities{})
+	runtimeKey := scheduleRuntimeKey(sctx)
+	if err := svc.LoadSchedule(sctx); err == nil {
+		t.Fatal("invalid cron unexpectedly loaded")
+	}
+	if _, ok := svc.scheduleFingerprints[runtimeKey]; ok {
+		t.Fatal("invalid cron fingerprint should not suppress the next rescan")
+	}
+
+	sctx.Schedule.CronExpression = "0 9 * * *"
+	if err := svc.LoadSchedule(sctx); err != nil {
+		t.Fatalf("corrected cron was not retried: %v", err)
+	}
+	if _, ok := svc.scheduleFingerprints[runtimeKey]; !ok {
+		t.Fatal("valid schedule fingerprint was not recorded")
+	}
+}
+
+func TestRemoveJobDropsInactiveRuntimeState(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	runtimeKey := workflowScheduleRuntimeKey("Workflow/demo", "daily")
+	svc.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.LastStatus = "success"
+	})
+	if err := svc.removeJobByKey(runtimeKey); err != nil {
+		t.Fatal(err)
+	}
+	svc.runtimeStatesMu.RLock()
+	_, exists := svc.runtimeStates[runtimeKey]
+	svc.runtimeStatesMu.RUnlock()
+	if exists {
+		t.Fatal("removed schedule retained inactive runtime state")
 	}
 }
 

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	virtualtools "mcp-agent-builder-go/agent_go/cmd/server/virtual-tools"
 	"mcp-agent-builder-go/agent_go/internal/terminals"
+	"mcp-agent-builder-go/agent_go/pkg/schedulerstate"
 	"mcp-agent-builder-go/agent_go/pkg/workflowtypes"
 )
 
@@ -50,6 +52,256 @@ func TestBuildScheduleCronExpressionAlwaysSetsTimezone(t *testing.T) {
 				t.Fatalf("buildScheduleCronExpression() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMergeRuntimeStatePreservesRunningPulseForSameSession(t *testing.T) {
+	runtimeStarted := time.Now().Add(-time.Minute).UTC()
+	historyStarted := runtimeStarted.Add(time.Millisecond)
+	duration := int64(1200)
+
+	got := mergeRuntimeStateWithRuns(ScheduleRuntimeState{
+		LastStatus:    "running",
+		LastRunAt:     &runtimeStarted,
+		LastSessionID: "session-1",
+	}, "schedule-1", []ScheduleRunEntry{{
+		ID:         "run-1",
+		ScheduleID: "schedule-1",
+		SessionID:  "session-1",
+		Status:     "success",
+		StartedAt:  historyStarted,
+		DurationMs: &duration,
+	}})
+
+	if got.LastStatus != "running" {
+		t.Fatalf("LastStatus = %q, want running while Pulse owns the session", got.LastStatus)
+	}
+	if got.LastSessionID != "session-1" {
+		t.Fatalf("LastSessionID = %q, want session-1", got.LastSessionID)
+	}
+}
+
+func TestMergeRuntimeStateAdoptsGenuinelyNewerRun(t *testing.T) {
+	runtimeStarted := time.Now().Add(-time.Hour).UTC()
+	historyStarted := runtimeStarted.Add(30 * time.Minute)
+
+	got := mergeRuntimeStateWithRuns(ScheduleRuntimeState{
+		LastStatus:    "running",
+		LastRunAt:     &runtimeStarted,
+		LastSessionID: "old-session",
+	}, "schedule-1", []ScheduleRunEntry{{
+		ID:         "run-2",
+		ScheduleID: "schedule-1",
+		SessionID:  "new-session",
+		Status:     "success",
+		StartedAt:  historyStarted,
+	}})
+
+	if got.LastStatus != "success" || got.LastSessionID != "new-session" {
+		t.Fatalf("merged state = %+v, want newer persisted run", got)
+	}
+}
+
+func TestUpdateRuntimeStateSerializesMutations(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	const workers = 32
+	const increments = 250
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < increments; j++ {
+				svc.updateRuntimeState("schedule-1", func(state *ScheduleRuntimeState) {
+					state.RunCount++
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	got := svc.GetRuntimeState("schedule-1")
+	if got.RunCount != workers*increments {
+		t.Fatalf("RunCount = %d, want %d", got.RunCount, workers*increments)
+	}
+}
+
+func TestRuntimeStateIsScopedAcrossUsersAndWorkflows(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	userOneKey := multiAgentScheduleRuntimeKey("user-1", "builtin-org-pulse")
+	userTwoKey := multiAgentScheduleRuntimeKey("user-2", "builtin-org-pulse")
+	workflowOneKey := workflowScheduleRuntimeKey("Workflow/one", "copied-schedule")
+	workflowTwoKey := workflowScheduleRuntimeKey("Workflow/two", "copied-schedule")
+
+	svc.updateRuntimeState(userOneKey, func(state *ScheduleRuntimeState) {
+		state.LastStatus = "running"
+		state.LastSessionID = "user-1-session"
+	})
+	svc.updateRuntimeState(userTwoKey, func(state *ScheduleRuntimeState) {
+		state.LastStatus = "success"
+		state.LastSessionID = "user-2-session"
+	})
+	svc.updateRuntimeState(workflowOneKey, func(state *ScheduleRuntimeState) {
+		state.LastStatus = "running"
+	})
+	svc.updateRuntimeState(workflowTwoKey, func(state *ScheduleRuntimeState) {
+		state.LastStatus = "stopped"
+	})
+
+	if got := svc.getRuntimeStateByKey(userOneKey); got.LastSessionID != "user-1-session" || got.LastStatus != "running" {
+		t.Fatalf("user 1 state = %+v", got)
+	}
+	if got := svc.getRuntimeStateByKey(userTwoKey); got.LastSessionID != "user-2-session" || got.LastStatus != "success" {
+		t.Fatalf("user 2 state = %+v", got)
+	}
+	if got := svc.getRuntimeStateByKey(workflowOneKey); got.LastStatus != "running" {
+		t.Fatalf("workflow one state = %+v", got)
+	}
+	if got := svc.getRuntimeStateByKey(workflowTwoKey); got.LastStatus != "stopped" {
+		t.Fatalf("workflow two state = %+v", got)
+	}
+	if got := svc.GetRuntimeState("builtin-org-pulse"); got.LastStatus != "" {
+		t.Fatalf("ambiguous unscoped state = %+v, want empty", got)
+	}
+}
+
+func TestScheduleStateLockKeyFromRuntimeKey(t *testing.T) {
+	workflowKey := workflowScheduleRuntimeKey("/tmp/Workflow/demo", "daily")
+	wantWorkflow := strings.Join([]string{"workflow", "/tmp/Workflow/demo"}, scheduleScopeSeparator)
+	if got := scheduleStateLockKeyFromRuntimeKey(workflowKey); got != wantWorkflow {
+		t.Fatalf("workflow lock key = %q, want %q", got, wantWorkflow)
+	}
+	multiAgentKey := multiAgentScheduleRuntimeKey("user-1", "daily")
+	if got := scheduleStateLockKeyFromRuntimeKey(multiAgentKey); got != multiAgentKey {
+		t.Fatalf("multi-agent lock key = %q, want %q", got, multiAgentKey)
+	}
+}
+
+func TestStopRunningJobCancelsBeforeSessionStarts(t *testing.T) {
+	store, err := schedulerstate.Open(filepath.Join(t.TempDir(), "schedule-state.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewSchedulerService(nil)
+	svc.stateStore = store
+	sctx := buildScheduleContext("Workflow/demo", &WorkflowManifest{ID: "demo"}, WorkflowSchedule{ID: "daily"})
+	runID := "run-before-session"
+	if err := svc.claimScheduleRun(context.Background(), sctx, runID, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	runCtx := svc.registerScheduleRunContext(runID)
+	runtimeKey := scheduleRuntimeKey(sctx)
+	svc.updateRuntimeState(runtimeKey, func(state *ScheduleRuntimeState) {
+		state.ActiveRunID = runID
+		state.LastStatus = "running"
+	})
+
+	svc.stopRunningJob(runtimeKey, sctx.Schedule.ID)
+	select {
+	case <-runCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("run context was not canceled")
+	}
+	run, err := store.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != schedulerstate.StateStopped {
+		t.Fatalf("durable state = %s, want stopped", run.State)
+	}
+	state := svc.getRuntimeStateByKey(runtimeKey)
+	if state.LastStatus != "stopped" || state.ActiveRunID != "" {
+		t.Fatalf("runtime state after stop = %+v", state)
+	}
+}
+
+func TestScheduleConfigFingerprintChangesWithCapabilities(t *testing.T) {
+	sctx := buildMultiAgentScheduleContext("user-1", WorkflowSchedule{ID: "daily", Enabled: true, CronExpression: "0 9 * * *", Timezone: "UTC"}, WorkflowCapabilities{})
+	first := scheduleConfigFingerprint(sctx)
+	second := scheduleConfigFingerprint(sctx)
+	if first == "" || first != second {
+		t.Fatalf("fingerprint should be stable and non-empty: %q %q", first, second)
+	}
+	sctx.Capabilities.SelectedSkills = []string{"research"}
+	if changed := scheduleConfigFingerprint(sctx); changed == first {
+		t.Fatal("capability change did not change schedule fingerprint")
+	}
+}
+
+func TestScheduleWithReloadedCalendarItemUsesLatestOverrides(t *testing.T) {
+	requested := &CalendarScheduleItem{ID: "item-1", Date: "2030-01-01", Time: "09:00", Messages: []string{"old"}}
+	sched := WorkflowSchedule{
+		ID: "calendar", ScheduleType: "calendar", Timezone: "UTC",
+		Messages:      []string{"base"},
+		CalendarItems: []CalendarScheduleItem{{ID: "item-1", Date: requested.Date, Time: requested.Time, Messages: []string{"new"}}},
+	}
+	resolved, item, ok := scheduleWithReloadedCalendarItem(sched, requested)
+	if !ok || item == nil {
+		t.Fatal("expected calendar item to resolve")
+	}
+	if got := strings.Join(resolved.Messages, ","); got != "new" {
+		t.Fatalf("resolved messages = %q, want latest override", got)
+	}
+}
+
+func TestLoadScheduleReplacesCalendarRegistrations(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	when := time.Now().UTC().Add(24 * time.Hour)
+	item := CalendarScheduleItem{ID: "item-1", Date: when.Format("2006-01-02"), Time: when.Format("15:04"), Messages: []string{"old"}}
+	sched := WorkflowSchedule{ID: "calendar", Name: "Calendar", Enabled: true, ScheduleType: "calendar", Timezone: "UTC", CalendarItems: []CalendarScheduleItem{item}}
+	if err := svc.LoadSchedule(buildMultiAgentScheduleContext("user-1", sched, WorkflowCapabilities{})); err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	sched.CalendarItems[0].Messages = []string{"new"}
+	if err := svc.LoadSchedule(buildMultiAgentScheduleContext("user-1", sched, WorkflowCapabilities{})); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	keyPrefix := multiAgentScheduleRuntimeKey("user-1", sched.ID) + "__cal__"
+	matching := 0
+	for key, job := range svc.jobs {
+		if !strings.HasPrefix(key, keyPrefix) {
+			continue
+		}
+		matching++
+		if job.sctx.CalendarItem == nil || strings.Join(job.sctx.Schedule.Messages, ",") != "new" {
+			t.Fatalf("calendar registration did not retain latest item override: %+v", job.sctx)
+		}
+	}
+	if matching != 1 {
+		t.Fatalf("calendar registrations = %d, want 1", matching)
+	}
+}
+
+func TestLoadScheduleKeepsSameIDForDifferentUsers(t *testing.T) {
+	svc := NewSchedulerService(nil)
+	for _, userID := range []string{"user-1", "user-2"} {
+		sctx := buildMultiAgentScheduleContext(userID, WorkflowSchedule{
+			ID:             "builtin-org-pulse",
+			Name:           "Org Pulse",
+			Enabled:        true,
+			CronExpression: "0 9 * * *",
+			Timezone:       "UTC",
+			Query:          "Run Org Pulse",
+		}, WorkflowCapabilities{})
+		if err := svc.LoadSchedule(sctx); err != nil {
+			t.Fatalf("LoadSchedule(%s): %v", userID, err)
+		}
+	}
+
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if len(svc.jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 scoped jobs", len(svc.jobs))
+	}
+	for _, userID := range []string{"user-1", "user-2"} {
+		if _, ok := svc.jobs[multiAgentScheduleRuntimeKey(userID, "builtin-org-pulse")]; !ok {
+			t.Fatalf("missing scoped job for %s", userID)
+		}
 	}
 }
 

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -218,6 +218,102 @@ func TestStopRunningJobCancelsBeforeSessionStarts(t *testing.T) {
 	}
 }
 
+func TestScheduleRunPublicationRegistersCancelBeforeUnlock(t *testing.T) {
+	store, err := schedulerstate.Open(filepath.Join(t.TempDir(), "schedule-state.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewSchedulerService(nil)
+	svc.stateStore = store
+	sctx := buildScheduleContext("Workflow/demo", &WorkflowManifest{ID: "demo"}, WorkflowSchedule{ID: "daily"})
+	runID := "atomic-publication"
+	startedAt := time.Now().UTC()
+	if err := svc.claimScheduleRun(context.Background(), sctx, runID, startedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeKey := scheduleRuntimeKey(sctx)
+	svc.runtimeStatesMu.Lock()
+	state := svc.getRuntimeStateLocked(runtimeKey)
+	runCtx := svc.activateScheduleRunLocked(state, runID, startedAt)
+	stopStarted := make(chan struct{})
+	stopDone := make(chan struct{})
+	go func() {
+		close(stopStarted)
+		svc.stopRunningJob(runtimeKey, sctx.Schedule.ID)
+		close(stopDone)
+	}()
+	<-stopStarted
+	select {
+	case <-stopDone:
+		t.Fatal("stop completed before active run publication released its lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	svc.runtimeStatesMu.Unlock()
+
+	select {
+	case <-runCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("stop did not cancel the atomically published run context")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not complete")
+	}
+}
+
+func TestTriggerMultiAgentNowFindsBuiltinWithoutScheduleFile(t *testing.T) {
+	workspace := httptest.NewServer(&mockWorkspaceAPI{files: map[string]string{}})
+	defer workspace.Close()
+	t.Setenv("WORKSPACE_API_URL", workspace.URL)
+
+	svc := NewSchedulerService(nil)
+	userID := "user-without-schedule-file"
+	svc.updateRuntimeState(multiAgentScheduleRuntimeKey(userID, builtinOrgPulseID), func(state *ScheduleRuntimeState) {
+		state.LastStatus = "running"
+		state.LastSessionID = "existing-session"
+	})
+
+	_, err := svc.TriggerMultiAgentNow(userID, builtinOrgPulseID)
+	if err == nil || !strings.Contains(err.Error(), "job is already running") {
+		t.Fatalf("TriggerMultiAgentNow() error = %v, want builtin resolution followed by running guard", err)
+	}
+}
+
+func TestGetRuntimeStateForUserReconcilesStaleRun(t *testing.T) {
+	workspace := httptest.NewServer(&mockWorkspaceAPI{files: map[string]string{}})
+	defer workspace.Close()
+	t.Setenv("WORKSPACE_API_URL", workspace.URL)
+
+	userID := "user-1"
+	scheduleID := "daily"
+	if err := AppendMultiAgentScheduleRun(context.Background(), userID, &ScheduleRunEntry{
+		ID:         "stale-run",
+		ScheduleID: scheduleID,
+		SessionID:  "missing-session",
+		Status:     "running",
+		StartedAt:  time.Now().Add(-time.Minute).UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewSchedulerService(&StreamingAPI{})
+	state := svc.GetRuntimeStateForUser(userID, scheduleID)
+	if state.LastStatus != "error" || !strings.Contains(state.LastError, "session not active") {
+		t.Fatalf("reconciled state = %+v, want stale run finalized as error", state)
+	}
+	runs, err := ReadMultiAgentScheduleRuns(context.Background(), userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].Status != "error" || runs[0].CompletedAt == nil {
+		t.Fatalf("persisted runs = %+v, want finalized stale run", runs)
+	}
+}
+
 func TestScheduleConfigFingerprintChangesWithCapabilities(t *testing.T) {
 	sctx := buildMultiAgentScheduleContext("user-1", WorkflowSchedule{ID: "daily", Enabled: true, CronExpression: "0 9 * * *", Timezone: "UTC"}, WorkflowCapabilities{})
 	first := scheduleConfigFingerprint(sctx)

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -2246,26 +2246,29 @@ func TestWaitForWorkshopIdleAbortsCanceledTurnBeforeNextMessage(t *testing.T) {
 	}
 }
 
-func TestRunJobGenerationZeroDoesNotJoinActiveRun(t *testing.T) {
+func TestRunJobDoesNotJoinAnotherActiveRun(t *testing.T) {
 	startedAt := time.Now().Add(-time.Minute)
+	sctx := &ScheduleContext{
+		WorkspacePath: "/tmp/workflow",
+		Schedule:      WorkflowSchedule{ID: "schedule-1", Name: "Active schedule"},
+	}
+	runtimeKey := scheduleRuntimeKey(sctx)
 	svc := &SchedulerService{runtimeStates: map[string]*ScheduleRuntimeState{
-		"schedule-1": {
-			LastStatus:    "running",
-			LastRunAt:     &startedAt,
-			runGeneration: 7,
+		runtimeKey: {
+			ActiveRunID: "active-run",
+			LastStatus:  "running",
+			LastRunAt:   &startedAt,
 		},
+	}, runCancels: map[string]context.CancelFunc{
+		"stale-run": func() {},
 	}}
-	sctx := &ScheduleContext{Schedule: WorkflowSchedule{ID: "schedule-1", Name: "Active schedule"}}
 
-	_, err := svc.runJob(context.Background(), sctx)
+	_, err := svc.runJob(context.Background(), sctx, "stale-run")
 	if !errors.Is(err, errWorkshopSequenceInterrupted) {
 		t.Fatalf("runJob error = %v, want errWorkshopSequenceInterrupted", err)
 	}
-	if sctx.runGeneration != 0 {
-		t.Fatalf("generation-zero caller adopted generation %d", sctx.runGeneration)
-	}
-	if got := svc.runtimeStates["schedule-1"].runGeneration; got != 7 {
-		t.Fatalf("active run generation changed to %d", got)
+	if got := svc.runtimeStates[runtimeKey].ActiveRunID; got != "active-run" {
+		t.Fatalf("active run ownership changed to %q", got)
 	}
 }
 

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -7704,7 +7704,7 @@ func (api *StreamingAPI) buildSchedulerCallbacks() *todo_creation_human.Schedule
 				sb.WriteString(fmt.Sprintf("- **Timezone**: %s\n", sched.Timezone))
 				sb.WriteString(fmt.Sprintf("- **Status**: %s\n", status))
 				if api.scheduler != nil {
-					state := api.scheduler.GetRuntimeState(sched.ID)
+					state := api.scheduler.GetRuntimeStateForWorkflow(workspacePath, sched.ID)
 					if state.LastStatus != "" {
 						sb.WriteString(fmt.Sprintf("- **Last Run**: %v (status: %s)\n", state.LastRunAt, state.LastStatus))
 					}
@@ -7896,12 +7896,12 @@ func (api *StreamingAPI) buildSchedulerCallbacks() *todo_creation_human.Schedule
 			return fmt.Sprintf("Schedule updated.\n- **ID**: `%s`\n- **Name**: %s\n- **Cron**: `%s`\n- **Enabled**: %v\n- **Next Run**: %s", sched.ID, sched.Name, sched.CronExpression, sched.Enabled, nextRunStr), nil
 		},
 		DeleteSchedule: func(ctx context.Context, jobID string) error {
-			if api.scheduler != nil {
-				api.scheduler.RemoveJob(jobID)
-			}
 			workspacePath, manifest, idx, err := findScheduleByID(ctx, jobID)
 			if err != nil {
 				return err
+			}
+			if api.scheduler != nil {
+				_ = api.scheduler.RemoveWorkflowJob(workspacePath, jobID)
 			}
 			manifest.Schedules = append(manifest.Schedules[:idx], manifest.Schedules[idx+1:]...)
 			return WriteWorkflowManifest(ctx, workspacePath, manifest)

--- a/agent_go/cmd/server/workflow_schedule_tools.go
+++ b/agent_go/cmd/server/workflow_schedule_tools.go
@@ -490,7 +490,7 @@ func formatGlobalSchedules(ctx context.Context, api *StreamingAPI, currentUserID
 					nextRun: getNextRunTime(sched.CronExpression, sched.Timezone),
 				}
 				if api.scheduler != nil {
-					st := api.scheduler.GetRuntimeState(sched.ID)
+					st := api.scheduler.GetRuntimeStateForWorkflow(dw.WorkspacePath, sched.ID)
 					entry.lastStatus = st.LastStatus
 					entry.lastRunAt = st.LastRunAt
 				}
@@ -512,7 +512,7 @@ func formatGlobalSchedules(ctx context.Context, api *StreamingAPI, currentUserID
 					nextRun: getNextRunTime(sched.CronExpression, sched.Timezone),
 				}
 				if api.scheduler != nil {
-					st := api.scheduler.GetRuntimeState(sched.ID)
+					st := api.scheduler.GetRuntimeStateForUser(currentUserID, sched.ID)
 					entry.lastStatus = st.LastStatus
 					entry.lastRunAt = st.LastRunAt
 				}

--- a/agent_go/pkg/schedulerstate/store.go
+++ b/agent_go/pkg/schedulerstate/store.go
@@ -1,0 +1,474 @@
+package schedulerstate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+type State string
+
+const (
+	StateStarting         State = "starting"
+	StateWorkflowRunning  State = "workflow_running"
+	StateWorkflowFinished State = "workflow_finished"
+	StatePulseGate        State = "pulse_gate"
+	StatePulseModules     State = "pulse_modules"
+	StatePulseFinalizing  State = "pulse_finalizing"
+	StateCompleted        State = "completed"
+	StatePartial          State = "partial"
+	StateFailed           State = "failed"
+	StateStopped          State = "stopped"
+	StateInterrupted      State = "interrupted"
+)
+
+var (
+	ErrRunAlreadyActive  = errors.New("schedule run already active for scope")
+	ErrRunNotFound       = errors.New("schedule run not found")
+	ErrInvalidTransition = errors.New("invalid schedule run transition")
+)
+
+var allowedTransitions = map[State]map[State]bool{
+	StateStarting: {
+		StateWorkflowRunning: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+	StateWorkflowRunning: {
+		StateWorkflowFinished: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+	StateWorkflowFinished: {
+		StatePulseGate: true, StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+	StatePulseGate: {
+		StatePulseModules: true, StatePulseFinalizing: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+	StatePulseModules: {
+		StatePulseFinalizing: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+	StatePulseFinalizing: {
+		StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+	},
+}
+
+func IsTerminal(state State) bool {
+	switch state {
+	case StateCompleted, StatePartial, StateFailed, StateStopped, StateInterrupted:
+		return true
+	default:
+		return false
+	}
+}
+
+type Run struct {
+	RunID           string
+	ScopeType       string
+	ScopeID         string
+	LockKey         string
+	ScheduleID      string
+	TriggerSource   string
+	State           State
+	StartedAt       time.Time
+	UpdatedAt       time.Time
+	CompletedAt     *time.Time
+	ActiveSessionID string
+	RunFolder       string
+	ErrorMessage    string
+}
+
+type Transition struct {
+	RunID        string
+	To           State
+	Reason       string
+	SessionID    string
+	SessionKind  string
+	RunFolder    string
+	ErrorMessage string
+	At           time.Time
+}
+
+type FireDecision struct {
+	DecisionID    string
+	ScopeType     string
+	ScopeID       string
+	ScheduleID    string
+	TriggerSource string
+	Decision      string
+	Reason        string
+	RunID         string
+	FiredAt       time.Time
+}
+
+type Event struct {
+	Sequence  int64
+	RunID     string
+	FromState State
+	ToState   State
+	Reason    string
+	CreatedAt time.Time
+}
+
+type Store struct {
+	db *sql.DB
+}
+
+func Open(path string) (*Store, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("schedule state path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create schedule state directory: %w", err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open schedule state: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	store := &Store{db: db}
+	if err := store.init(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *Store) init(ctx context.Context) error {
+	statements := []string{
+		`PRAGMA journal_mode=WAL`,
+		`PRAGMA busy_timeout=5000`,
+		`PRAGMA foreign_keys=ON`,
+		`CREATE TABLE IF NOT EXISTS schedule_runs (
+			run_id TEXT PRIMARY KEY,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			lock_key TEXT NOT NULL,
+			schedule_id TEXT NOT NULL,
+			trigger_source TEXT NOT NULL,
+			state TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			completed_at TEXT,
+			active_session_id TEXT NOT NULL DEFAULT '',
+			run_folder TEXT NOT NULL DEFAULT '',
+			error_message TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_schedule_runs_active_lock
+			ON schedule_runs(lock_key)
+			WHERE state IN ('starting','workflow_running','workflow_finished','pulse_gate','pulse_modules','pulse_finalizing')`,
+		`CREATE INDEX IF NOT EXISTS idx_schedule_runs_scope_started
+			ON schedule_runs(scope_type, scope_id, schedule_id, started_at DESC)`,
+		`CREATE TABLE IF NOT EXISTS schedule_run_events (
+			sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id TEXT NOT NULL,
+			from_state TEXT NOT NULL,
+			to_state TEXT NOT NULL,
+			reason TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL,
+			FOREIGN KEY(run_id) REFERENCES schedule_runs(run_id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE IF NOT EXISTS schedule_run_sessions (
+			run_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			session_kind TEXT NOT NULL,
+			status TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			ended_at TEXT,
+			PRIMARY KEY(run_id, session_id),
+			FOREIGN KEY(run_id) REFERENCES schedule_runs(run_id) ON DELETE CASCADE
+		)`,
+		`CREATE TABLE IF NOT EXISTS schedule_fire_decisions (
+			decision_id TEXT PRIMARY KEY,
+			scope_type TEXT NOT NULL,
+			scope_id TEXT NOT NULL,
+			schedule_id TEXT NOT NULL,
+			trigger_source TEXT NOT NULL,
+			decision TEXT NOT NULL,
+			reason TEXT NOT NULL DEFAULT '',
+			run_id TEXT NOT NULL DEFAULT '',
+			fired_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_schedule_fire_scope_time
+			ON schedule_fire_decisions(scope_type, scope_id, schedule_id, fired_at DESC)`,
+	}
+	for _, statement := range statements {
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("initialize schedule state: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) BeginRun(ctx context.Context, run Run) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("schedule state store is unavailable")
+	}
+	if strings.TrimSpace(run.RunID) == "" || strings.TrimSpace(run.LockKey) == "" || strings.TrimSpace(run.ScheduleID) == "" {
+		return fmt.Errorf("run_id, lock_key, and schedule_id are required")
+	}
+	if run.StartedAt.IsZero() {
+		run.StartedAt = time.Now().UTC()
+	}
+	run.StartedAt = run.StartedAt.UTC()
+	if run.State == "" {
+		run.State = StateStarting
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, err = tx.ExecContext(ctx, `INSERT INTO schedule_runs (
+		run_id, scope_type, scope_id, lock_key, schedule_id, trigger_source,
+		state, started_at, updated_at, active_session_id, run_folder, error_message
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.RunID, run.ScopeType, run.ScopeID, run.LockKey, run.ScheduleID, run.TriggerSource,
+		run.State, formatTime(run.StartedAt), formatTime(run.StartedAt), run.ActiveSessionID, run.RunFolder, run.ErrorMessage)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unique constraint") {
+			return fmt.Errorf("%w: %s", ErrRunAlreadyActive, run.LockKey)
+		}
+		return fmt.Errorf("insert schedule run: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_run_events (run_id, from_state, to_state, reason, created_at)
+		VALUES (?, '', ?, 'run claimed', ?)`, run.RunID, run.State, formatTime(run.StartedAt)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) Transition(ctx context.Context, transition Transition) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("schedule state store is unavailable")
+	}
+	if transition.At.IsZero() {
+		transition.At = time.Now().UTC()
+	}
+	transition.At = transition.At.UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var current string
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM schedule_runs WHERE run_id = ?`, transition.RunID).Scan(&current); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: %s", ErrRunNotFound, transition.RunID)
+		}
+		return err
+	}
+	from := State(current)
+	if from == transition.To {
+		return tx.Commit()
+	}
+	if IsTerminal(from) || !allowedTransitions[from][transition.To] {
+		return fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, from, transition.To)
+	}
+
+	completedAt := ""
+	if IsTerminal(transition.To) {
+		completedAt = formatTime(transition.At)
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE schedule_runs SET
+		state = ?, updated_at = ?,
+		completed_at = CASE WHEN ? <> '' THEN ? ELSE completed_at END,
+		active_session_id = CASE WHEN ? <> '' THEN ? ELSE active_session_id END,
+		run_folder = CASE WHEN ? <> '' THEN ? ELSE run_folder END,
+		error_message = CASE WHEN ? <> '' THEN ? ELSE error_message END
+		WHERE run_id = ?`,
+		transition.To, formatTime(transition.At), completedAt, completedAt,
+		transition.SessionID, transition.SessionID, transition.RunFolder, transition.RunFolder,
+		transition.ErrorMessage, transition.ErrorMessage, transition.RunID)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_run_events (run_id, from_state, to_state, reason, created_at)
+		VALUES (?, ?, ?, ?, ?)`, transition.RunID, from, transition.To, transition.Reason, formatTime(transition.At)); err != nil {
+		return err
+	}
+	if transition.SessionID != "" {
+		sessionKind := transition.SessionKind
+		if sessionKind == "" {
+			sessionKind = "main"
+		}
+		sessionStatus := "running"
+		var endedAt any
+		if IsTerminal(transition.To) {
+			sessionStatus = string(transition.To)
+			endedAt = formatTime(transition.At)
+		}
+		_, err = tx.ExecContext(ctx, `INSERT INTO schedule_run_sessions (
+			run_id, session_id, session_kind, status, started_at, ended_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, session_id) DO UPDATE SET
+			session_kind = excluded.session_kind,
+			status = excluded.status,
+			ended_at = COALESCE(excluded.ended_at, schedule_run_sessions.ended_at)`,
+			transition.RunID, transition.SessionID, sessionKind, sessionStatus, formatTime(transition.At), endedAt)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) RecordFireDecision(ctx context.Context, decision FireDecision) error {
+	if decision.FiredAt.IsZero() {
+		decision.FiredAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO schedule_fire_decisions (
+		decision_id, scope_type, scope_id, schedule_id, trigger_source, decision, reason, run_id, fired_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, decision.DecisionID, decision.ScopeType, decision.ScopeID,
+		decision.ScheduleID, decision.TriggerSource, decision.Decision, decision.Reason, decision.RunID, formatTime(decision.FiredAt))
+	return err
+}
+
+func (s *Store) ListFireDecisions(ctx context.Context, scopeType, scopeID, scheduleID string, limit int) ([]FireDecision, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT decision_id, scope_type, scope_id, schedule_id,
+		trigger_source, decision, reason, run_id, fired_at
+		FROM schedule_fire_decisions
+		WHERE scope_type = ? AND scope_id = ? AND schedule_id = ?
+		ORDER BY fired_at DESC LIMIT ?`, scopeType, scopeID, scheduleID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var decisions []FireDecision
+	for rows.Next() {
+		var decision FireDecision
+		var firedAt string
+		if err := rows.Scan(&decision.DecisionID, &decision.ScopeType, &decision.ScopeID, &decision.ScheduleID,
+			&decision.TriggerSource, &decision.Decision, &decision.Reason, &decision.RunID, &firedAt); err != nil {
+			return nil, err
+		}
+		decision.FiredAt, err = parseTime(firedAt)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, decision)
+	}
+	return decisions, rows.Err()
+}
+
+func (s *Store) GetRun(ctx context.Context, runID string) (Run, error) {
+	var run Run
+	var startedAt, updatedAt, completedAt string
+	err := s.db.QueryRowContext(ctx, `SELECT run_id, scope_type, scope_id, lock_key, schedule_id,
+		trigger_source, state, started_at, updated_at, COALESCE(completed_at, ''), active_session_id,
+		run_folder, error_message FROM schedule_runs WHERE run_id = ?`, runID).Scan(
+		&run.RunID, &run.ScopeType, &run.ScopeID, &run.LockKey, &run.ScheduleID, &run.TriggerSource,
+		&run.State, &startedAt, &updatedAt, &completedAt, &run.ActiveSessionID, &run.RunFolder, &run.ErrorMessage)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Run{}, ErrRunNotFound
+	}
+	if err != nil {
+		return Run{}, err
+	}
+	run.StartedAt, err = parseTime(startedAt)
+	if err != nil {
+		return Run{}, err
+	}
+	run.UpdatedAt, err = parseTime(updatedAt)
+	if err != nil {
+		return Run{}, err
+	}
+	if completedAt != "" {
+		parsed, parseErr := parseTime(completedAt)
+		if parseErr != nil {
+			return Run{}, parseErr
+		}
+		run.CompletedAt = &parsed
+	}
+	return run, nil
+}
+
+// ActiveRunByLockKey returns the run currently holding a schedule/workflow
+// lease. The partial unique index guarantees that at most one row can match.
+func (s *Store) ActiveRunByLockKey(ctx context.Context, lockKey string) (Run, error) {
+	var runID string
+	err := s.db.QueryRowContext(ctx, `SELECT run_id FROM schedule_runs
+		WHERE lock_key = ?
+		  AND state IN ('starting','workflow_running','workflow_finished','pulse_gate','pulse_modules','pulse_finalizing')
+		LIMIT 1`, lockKey).Scan(&runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Run{}, ErrRunNotFound
+	}
+	if err != nil {
+		return Run{}, err
+	}
+	return s.GetRun(ctx, runID)
+}
+
+func (s *Store) ListEvents(ctx context.Context, runID string) ([]Event, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT sequence, run_id, from_state, to_state, reason, created_at
+		FROM schedule_run_events WHERE run_id = ? ORDER BY sequence`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []Event
+	for rows.Next() {
+		var event Event
+		var createdAt string
+		if err := rows.Scan(&event.Sequence, &event.RunID, &event.FromState, &event.ToState, &event.Reason, &createdAt); err != nil {
+			return nil, err
+		}
+		event.CreatedAt, err = parseTime(createdAt)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func (s *Store) InterruptActiveRuns(ctx context.Context, reason string, at time.Time) (int, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id FROM schedule_runs
+		WHERE state IN ('starting','workflow_running','workflow_finished','pulse_gate','pulse_modules','pulse_finalizing')`)
+	if err != nil {
+		return 0, err
+	}
+	var runIDs []string
+	for rows.Next() {
+		var runID string
+		if err := rows.Scan(&runID); err != nil {
+			_ = rows.Close()
+			return 0, err
+		}
+		runIDs = append(runIDs, runID)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	for _, runID := range runIDs {
+		if err := s.Transition(ctx, Transition{RunID: runID, To: StateInterrupted, Reason: reason, ErrorMessage: reason, At: at}); err != nil {
+			return 0, err
+		}
+	}
+	return len(runIDs), nil
+}
+
+func formatTime(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTime(value string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, value)
+}

--- a/agent_go/pkg/schedulerstate/store.go
+++ b/agent_go/pkg/schedulerstate/store.go
@@ -46,10 +46,10 @@ var allowedTransitions = map[State]map[State]bool{
 		StatePulseGate: true, StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
 	},
 	StatePulseGate: {
-		StatePulseModules: true, StatePulseFinalizing: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+		StatePulseModules: true, StatePulseFinalizing: true, StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
 	},
 	StatePulseModules: {
-		StatePulseFinalizing: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
+		StatePulseFinalizing: true, StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
 	},
 	StatePulseFinalizing: {
 		StateCompleted: true, StatePartial: true, StateFailed: true, StateStopped: true, StateInterrupted: true,
@@ -116,6 +116,8 @@ type Event struct {
 type Store struct {
 	db *sql.DB
 }
+
+const fireDecisionRetentionPerSchedule = 500
 
 func Open(path string) (*Store, error) {
 	path = strings.TrimSpace(path)
@@ -326,15 +328,102 @@ func (s *Store) Transition(ctx context.Context, transition Transition) error {
 	return tx.Commit()
 }
 
+// ForceTerminal releases an active run lease after ordinary terminal
+// transition retries fail. It never changes one terminal state into another.
+func (s *Store) ForceTerminal(ctx context.Context, transition Transition) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("schedule state store is unavailable")
+	}
+	if !IsTerminal(transition.To) {
+		return fmt.Errorf("forced transition must be terminal: %s", transition.To)
+	}
+	if transition.At.IsZero() {
+		transition.At = time.Now().UTC()
+	}
+	transition.At = transition.At.UTC()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var current string
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM schedule_runs WHERE run_id = ?`, transition.RunID).Scan(&current); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: %s", ErrRunNotFound, transition.RunID)
+		}
+		return err
+	}
+	from := State(current)
+	if IsTerminal(from) {
+		if from == transition.To {
+			return tx.Commit()
+		}
+		return fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, from, transition.To)
+	}
+
+	completedAt := formatTime(transition.At)
+	if _, err := tx.ExecContext(ctx, `UPDATE schedule_runs SET
+		state = ?, updated_at = ?, completed_at = ?,
+		active_session_id = CASE WHEN ? <> '' THEN ? ELSE active_session_id END,
+		run_folder = CASE WHEN ? <> '' THEN ? ELSE run_folder END,
+		error_message = CASE WHEN ? <> '' THEN ? ELSE error_message END
+		WHERE run_id = ?`,
+		transition.To, completedAt, completedAt,
+		transition.SessionID, transition.SessionID, transition.RunFolder, transition.RunFolder,
+		transition.ErrorMessage, transition.ErrorMessage, transition.RunID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_run_events (run_id, from_state, to_state, reason, created_at)
+		VALUES (?, ?, ?, ?, ?)`, transition.RunID, from, transition.To, "recovered terminal transition: "+transition.Reason, completedAt); err != nil {
+		return err
+	}
+	if transition.SessionID != "" {
+		sessionKind := transition.SessionKind
+		if sessionKind == "" {
+			sessionKind = "main"
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_run_sessions (
+			run_id, session_id, session_kind, status, started_at, ended_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, session_id) DO UPDATE SET
+			session_kind = excluded.session_kind,
+			status = excluded.status,
+			ended_at = excluded.ended_at`, transition.RunID, transition.SessionID, sessionKind,
+			transition.To, completedAt, completedAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Store) RecordFireDecision(ctx context.Context, decision FireDecision) error {
 	if decision.FiredAt.IsZero() {
 		decision.FiredAt = time.Now().UTC()
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO schedule_fire_decisions (
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_fire_decisions (
 		decision_id, scope_type, scope_id, schedule_id, trigger_source, decision, reason, run_id, fired_at
 	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, decision.DecisionID, decision.ScopeType, decision.ScopeID,
-		decision.ScheduleID, decision.TriggerSource, decision.Decision, decision.Reason, decision.RunID, formatTime(decision.FiredAt))
-	return err
+		decision.ScheduleID, decision.TriggerSource, decision.Decision, decision.Reason, decision.RunID, formatTime(decision.FiredAt)); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM schedule_fire_decisions
+		WHERE scope_type = ? AND scope_id = ? AND schedule_id = ?
+		AND decision_id NOT IN (
+			SELECT decision_id FROM schedule_fire_decisions
+			WHERE scope_type = ? AND scope_id = ? AND schedule_id = ?
+			ORDER BY fired_at DESC, decision_id DESC LIMIT ?
+		)`, decision.ScopeType, decision.ScopeID, decision.ScheduleID,
+		decision.ScopeType, decision.ScopeID, decision.ScheduleID, fireDecisionRetentionPerSchedule); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) ListFireDecisions(ctx context.Context, scopeType, scopeID, scheduleID string, limit int) ([]FireDecision, error) {

--- a/agent_go/pkg/schedulerstate/store_test.go
+++ b/agent_go/pkg/schedulerstate/store_test.go
@@ -102,6 +102,41 @@ func TestRejectsInvalidAndTerminalRegression(t *testing.T) {
 	}
 }
 
+func TestPulseGateCanCompleteWithoutSelectedModules(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	run := Run{RunID: "run-no-modules", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-1"}
+	if err := store.BeginRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	for _, transition := range []Transition{
+		{RunID: run.RunID, To: StateWorkflowRunning},
+		{RunID: run.RunID, To: StateWorkflowFinished},
+		{RunID: run.RunID, To: StatePulseGate},
+		{RunID: run.RunID, To: StateCompleted},
+	} {
+		if err := store.Transition(ctx, transition); err != nil {
+			t.Fatalf("transition to %s: %v", transition.To, err)
+		}
+	}
+}
+
+func TestForceTerminalReleasesStuckLease(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	first := Run{RunID: "run-stuck", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-1"}
+	if err := store.BeginRun(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ForceTerminal(ctx, Transition{RunID: first.RunID, To: StateCompleted, Reason: "recover lease"}); err != nil {
+		t.Fatalf("force terminal: %v", err)
+	}
+	second := Run{RunID: "run-next", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: first.LockKey, ScheduleID: "schedule-2"}
+	if err := store.BeginRun(ctx, second); err != nil {
+		t.Fatalf("lease remained stuck: %v", err)
+	}
+}
+
 func TestInterruptActiveRunsReleasesLeases(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
@@ -175,5 +210,30 @@ func TestFireDecisionsAreDurableAndScoped(t *testing.T) {
 	}
 	if len(decisions) != 2 || decisions[0].Decision != "started" || decisions[1].Decision != "skipped_busy" {
 		t.Fatalf("unexpected decisions: %+v", decisions)
+	}
+}
+
+func TestFireDecisionRetentionIsBoundedPerSchedule(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i := 0; i < fireDecisionRetentionPerSchedule+5; i++ {
+		if err := store.RecordFireDecision(ctx, FireDecision{
+			DecisionID: fmt.Sprintf("decision-%03d", i), ScopeType: "workflow", ScopeID: "Workflow/demo",
+			ScheduleID: "frequent", TriggerSource: "cron", Decision: "skipped_paused",
+			FiredAt: now.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("record decision %d: %v", i, err)
+		}
+	}
+	decisions, err := store.ListFireDecisions(ctx, "workflow", "Workflow/demo", "frequent", fireDecisionRetentionPerSchedule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != fireDecisionRetentionPerSchedule {
+		t.Fatalf("retained decisions = %d, want %d", len(decisions), fireDecisionRetentionPerSchedule)
+	}
+	if got := decisions[len(decisions)-1].DecisionID; got != "decision-005" {
+		t.Fatalf("oldest retained decision = %q, want decision-005", got)
 	}
 }

--- a/agent_go/pkg/schedulerstate/store_test.go
+++ b/agent_go/pkg/schedulerstate/store_test.go
@@ -1,0 +1,179 @@
+package schedulerstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "schedule-state.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestRunLifecycleAndEvents(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	startedAt := time.Now().UTC()
+	run := Run{
+		RunID:         "run-1",
+		ScopeType:     "workflow",
+		ScopeID:       "Workflow/demo",
+		LockKey:       "workflow:Workflow/demo",
+		ScheduleID:    "schedule-1",
+		TriggerSource: "cron",
+		StartedAt:     startedAt,
+	}
+	if err := store.BeginRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	transitions := []Transition{
+		{RunID: run.RunID, To: StateWorkflowRunning, SessionID: "session-1", SessionKind: "workflow", Reason: "session started"},
+		{RunID: run.RunID, To: StateWorkflowFinished, SessionID: "session-1", RunFolder: "iteration-0", Reason: "workflow finished"},
+		{RunID: run.RunID, To: StatePulseGate, SessionID: "session-1", SessionKind: "pulse", Reason: "Pulse enabled"},
+		{RunID: run.RunID, To: StatePulseModules, SessionID: "session-1", SessionKind: "pulse", Reason: "Gate recorded worklist"},
+		{RunID: run.RunID, To: StatePulseFinalizing, SessionID: "recovery-session", SessionKind: "pulse_recovery", Reason: "finalizing"},
+		{RunID: run.RunID, To: StateCompleted, SessionID: "recovery-session", SessionKind: "pulse_recovery", Reason: "done"},
+	}
+	for _, transition := range transitions {
+		if err := store.Transition(ctx, transition); err != nil {
+			t.Fatalf("Transition(%s): %v", transition.To, err)
+		}
+	}
+
+	got, err := store.GetRun(ctx, run.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != StateCompleted || got.CompletedAt == nil || got.ActiveSessionID != "recovery-session" {
+		t.Fatalf("run = %+v", got)
+	}
+	events, err := store.ListEvents(ctx, run.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != len(transitions)+1 {
+		t.Fatalf("len(events) = %d, want %d", len(events), len(transitions)+1)
+	}
+}
+
+func TestActiveLeaseRejectsOverlappingWorkflowSchedules(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	first := Run{RunID: "run-1", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-1", TriggerSource: "cron"}
+	second := Run{RunID: "run-2", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-2", TriggerSource: "manual"}
+	if err := store.BeginRun(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BeginRun(ctx, second); !errors.Is(err, ErrRunAlreadyActive) {
+		t.Fatalf("BeginRun(overlap) error = %v, want ErrRunAlreadyActive", err)
+	}
+	if err := store.Transition(ctx, Transition{RunID: first.RunID, To: StateStopped, Reason: "user stopped"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BeginRun(ctx, second); err != nil {
+		t.Fatalf("BeginRun(after terminal): %v", err)
+	}
+}
+
+func TestRejectsInvalidAndTerminalRegression(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	run := Run{RunID: "run-1", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-1", TriggerSource: "cron"}
+	if err := store.BeginRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Transition(ctx, Transition{RunID: run.RunID, To: StatePulseModules}); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("invalid transition error = %v", err)
+	}
+	if err := store.Transition(ctx, Transition{RunID: run.RunID, To: StateFailed, Reason: "failed to start"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Transition(ctx, Transition{RunID: run.RunID, To: StateWorkflowRunning}); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("terminal regression error = %v", err)
+	}
+}
+
+func TestInterruptActiveRunsReleasesLeases(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	run := Run{RunID: "run-1", ScopeType: "workflow", ScopeID: "Workflow/demo", LockKey: "workflow:Workflow/demo", ScheduleID: "schedule-1", TriggerSource: "cron"}
+	if err := store.BeginRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	count, err := store.InterruptActiveRuns(ctx, "server restarted", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+	got, err := store.GetRun(ctx, run.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != StateInterrupted {
+		t.Fatalf("state = %s, want interrupted", got.State)
+	}
+}
+
+func TestActiveRunByLockKey(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	run := Run{RunID: "run-active", ScopeType: "workflow", ScopeID: "demo", LockKey: "workflow/demo", ScheduleID: "daily", StartedAt: now}
+	if err := store.BeginRun(ctx, run); err != nil {
+		t.Fatalf("begin run: %v", err)
+	}
+
+	active, err := store.ActiveRunByLockKey(ctx, run.LockKey)
+	if err != nil {
+		t.Fatalf("active run: %v", err)
+	}
+	if active.RunID != run.RunID || active.State != StateStarting {
+		t.Fatalf("unexpected active run: %+v", active)
+	}
+
+	if err := store.Transition(ctx, Transition{RunID: run.RunID, To: StateStopped, Reason: "test stop", At: now.Add(time.Second)}); err != nil {
+		t.Fatalf("stop run: %v", err)
+	}
+	if _, err := store.ActiveRunByLockKey(ctx, run.LockKey); !errors.Is(err, ErrRunNotFound) {
+		t.Fatalf("expected no active run after stop, got %v", err)
+	}
+}
+
+func TestFireDecisionsAreDurableAndScoped(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i, decision := range []string{"skipped_busy", "started"} {
+		if err := store.RecordFireDecision(ctx, FireDecision{
+			DecisionID: fmt.Sprintf("decision-%d", i), ScopeType: "workflow", ScopeID: "Workflow/demo",
+			ScheduleID: "daily", TriggerSource: "cron", Decision: decision, Reason: "test", FiredAt: now.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("record decision: %v", err)
+		}
+	}
+	if err := store.RecordFireDecision(ctx, FireDecision{
+		DecisionID: "other", ScopeType: "workflow", ScopeID: "Workflow/other", ScheduleID: "daily",
+		TriggerSource: "cron", Decision: "started", Reason: "other", FiredAt: now,
+	}); err != nil {
+		t.Fatalf("record other decision: %v", err)
+	}
+
+	decisions, err := store.ListFireDecisions(ctx, "workflow", "Workflow/demo", "daily", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 2 || decisions[0].Decision != "started" || decisions[1].Decision != "skipped_busy" {
+		t.Fatalf("unexpected decisions: %+v", decisions)
+	}
+}

--- a/frontend/src/components/scheduler/MultiAgentSchedulesPopup.tsx
+++ b/frontend/src/components/scheduler/MultiAgentSchedulesPopup.tsx
@@ -9,6 +9,9 @@ const MISSED_SCHEDULE_GRACE_MS = 60_000
 const ORG_PULSE_JOB_ID = 'builtin-org-pulse'
 type JobFilter = 'running' | 'enabled' | 'paused' | 'missed' | 'issues' | 'all'
 
+const isScheduleIssueStatus = (status?: ScheduledJob['last_status']) =>
+  status === 'error' || status === 'partial' || status === 'interrupted'
+
 function describeCron(expr: string): string {
   try {
     return cronstrue.toString(expr, { throwExceptionOnParseError: true })
@@ -67,7 +70,7 @@ function sortJobs(a: ScheduledJob, b: ScheduledJob): number {
     if (getMissedScheduleDelayMs(job) != null) return 1
     if (job.enabled && job.next_run_at) return 2
     if (job.enabled) return 3
-    if (job.last_status === 'error') return 4
+    if (job.last_status === 'error' || job.last_status === 'partial' || job.last_status === 'interrupted') return 4
     return 5
   }
 
@@ -152,7 +155,7 @@ const MultiAgentSchedulesPopup: React.FC<MultiAgentSchedulesPopupProps> = ({ onC
       if (job.enabled) enabled += 1
       else paused += 1
       if (getMissedScheduleDelayMs(job) != null) missed += 1
-      if (job.last_status === 'error') issues += 1
+      if (isScheduleIssueStatus(job.last_status)) issues += 1
       if (job.last_run_at && (!lastRunAt || job.last_run_at > lastRunAt)) {
         lastRunAt = job.last_run_at
       }
@@ -186,7 +189,7 @@ const MultiAgentSchedulesPopup: React.FC<MultiAgentSchedulesPopupProps> = ({ onC
         case 'missed':
           return getMissedScheduleDelayMs(job) != null
         case 'issues':
-          return job.last_status === 'error'
+          return isScheduleIssueStatus(job.last_status)
         case 'all':
         default:
           return true
@@ -273,6 +276,16 @@ const MultiAgentSchedulesPopup: React.FC<MultiAgentSchedulesPopupProps> = ({ onC
     if (job.last_status === 'error') {
       return <span className="inline-flex items-center gap-1 rounded-full border border-red-500/30 bg-red-500/10 px-1.5 py-0.5 text-[11px] font-medium text-red-600 dark:text-red-300">
         <AlertCircle className="h-3 w-3" /> Issue
+      </span>
+    }
+    if (job.last_status === 'partial' || job.last_status === 'interrupted') {
+      return <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+        <AlertCircle className="h-3 w-3" /> {job.last_status === 'partial' ? 'Partial' : 'Interrupted'}
+      </span>
+    }
+    if (job.last_status === 'stopped') {
+      return <span className="inline-flex items-center gap-1 rounded-full border border-gray-500/30 bg-gray-500/10 px-1.5 py-0.5 text-[11px] font-medium text-gray-600 dark:text-gray-300">
+        <Square className="h-3 w-3" /> Stopped
       </span>
     }
     if (job.last_status === 'success') {
@@ -432,6 +445,7 @@ const MultiAgentSchedulesPopup: React.FC<MultiAgentSchedulesPopupProps> = ({ onC
                                 isRunning ? 'bg-amber-500 animate-pulse' :
                                 missedDelayMs != null ? 'bg-amber-500' :
                                 job.last_status === 'error' ? 'bg-red-500' :
+                                job.last_status === 'partial' || job.last_status === 'interrupted' ? 'bg-amber-500' :
                                 job.enabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
                               }`} />
                               <div className="min-w-0 flex-1">
@@ -484,8 +498,8 @@ const MultiAgentSchedulesPopup: React.FC<MultiAgentSchedulesPopupProps> = ({ onC
                                   </p>
                                 )}
 
-                                {job.last_error && job.last_status === 'error' && (
-                                  <p className="mt-1 truncate text-xs text-red-500" title={job.last_error}>
+                                {job.last_error && (isScheduleIssueStatus(job.last_status) || job.last_status === 'stopped') && (
+                                  <p className={`mt-1 truncate text-xs ${job.last_status === 'error' ? 'text-red-500' : job.last_status === 'stopped' ? 'text-muted-foreground' : 'text-amber-600 dark:text-amber-400'}`} title={job.last_error}>
                                     {job.last_error}
                                   </p>
                                 )}

--- a/frontend/src/components/scheduler/WorkflowScheduleRunsPanel.tsx
+++ b/frontend/src/components/scheduler/WorkflowScheduleRunsPanel.tsx
@@ -1522,7 +1522,10 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                 </div>
 
                 {isScheduleIssueStatus(job.last_status) && job.last_error && (
-                  <div className="mt-1 truncate text-xs text-red-500" title={job.last_error}>
+                  <div
+                    className={`mt-1 truncate text-xs ${isSchedulePartialStatus(job.last_status) ? 'text-amber-600 dark:text-amber-400' : 'text-red-500'}`}
+                    title={job.last_error}
+                  >
                     {job.last_error}
                   </div>
                 )}

--- a/frontend/src/components/scheduler/WorkflowScheduleRunsPanel.tsx
+++ b/frontend/src/components/scheduler/WorkflowScheduleRunsPanel.tsx
@@ -35,6 +35,12 @@ type ActivePopup = 'costs' | 'logs' | 'eval' | 'report' | 'live' | null
 type JobFilter = 'running' | 'enabled' | 'paused' | 'missed' | 'issues' | 'all'
 type SchedulePanelView = 'overview' | 'calendar' | 'by-workflow' | 'schedules'
 
+const isScheduleIssueStatus = (status?: ScheduledJob['last_status']) =>
+  status === 'error' || status === 'partial' || status === 'interrupted'
+
+const isSchedulePartialStatus = (status?: ScheduledJob['last_status']) =>
+  status === 'partial' || status === 'interrupted'
+
 const WORKFLOW_SCHEDULE_PANEL_LIMIT = 10_000
 
 type WorkflowScheduleGroup = {
@@ -575,7 +581,7 @@ function sortJobs(a: ScheduledJob, b: ScheduledJob): number {
     if (isMissedSchedule(job)) return 1
     if (job.enabled && job.next_run_at) return 2
     if (job.enabled) return 3
-    if (job.last_status === 'error') return 4
+    if (isScheduleIssueStatus(job.last_status)) return 4
     return 5
   }
 
@@ -861,7 +867,7 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
   const summary = useMemo(() => {
     const running = panelJobs.filter(j => j.last_status === 'running').length
     const missed = panelJobs.filter(isMissedSchedule).length
-    const issues = panelJobs.filter(j => j.last_status === 'error').length
+    const issues = panelJobs.filter(j => isScheduleIssueStatus(j.last_status)).length
     const paused = panelJobs.filter(j => !j.enabled).length
     const lastRunAt = panelJobs.reduce<string | undefined>((latest, job) => {
       if (!job.last_run_at) return latest
@@ -997,7 +1003,7 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
       group.runCount += job.run_count || 0
       if (job.last_status === 'running') group.running += 1
       if (isMissedSchedule(job)) group.missed += 1
-      if (job.last_status === 'error') group.issues += 1
+      if (isScheduleIssueStatus(job.last_status)) group.issues += 1
       if (job.enabled) group.enabled += 1
       else group.paused += 1
 
@@ -1438,6 +1444,7 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                 isRunningJob ? 'bg-amber-500 animate-pulse' :
                 isMissedJob ? 'bg-amber-500' :
                 job.last_status === 'error' ? 'bg-red-500' :
+                isSchedulePartialStatus(job.last_status) ? 'bg-amber-500' :
                 job.enabled ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
               }`} />
               <div className="min-w-0 flex-1">
@@ -1463,6 +1470,11 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                   {job.last_status === 'error' && (
                     <span className="rounded-full border border-red-500/30 bg-red-500/10 px-1.5 py-0.5 text-[11px] font-medium text-red-600 dark:text-red-300">
                       Issue
+                    </span>
+                  )}
+                  {isSchedulePartialStatus(job.last_status) && (
+                    <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+                      {job.last_status === 'partial' ? 'Partial' : 'Interrupted'}
                     </span>
                   )}
                 </div>
@@ -1509,7 +1521,7 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                   )}
                 </div>
 
-                {job.last_status === 'error' && job.last_error && (
+                {isScheduleIssueStatus(job.last_status) && job.last_error && (
                   <div className="mt-1 truncate text-xs text-red-500" title={job.last_error}>
                     {job.last_error}
                   </div>
@@ -2463,6 +2475,10 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                               <CheckCircle className="w-3 h-3 text-green-500" />
                             ) : job.last_status === 'error' ? (
                               <XCircle className="w-3 h-3 text-red-500" />
+                            ) : isSchedulePartialStatus(job.last_status) ? (
+                              <AlertTriangle className="w-3 h-3 text-amber-500" />
+                            ) : job.last_status === 'stopped' ? (
+                              <Square className="w-3 h-3 text-gray-500" />
                             ) : (
                               <Minus className="w-3 h-3" />
                             )}
@@ -2493,8 +2509,8 @@ const WorkflowScheduleRunsPanel: React.FC<WorkflowScheduleRunsPanelProps> = ({ o
                         </div>
 
                         {/* Error message */}
-                        {job.last_status === 'error' && job.last_error && (
-                          <div className="mt-1 text-xs text-red-500 truncate max-w-lg" title={job.last_error}>
+                        {(isScheduleIssueStatus(job.last_status) || job.last_status === 'stopped') && job.last_error && (
+                          <div className={`mt-1 text-xs truncate max-w-lg ${job.last_status === 'error' ? 'text-red-500' : isSchedulePartialStatus(job.last_status) ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500'}`} title={job.last_error}>
                             ✗ {job.last_error}
                           </div>
                         )}

--- a/frontend/src/services/api-types.ts
+++ b/frontend/src/services/api-types.ts
@@ -2270,7 +2270,7 @@ export interface ScheduledJob {
   last_run_at?: string
   next_run_at?: string
   last_session_id?: string
-  last_status?: 'success' | 'error' | 'running' | 'stopped'
+  last_status?: 'success' | 'error' | 'running' | 'partial' | 'stopped' | 'interrupted'
   last_error?: string
   last_duration_ms?: number
   run_count: number


### PR DESCRIPTION
## Summary
- scope scheduler identity by workflow/user instead of bare schedule ID
- add a SQLite-backed schedule/Pulse lifecycle ledger with enforced transitions, active leases, session links, retained events, restart interruption, and durable fire decisions
- serialize JSON run-history mutations and reject corrupt/missing updates instead of silently overwriting history
- keep runtime state running through Pulse; expose partial/stopped/interrupted states consistently to the schedule UI
- cancel by durable run ID so Stop works before terminal registration, during workflow execution, and during Pulse
- reload changed Chief of Staff schedules using configuration fingerprints
- preserve calendar-item identity and latest item overrides through trigger-time reload
- replace the unbounded single-query Chief of Staff wait with the tmux/background-aware inactivity wait

## Why
This is the foundation for #140. It removes the confirmed collision, race, false-success, unsafe-persistence, skipped-fire, immediate-stop, config-reload, calendar-override, and unbounded-wait failures.

## Verification
- `go test -race ./pkg/schedulerstate`
- focused race suite for scheduler identity, runtime merge/update, stop-before-session, calendar reload, and concurrent JSON persistence
- `go vet ./cmd/server ./pkg/schedulerstate`
- `npx tsc -b`
- targeted ESLint for changed scheduler UI files
- repository pre-commit hook: gitleaks, golangci-lint, frontend build, Go build, workspace build, Electron build

## Known unrelated failures
A full `go test ./...` reaches three existing stale provider-default assertions that also fail on `main`:
- `TestProviderProfileOverridesStaleExplicitChatLLM`
- `TestResolveDelegationTierConfigExpandsProviderProfile`
- `TestWorkshopResolveLLMConfigExpandsCodingAgentMode`

## Follow-up scope from #140
This PR intentionally leaves the deeper agent-tool authorization/cadence slice for a follow-up: binding Pulse tool calls to the active scheduled session, server-enforcing due-module/final-command transitions, and deterministic cooldown consumption.

Closes the foundation findings in #140; does not close the whole issue yet.
