### PR TITLE
Unify terminal process lease lifecycle

### DIFF
--- a/agent_go/cmd/server/bot_session_starter.go
+++ b/agent_go/cmd/server/bot_session_starter.go
@@ -323,7 +323,7 @@ func (api *StreamingAPI) terminalFingerprint(sessionID string) string {
 		return ""
 	}
 	var b strings.Builder
-	for _, snapshot := range api.terminalStore.List(sessionID) {
+	for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
 		if strings.TrimSpace(snapshot.TmuxSession) == "" {
 			continue
 		}

--- a/agent_go/cmd/server/coding_agent_tmux_reaper.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"mcp-agent-builder-go/agent_go/internal/terminalleases"
 	"mcp-agent-builder-go/agent_go/internal/terminals"
 )
 
@@ -19,6 +20,7 @@ const (
 
 type codingAgentTmuxCleanupCandidate struct {
 	snapshot terminals.Snapshot
+	lease    terminalleases.Lease
 	reason   string
 }
 
@@ -50,7 +52,10 @@ func (api *StreamingAPI) cleanupStaleCodingAgentTmuxSessions(now time.Time) int 
 	closed := 0
 	for _, candidate := range candidates {
 		snapshot := candidate.snapshot
-		tmuxSession := strings.TrimSpace(snapshot.TmuxSession)
+		tmuxSession := strings.TrimSpace(candidate.lease.TmuxSession)
+		if tmuxSession == "" {
+			tmuxSession = strings.TrimSpace(snapshot.TmuxSession)
+		}
 		if tmuxSession == "" {
 			continue
 		}
@@ -58,12 +63,16 @@ func (api *StreamingAPI) cleanupStaleCodingAgentTmuxSessions(now time.Time) int 
 		if candidate.reason != "" {
 			reason += ": " + candidate.reason
 		}
-		closeCodingAgentTmuxSessionByName(tmuxSession, reason)
-		if _, ok := api.terminalStore.MarkStale(snapshot.TerminalID); ok {
-			closed++
-			log.Printf("[TMUX_REAPER] Closed stale coding-agent tmux session %q terminal=%q owner=%q session=%q reason=%s",
-				tmuxSession, snapshot.TerminalID, snapshot.OwnerID, snapshot.SessionID, candidate.reason)
+		if !closeCodingAgentTmuxSessionByName(tmuxSession, reason) {
+			continue
 		}
+		if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+			registry.MarkClosed(tmuxSession, candidate.reason, now)
+		}
+		api.terminalStore.MarkArchived(snapshot.TerminalID, candidate.reason)
+		closed++
+		log.Printf("[TMUX_REAPER] Closed stale coding-agent tmux session %q terminal=%q owner=%q session=%q reason=%s",
+			tmuxSession, snapshot.TerminalID, snapshot.OwnerID, snapshot.SessionID, candidate.reason)
 	}
 	return closed
 }
@@ -80,35 +89,61 @@ func (api *StreamingAPI) staleCodingAgentTmuxCleanupCandidates(now time.Time, id
 	}
 
 	sessionStates := api.codingAgentTmuxActiveSessionStates()
-	snapshots := api.terminalStore.List("")
+	registry := api.ensureTerminalLeaseRegistry()
+	if registry == nil {
+		return nil
+	}
+	leases := registry.List()
 	candidates := make([]codingAgentTmuxCleanupCandidate, 0)
-	for _, snapshot := range snapshots {
-		tmuxSession := strings.TrimSpace(snapshot.TmuxSession)
+	for _, lease := range leases {
+		if lease.ProcessState == terminalleases.ProcessClosed {
+			continue
+		}
+		tmuxSession := strings.TrimSpace(lease.TmuxSession)
 		if tmuxSession == "" || !isCodingAgentTmuxSessionName(tmuxSession) {
 			continue
 		}
+		snapshot, ok := api.terminalStore.GetRaw(lease.TerminalID)
+		if !ok {
+			snapshot = terminals.Snapshot{
+				TerminalID:    lease.TerminalID,
+				TmuxSession:   lease.TmuxSession,
+				SessionID:     lease.SessionID,
+				OwnerID:       lease.OwnerID,
+				ExecutionID:   lease.ExecutionID,
+				ExecutionKind: lease.ExecutionKind,
+				WorkflowPath:  lease.WorkflowPath,
+				UpdatedAt:     lease.LastActivity,
+			}
+		}
 
-		state, sessionExists := sessionStates[snapshot.SessionID]
+		state, sessionExists := sessionStates[lease.SessionID]
 		switch {
 		case !sessionExists:
 			candidates = append(candidates, codingAgentTmuxCleanupCandidate{
 				snapshot: snapshot,
+				lease:    lease,
 				reason:   "owner session missing",
 			})
 		case codingAgentTmuxSessionStatusClosesImmediately(state.status):
 			candidates = append(candidates, codingAgentTmuxCleanupCandidate{
 				snapshot: snapshot,
+				lease:    lease,
 				reason:   "owner session " + state.status,
 			})
-		case snapshot.ClosesAt != nil && !now.Before(*snapshot.ClosesAt):
+		case lease.Policy == terminalleases.PolicyBounded &&
+			lease.ProcessDeadline != nil && !now.Before(*lease.ProcessDeadline):
 			candidates = append(candidates, codingAgentTmuxCleanupCandidate{
 				snapshot: snapshot,
-				reason:   "retention elapsed",
+				lease:    lease,
+				reason:   "bounded process grace elapsed",
 			})
 		case codingAgentTmuxSessionStatusUsesIdleBackstop(state.status) &&
+			lease.Policy == terminalleases.PolicyPersistent &&
 			codingAgentTmuxSnapshotIdleFor(snapshot, now, idleTimeout):
 			candidates = append(candidates, codingAgentTmuxCleanupCandidate{
 				snapshot: snapshot,
+				lease:    lease,
 				reason:   "idle backstop elapsed",
 			})
 		}
@@ -173,17 +208,19 @@ func isCodingAgentTmuxSessionName(tmuxSession string) bool {
 		strings.HasPrefix(name, "mlp-pi-cli")
 }
 
-func closeCodingAgentTmuxSessionByName(tmuxSession, reason string) {
+func closeCodingAgentTmuxSessionByName(tmuxSession, reason string) bool {
 	tmuxSession = strings.TrimSpace(tmuxSession)
 	if tmuxSession == "" {
-		return
+		return false
 	}
 	_ = gracefulCloseCodingCLITmuxByName(tmuxSession, reason)
 	ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
 	defer cancel()
 	if err := runTerminalTmuxCommand(ctx, "", "kill-session", "-t", tmuxSession); err != nil && !isMissingTmuxTargetError(err) {
 		log.Printf("[TMUX_REAPER] kill-session %q failed: %v", tmuxSession, err)
+		return false
 	}
+	return true
 }
 
 // cleanupConflictingPiCLIInteractiveSessions closes older manual Pi CLI main

--- a/agent_go/cmd/server/coding_agent_tmux_reaper.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper.go
@@ -239,9 +239,12 @@ func (api *StreamingAPI) cleanupConflictingPiCLIInteractiveSessions(currentSessi
 	}
 
 	sessionStates := api.codingAgentTmuxActiveSessionStates()
-	closedTmuxSessions := map[string]struct{}{}
+	registry := api.ensureTerminalLeaseRegistry()
+	if registry == nil {
+		return 0
+	}
 	closed := 0
-	for _, snapshot := range api.terminalStore.List("") {
+	for _, snapshot := range api.terminalStore.ListRaw("") {
 		if snapshot.SessionID == currentSessionID {
 			continue
 		}
@@ -253,6 +256,18 @@ func (api *StreamingAPI) cleanupConflictingPiCLIInteractiveSessions(currentSessi
 			continue
 		}
 		if !sameCodingAgentWorkingDir(codingAgentSnapshotWorkingDir(snapshot), targetWorkingDir) {
+			continue
+		}
+		lease, leased := registry.GetByTerminal(snapshot.TerminalID)
+		if !leased || lease.ProcessState == terminalleases.ProcessClosed {
+			continue
+		}
+		ownershipCtx, ownershipCancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+		owned := tmuxSessionOwnedByRegistry(ownershipCtx, tmuxSession, registry)
+		ownershipCancel()
+		if !owned {
+			log.Printf("[PI_CLI_CONFLICT] Preserving unowned Pi CLI tmux=%s old_session=%s while starting %s",
+				tmuxSession, snapshot.SessionID, currentSessionID)
 			continue
 		}
 
@@ -267,16 +282,20 @@ func (api *StreamingAPI) cleanupConflictingPiCLIInteractiveSessions(currentSessi
 		if reason != "" {
 			closeReason += ": " + reason
 		}
-		closeCodingAgentTmuxSessionByName(tmuxSession, closeReason)
+		if !closeCodingAgentTmuxSessionByName(tmuxSession, closeReason) {
+			continue
+		}
+		registry.MarkClosed(tmuxSession, closeReason, time.Now())
 		api.detachConflictingPiCLISession(snapshot.SessionID, state.status)
-		closedTmuxSessions[tmuxSession] = struct{}{}
-		if _, ok := api.terminalStore.MarkStale(snapshot.TerminalID); ok {
+		if snapshot.Active {
+			api.terminalStore.MarkFailed(snapshot.TerminalID)
+		}
+		if _, ok := api.terminalStore.MarkProcessClosed(snapshot.TerminalID, closeReason); ok {
 			closed++
 			log.Printf("[PI_CLI_CONFLICT] Closed conflicting Pi CLI tmux session %q terminal=%q old_session=%q new_session=%q status=%q working_dir=%s",
 				tmuxSession, snapshot.TerminalID, snapshot.SessionID, currentSessionID, state.status, targetWorkingDir)
 		}
 	}
-	closed += cleanupLivePiCLITmuxSessionsByWorkingDir(targetWorkingDir, closedTmuxSessions, reason)
 	return closed
 }
 
@@ -355,56 +374,4 @@ func cleanCodingAgentWorkingDir(path string) string {
 		return ""
 	}
 	return filepath.Clean(path)
-}
-
-func cleanupLivePiCLITmuxSessionsByWorkingDir(workingDir string, alreadyClosed map[string]struct{}, reason string) int {
-	targetWorkingDir := cleanCodingAgentWorkingDir(workingDir)
-	if targetWorkingDir == "" {
-		return 0
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
-	defer cancel()
-	output, err := runTerminalTmuxOutputCommand(ctx, "list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}")
-	if err != nil {
-		if !isMissingTmuxTargetError(err) {
-			log.Printf("[PI_CLI_CONFLICT] Failed to list tmux panes for Pi CLI conflict cleanup: %v", err)
-		}
-		return 0
-	}
-
-	closed := 0
-	seen := map[string]struct{}{}
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		tmuxSession := strings.TrimSpace(parts[0])
-		paneWorkingDir := strings.TrimSpace(parts[1])
-		if !strings.HasPrefix(tmuxSession, "mlp-pi-cli") {
-			continue
-		}
-		if !sameCodingAgentWorkingDir(paneWorkingDir, targetWorkingDir) {
-			continue
-		}
-		if _, ok := alreadyClosed[tmuxSession]; ok {
-			continue
-		}
-		if _, ok := seen[tmuxSession]; ok {
-			continue
-		}
-		seen[tmuxSession] = struct{}{}
-		closeReason := "pi-cli live same-working-dir conflict"
-		if reason != "" {
-			closeReason += ": " + reason
-		}
-		closeCodingAgentTmuxSessionByName(tmuxSession, closeReason)
-		closed++
-		log.Printf("[PI_CLI_CONFLICT] Closed live Pi CLI tmux session %q in working_dir=%s", tmuxSession, targetWorkingDir)
-	}
-	return closed
 }

--- a/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -220,6 +221,7 @@ func TestCleanupConflictingPiCLIInteractiveSessionsClosesManualSameWorkingDir(t 
 	}
 
 	gotArgs := stubTerminalTmuxCommand(t)
+	stubOwnedTmuxSession(t, api, tmuxSession)
 
 	closed := api.cleanupConflictingPiCLIInteractiveSessions(newSessionID, workingDir, "test")
 
@@ -233,8 +235,8 @@ func TestCleanupConflictingPiCLIInteractiveSessionsClosesManualSameWorkingDir(t 
 	if !ok {
 		t.Fatal("expected terminal snapshot to remain visible")
 	}
-	if snapshot.Active || snapshot.State != "stale" || snapshot.TmuxSession != "" {
-		t.Fatalf("snapshot active/state/tmux = %v/%q/%q, want false/stale/empty", snapshot.Active, snapshot.State, snapshot.TmuxSession)
+	if snapshot.Active || snapshot.State != "completed" || snapshot.TmuxSession != "" {
+		t.Fatalf("snapshot active/state/tmux = %v/%q/%q, want false/completed/empty", snapshot.Active, snapshot.State, snapshot.TmuxSession)
 	}
 	if got := api.activeSessions[oldSessionID].Status; got != "completed" {
 		t.Fatalf("old session status = %q, want completed", got)
@@ -264,6 +266,7 @@ func TestCleanupConflictingPiCLIInteractiveSessionsStopsRunningManualSameWorking
 	}
 
 	gotArgs := stubTerminalTmuxCommand(t)
+	stubOwnedTmuxSession(t, api, tmuxSession)
 
 	closed := api.cleanupConflictingPiCLIInteractiveSessions(newSessionID, workingDir, "test")
 
@@ -281,6 +284,37 @@ func TestCleanupConflictingPiCLIInteractiveSessionsStopsRunningManualSameWorking
 	}
 	if api.isSessionBusy(oldSessionID) {
 		t.Fatal("expected old session busy flag to be cleared")
+	}
+}
+
+func TestCleanupConflictingPiCLIInteractiveSessionsPreservesForeignOwner(t *testing.T) {
+	now := time.Now()
+	store := terminals.NewStore()
+	oldSessionID := "foreign-chat-session"
+	newSessionID := "new-chat-session"
+	tmuxSession := "mlp-pi-cli-int-foreign"
+	workingDir := "/tmp/workspace-docs/_users/default/Chats"
+	store.HandleEvent(oldSessionID, codingAgentTmuxReaperChunkEvent(now, oldSessionID, "main:"+oldSessionID, tmuxSession))
+	store.HandleEvent(oldSessionID, codingAgentTmuxStatusLineEvent(now, oldSessionID, tmuxSession, workingDir))
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			oldSessionID: {SessionID: oldSessionID, Status: "completed"},
+			newSessionID: {SessionID: newSessionID, Status: "running"},
+		},
+	}
+	gotArgs := stubTerminalTmuxCommand(t)
+	oldOutput := runTerminalTmuxOutputCommand
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		return tmuxSession + "\tforeign-instance\t999999\t1\t1", nil
+	}
+	t.Cleanup(func() { runTerminalTmuxOutputCommand = oldOutput })
+
+	if closed := api.cleanupConflictingPiCLIInteractiveSessions(newSessionID, workingDir, "test"); closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
+	}
+	if len(*gotArgs) != 0 {
+		t.Fatalf("foreign-owned tmux must not be killed: %v", *gotArgs)
 	}
 }
 
@@ -317,7 +351,7 @@ func TestCleanupConflictingPiCLIInteractiveSessionsKeepsCronSameWorkingDir(t *te
 	}
 }
 
-func TestCleanupConflictingPiCLIInteractiveSessionsClosesLiveTmuxFallback(t *testing.T) {
+func TestCleanupConflictingPiCLIInteractiveSessionsPreservesUntrackedTmux(t *testing.T) {
 	workingDir := "/tmp/workspace-docs/_users/default/Chats"
 	tmuxSession := "mlp-pi-cli-int-live-orphan"
 	api := &StreamingAPI{terminalStore: terminals.NewStore()}
@@ -343,12 +377,33 @@ func TestCleanupConflictingPiCLIInteractiveSessionsClosesLiveTmuxFallback(t *tes
 
 	closed := api.cleanupConflictingPiCLIInteractiveSessions("new-chat-session", workingDir, "test")
 
-	if closed != 1 {
-		t.Fatalf("closed = %d, want 1", closed)
+	if closed != 0 {
+		t.Fatalf("closed = %d, want 0", closed)
 	}
-	if got := strings.Join(gotKill, " "); got != "kill-session -t "+tmuxSession {
-		t.Fatalf("tmux args = %q, want kill-session", got)
+	if len(gotKill) != 0 {
+		t.Fatalf("untracked tmux must not be killed: %v", gotKill)
 	}
+}
+
+func stubOwnedTmuxSession(t *testing.T, api *StreamingAPI, tmuxSession string) {
+	t.Helper()
+	registry := api.ensureTerminalLeaseRegistry()
+	if registry == nil {
+		t.Fatal("expected terminal lease registry")
+	}
+	original := runTerminalTmuxOutputCommand
+	runTerminalTmuxOutputCommand = func(_ context.Context, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "display-message" {
+			return fmt.Sprintf("%s\t%s\t%d\t%d\t1",
+				tmuxSession,
+				registry.InstanceID(),
+				registry.OwnerPID(),
+				registry.OwnerStartedAt().Unix(),
+			), nil
+		}
+		return original(context.Background(), args...)
+	}
+	t.Cleanup(func() { runTerminalTmuxOutputCommand = original })
 }
 
 // TestSessionHasLiveCodingTmuxTracksReap covers the gate that decides whether an

--- a/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
@@ -142,6 +142,64 @@ func TestCleanupStaleCodingAgentTmuxSessionsClosesStoppedSessionImmediately(t *t
 	}
 }
 
+func TestCleanupBoundedTmuxKeepsDismissedSnapshotUntilDisplayDeadline(t *testing.T) {
+	now := time.Now()
+	store := terminals.NewStore()
+	sessionID := "bounded-session"
+	tmuxSession := "mlp-cursor-cli-int-bounded"
+	terminalID := sessionID + ":workflow-step:review-plan"
+	store.HandleEvent(sessionID, codingAgentTmuxReaperChunkEvent(now, sessionID, "workflow-step:review-plan", tmuxSession))
+	store.HandleEvent(sessionID, storeevents.Event{
+		Type:          "streaming_end",
+		Timestamp:     now,
+		SessionID:     sessionID,
+		ExecutionID:   "workflow-step:review-plan",
+		ExecutionKind: "workflow_step",
+		Data: &agentevents.AgentEvent{
+			Type: agentevents.StreamingEnd,
+			Data: &agentevents.StreamingEndEvent{
+				BaseEventData: agentevents.BaseEventData{Metadata: map[string]interface{}{
+					"kind":                       "terminal",
+					"tmux_session":               tmuxSession,
+					"terminal_retention_seconds": 1800,
+				}},
+			},
+		},
+	})
+	if !store.Dismiss(terminalID) {
+		t.Fatal("expected snapshot dismissal")
+	}
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+	}
+	gotArgs := stubTerminalTmuxCommand(t)
+
+	closed := api.cleanupStaleCodingAgentTmuxSessions(now.Add(31 * time.Second))
+
+	if closed != 1 {
+		t.Fatalf("closed = %d, want 1", closed)
+	}
+	if got := strings.Join(*gotArgs, " "); got != "kill-session -t "+tmuxSession {
+		t.Fatalf("tmux args = %q, want kill-session", got)
+	}
+	raw, ok := store.GetRaw(terminalID)
+	if !ok {
+		t.Fatal("process cleanup deleted retained snapshot")
+	}
+	if raw.TmuxSession != "" || raw.ProcessState != "closed" || raw.SnapshotKind != "archived" {
+		t.Fatalf("raw tmux/process/kind = %q/%q/%q", raw.TmuxSession, raw.ProcessState, raw.SnapshotKind)
+	}
+	if raw.ClosesAt == nil || !raw.ClosesAt.After(now.Add(20*time.Minute)) {
+		t.Fatalf("snapshot display deadline was not retained: %v", raw.ClosesAt)
+	}
+	if _, visible := store.Get(terminalID); visible {
+		t.Fatal("dismissed snapshot became visible during cleanup")
+	}
+}
+
 func TestCleanupConflictingPiCLIInteractiveSessionsClosesManualSameWorkingDir(t *testing.T) {
 	now := time.Now()
 	store := terminals.NewStore()

--- a/agent_go/cmd/server/coding_tmux_watchdog.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog.go
@@ -46,7 +46,9 @@ func (api *StreamingAPI) startCodingTmuxRateLimitWatchdog() {
 func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int) {
 	// Metadata listing deliberately avoids Store's content reconciliation. Actual
 	// tmux pane state below is authoritative for whether a terminal is still live.
-	snapshots := api.terminalStore.ListMetadata("")
+	// Process supervision must include terminals dismissed from presentation.
+	// ListRaw avoids content reconciliation while retaining those ownership rows.
+	snapshots := api.terminalStore.ListRaw("")
 	stillLimited := make(map[string]bool)
 
 	for _, snap := range snapshots {
@@ -57,7 +59,7 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 		}
 		// Confirmation belongs to one real pane, not the app session. A workflow
 		// session can host several terminals; keying by tmux keeps two limited
-		// panes satisfy a two-tick streak during the same poll.
+		// panes from satisfying a two-tick streak during the same poll.
 		watchdogKey := tmux
 		switch inspectCodingTmuxPaneState(tmux) {
 		case codingTmuxPaneMissing:
@@ -68,6 +70,13 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 			delete(streak, watchdogKey)
 			continue
 		case codingTmuxPaneDead:
+			killCtx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+			killErr := runTmuxKill(killCtx, tmux)
+			cancel()
+			if killErr != nil && !isMissingTmuxTargetError(killErr) {
+				log.Printf("[CODING_WATCHDOG] dead pane cleanup failed session=%s tmux=%s: %v", sessionID, tmux, killErr)
+				continue
+			}
 			if snap.Active || !strings.EqualFold(strings.TrimSpace(snap.State), "completed") {
 				api.terminalStore.MarkCompleted(snap.TerminalID)
 			}
@@ -162,6 +171,6 @@ func captureTmuxPanePlain(tmuxSession string) string {
 	return out.String()
 }
 
-func runTmuxKill(ctx context.Context, tmuxSession string) error {
-	return exec.CommandContext(ctx, "tmux", "kill-session", "-t", tmuxSession).Run()
+var runTmuxKill = func(ctx context.Context, tmuxSession string) error {
+	return runTerminalTmuxCommand(ctx, "", "kill-session", "-t", tmuxSession)
 }

--- a/agent_go/cmd/server/coding_tmux_watchdog.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog.go
@@ -55,16 +55,27 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 		if tmux == "" || sessionID == "" {
 			continue
 		}
+		// Confirmation belongs to one real pane, not the app session. A workflow
+		// session can host several terminals; keying by tmux keeps two limited
+		// panes satisfy a two-tick streak during the same poll.
+		watchdogKey := tmux
 		switch inspectCodingTmuxPaneState(tmux) {
 		case codingTmuxPaneMissing:
 			api.terminalStore.MarkStale(snap.TerminalID)
-			delete(streak, sessionID)
+			if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+				registry.MarkClosed(tmux, "tmux pane missing", time.Now())
+			}
+			delete(streak, watchdogKey)
 			continue
 		case codingTmuxPaneDead:
 			if snap.Active || !strings.EqualFold(strings.TrimSpace(snap.State), "completed") {
 				api.terminalStore.MarkCompleted(snap.TerminalID)
 			}
-			delete(streak, sessionID)
+			api.terminalStore.MarkProcessClosed(snap.TerminalID, "tmux pane exited")
+			if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+				registry.MarkClosed(tmux, "tmux pane exited", time.Now())
+			}
+			delete(streak, watchdogKey)
 			continue
 		case codingTmuxPaneUnknown:
 			// A transient tmux command failure is not evidence of completion.
@@ -74,11 +85,11 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 		if !terminals.DetectRateLimit(captured) {
 			continue
 		}
-		stillLimited[sessionID] = true
-		streak[sessionID]++
-		if streak[sessionID] < codingWatchdogConfirmChecks {
+		stillLimited[watchdogKey] = true
+		streak[watchdogKey]++
+		if streak[watchdogKey] < codingWatchdogConfirmChecks {
 			log.Printf("[CODING_WATCHDOG] session %s tmux %s looks rate-limited (%d/%d) - waiting to confirm",
-				sessionID, tmux, streak[sessionID], codingWatchdogConfirmChecks)
+				sessionID, tmux, streak[watchdogKey], codingWatchdogConfirmChecks)
 			continue
 		}
 
@@ -91,12 +102,16 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 		_ = runTmuxKill(killCtx, tmux)
 		cancel()
 		api.terminalStore.MarkFailed(snap.TerminalID)
-		delete(streak, sessionID)
+		api.terminalStore.MarkProcessClosed(snap.TerminalID, "provider usage/rate limit reached")
+		if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+			registry.MarkClosed(tmux, "provider usage/rate limit reached", time.Now())
+		}
+		delete(streak, watchdogKey)
 	}
 
-	for sessionID := range streak {
-		if !stillLimited[sessionID] {
-			delete(streak, sessionID)
+	for watchdogKey := range streak {
+		if !stillLimited[watchdogKey] {
+			delete(streak, watchdogKey)
 		}
 	}
 }

--- a/agent_go/cmd/server/coding_tmux_watchdog_test.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog_test.go
@@ -92,3 +92,39 @@ func TestCodingTmuxWatchdogReconcilesFromActualPaneState(t *testing.T) {
 		})
 	}
 }
+
+func TestCodingTmuxWatchdogRequiresDistinctTicksPerTerminal(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldCapture := captureTmuxPanePlainForWatchdog
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		captureTmuxPanePlainForWatchdog = oldCapture
+	})
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		return "0", nil
+	}
+	captureTmuxPanePlainForWatchdog = func(string) string {
+		return "You've hit your usage limit"
+	}
+
+	store := terminals.NewStore()
+	sessionID := "shared-watchdog-session"
+	store.HandleEvent(sessionID, terminalRouteChunkEvent(sessionID, "workflow-step:one", "mlp-codex-cli-int-one", "limited", 1))
+	store.HandleEvent(sessionID, terminalRouteChunkEvent(sessionID, "workflow-step:two", "mlp-codex-cli-int-two", "limited", 1))
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+	}
+	streak := map[string]int{}
+
+	api.reapRateLimitedCodingSessionsOnce(streak)
+
+	if got := api.activeSessions[sessionID].Status; got != "running" {
+		t.Fatalf("session stopped after one tick across two terminals: %q", got)
+	}
+	if streak["mlp-codex-cli-int-one"] != 1 || streak["mlp-codex-cli-int-two"] != 1 {
+		t.Fatalf("terminal streaks = %#v, want one observation each", streak)
+	}
+}

--- a/agent_go/cmd/server/coding_tmux_watchdog_test.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog_test.go
@@ -46,11 +46,14 @@ func TestInspectCodingTmuxPaneStateRejectsEmptySession(t *testing.T) {
 func TestCodingTmuxWatchdogReconcilesFromActualPaneState(t *testing.T) {
 	originalOutput := runTerminalTmuxOutputCommand
 	originalCapture := captureTmuxPanePlainForWatchdog
+	originalKill := runTmuxKill
 	t.Cleanup(func() {
 		runTerminalTmuxOutputCommand = originalOutput
 		captureTmuxPanePlainForWatchdog = originalCapture
+		runTmuxKill = originalKill
 	})
 	captureTmuxPanePlainForWatchdog = func(string) string { return "" }
+	runTmuxKill = func(context.Context, string) error { return nil }
 
 	tests := []struct {
 		name       string
@@ -61,7 +64,7 @@ func TestCodingTmuxWatchdogReconcilesFromActualPaneState(t *testing.T) {
 		wantTmux   bool
 	}{
 		{name: "live pane stays active", paneState: "0\n", wantActive: true, wantState: "running", wantTmux: true},
-		{name: "dead pane completes", paneState: "1\n", wantActive: false, wantState: "completed", wantTmux: true},
+		{name: "dead pane completes", paneState: "1\n", wantActive: false, wantState: "completed", wantTmux: false},
 		{name: "missing session becomes stale", paneErr: errors.New("can't find session: mlp-test"), wantActive: false, wantState: "stale", wantTmux: false},
 		{name: "unknown failure stays active", paneErr: errors.New("temporary tmux failure"), wantActive: true, wantState: "running", wantTmux: true},
 	}

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -998,23 +998,26 @@ func (s *SchedulerService) cancelScheduledSessionWork(sessionID, closeReason str
 	// stop is a hard, full stop — always cancel sub-agents).
 	closeAllCodingCLIInteractiveSessionsForOwner(sessionID, closeReason)
 	if s.api.terminalStore != nil {
-		mainOwner := "main:" + sessionID
-		for _, snap := range s.api.terminalStore.List(sessionID) {
-			owner := strings.TrimSpace(snap.OwnerID)
+		closedTmux := make(map[string]struct{})
+		for _, snap := range s.api.terminalStore.ListRaw(sessionID) {
 			tmux := strings.TrimSpace(snap.TmuxSession)
-			if tmux == "" || owner == sessionID || owner == mainOwner {
-				continue // no pane, or main agent already handled above
+			if tmux == "" {
+				continue
 			}
-			if handled := gracefulCloseCodingCLITmuxByName(tmux, closeReason); !handled {
-				killCtx, killCancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
-				if err := runTerminalTmuxCommand(killCtx, "", "kill-session", "-t", tmux); err != nil {
-					scheduleLogf("[SCHEDULER] kill-session %q (owner %s) failed (may already be gone): %v", tmux, owner, err)
+			if _, seen := closedTmux[tmux]; !seen {
+				if !closeCodingAgentTmuxSessionByName(tmux, closeReason) {
+					scheduleLogf("[SCHEDULER] failed to close tmux %q (owner %s)", tmux, strings.TrimSpace(snap.OwnerID))
+					continue
 				}
-				killCancel()
+				closedTmux[tmux] = struct{}{}
+				if registry := s.api.ensureTerminalLeaseRegistry(); registry != nil {
+					registry.MarkClosed(tmux, closeReason, time.Now())
+				}
 			}
 			if snap.Active {
 				s.api.terminalStore.MarkFailed(snap.TerminalID)
 			}
+			s.api.terminalStore.MarkProcessClosed(snap.TerminalID, closeReason)
 		}
 	}
 

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -6091,7 +6091,7 @@ func (api *StreamingAPI) sessionHasLiveCodingTmux(sessionID string) bool {
 	if api == nil || api.terminalStore == nil {
 		return false
 	}
-	for _, snapshot := range api.terminalStore.List(sessionID) {
+	for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
 		if snapshot.Active && strings.TrimSpace(snapshot.TmuxSession) != "" {
 			return true
 		}
@@ -6603,7 +6603,7 @@ func (api *StreamingAPI) getAllActiveSessions() []*ActiveSessionInfo {
 
 // cleanupInactiveSessions runs periodically to:
 // 1. Mark running sessions as inactive if no events for 10 minutes
-// 2. Evict event store buffers after 30 minutes
+// 2. Evict event store buffers when the retained session expires
 // 3. Fully delete sessions from activeSessions after 24 hours
 //
 // The session entry is intentionally kept alive for 24 hours (not the old 30 minutes) so
@@ -8805,7 +8805,7 @@ func makeStepTmuxLookup(api *StreamingAPI) todo_creation_human.TmuxLookupFunc {
 		if strings.TrimSpace(mainSessionID) == "" || strings.TrimSpace(stepID) == "" {
 			return "", "", false
 		}
-		for _, snap := range api.terminalStore.List(mainSessionID) {
+		for _, snap := range api.terminalStore.ListRaw(mainSessionID) {
 			if snap.StepID != stepID {
 				continue
 			}

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -60,6 +60,7 @@ import (
 	"mcp-agent-builder-go/agent_go/cmd/server/guidance"
 	"mcp-agent-builder-go/agent_go/cmd/server/services"
 	virtualtools "mcp-agent-builder-go/agent_go/cmd/server/virtual-tools"
+	"mcp-agent-builder-go/agent_go/internal/terminalleases"
 	"mcp-agent-builder-go/agent_go/internal/terminals"
 	browserinstructions "mcp-agent-builder-go/agent_go/pkg/instructions"
 	"mcp-agent-builder-go/agent_go/pkg/workspace"
@@ -76,7 +77,6 @@ var (
 	cleanupCursorCLIProviderSessions  = llmproviders.CleanupCursorCLIInteractiveSessions
 	cleanupAgyCLIProviderSessions     = llmproviders.CleanupAgyCLIInteractiveSessions
 	cleanupPiCLIProviderSessions      = llmproviders.CleanupPiCLIInteractiveSessions
-	sweepOrphanedTmuxSessions         = llmproviders.SweepOrphanedInteractiveTmuxSessions
 )
 
 var mcpBridgeCustomToolCategories = map[string]bool{
@@ -305,6 +305,10 @@ type StreamingAPI struct {
 
 	// View-only runtime terminal snapshots for coding-agent TUI streams.
 	terminalStore *terminals.Store
+	// Process ownership is independent from terminal snapshot visibility and
+	// retention. The lease registry remains authoritative after UI dismissal.
+	terminalLeaseRegistry *terminalleases.Registry
+	terminalLeaseMux      sync.Mutex
 
 	// Phase 1 observer: immutable aggregate runtime snapshots. Existing stores
 	// remain authoritative until observer comparisons are proven in production.
@@ -1039,16 +1043,12 @@ func runServer(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Startup recovery: sweep coding-agent tmux sessions (and their orphaned
-	// process trees) stranded by a PREVIOUS run that exited ungracefully
-	// (crash, SIGKILL, machine sleep). The in-process registries the shutdown
-	// cleanup relies on are empty on a fresh boot, so those leftovers would
-	// otherwise accumulate across restarts. Single-instance only — set
-	// MCP_DISABLE_TMUX_STARTUP_SWEEP=1 to skip (e.g. when sharing a tmux server
-	// with another backend or test).
+	// Startup recovery is ownership-aware: only tagged coding-agent tmux
+	// sessions whose backend PID is dead are removed. Untagged legacy sessions
+	// and sessions owned by another live backend/test are preserved.
 	if os.Getenv("MCP_DISABLE_TMUX_STARTUP_SWEEP") == "" {
 		sweepCtx, cancelSweep := context.WithTimeout(context.Background(), 10*time.Second)
-		if n := sweepOrphanedTmuxSessions(sweepCtx); n > 0 {
+		if n := sweepOrphanedOwnedTmuxSessions(sweepCtx); n > 0 {
 			fmt.Printf("🧹 Swept %d orphaned coding-agent tmux session(s) from a previous run\n", n)
 			log.Printf("[STARTUP] swept %d orphaned coding-agent tmux sessions", n)
 		}
@@ -1164,9 +1164,25 @@ func runServer(cmd *cobra.Command, args []string) {
 	}
 	eventStore := events.NewEventStore(maxSessionEvents)
 	terminalStore := terminals.NewStore()
+	serverStartedAt := time.Now()
+	if processStart, ok := processStartedAt(os.Getpid()); ok {
+		serverStartedAt = processStart
+	}
+	terminalLeaseRegistry := terminalleases.NewRegistry(
+		fmt.Sprintf("%d-%d", os.Getpid(), serverStartedAt.UnixNano()),
+		os.Getpid(),
+		serverStartedAt,
+	)
 	terminalPipeRecorder := newTerminalPipeRecorder()
 	eventStore.SetEventAddedCallback(func(sessionID string, event events.Event) {
-		terminalStore.HandleEvent(sessionID, event)
+		if !terminalStore.HandleEventWithChange(sessionID, event) {
+			return
+		}
+		for _, snapshot := range terminalStore.ListRaw(sessionID) {
+			if lease, acquired := terminalLeaseRegistry.Observe(snapshot, event.Timestamp); acquired {
+				go markTerminalLeaseOwnership(lease)
+			}
+		}
 		if terminalPipeRecorder != nil {
 			terminalPipeRecorder.ObserveSnapshots(terminalStore.List(sessionID))
 		}
@@ -1264,6 +1280,7 @@ func runServer(cmd *cobra.Command, args []string) {
 		eventStore:                         eventStore,
 		terminalStore:                      terminalStore,
 		runtimeCoordinator:                 NewRuntimeCoordinator(),
+		terminalLeaseRegistry:              terminalLeaseRegistry,
 		terminalPipeRecorder:               terminalPipeRecorder,
 		liveAttach:                         newLiveAttachManagerIfEnabled(),
 		provider:                           config.Provider,
@@ -6586,7 +6603,7 @@ func (api *StreamingAPI) getAllActiveSessions() []*ActiveSessionInfo {
 
 // cleanupInactiveSessions runs periodically to:
 // 1. Mark running sessions as inactive if no events for 10 minutes
-// 2. Evict event store buffers when the retained session expires
+// 2. Evict event store buffers after 30 minutes
 // 3. Fully delete sessions from activeSessions after 24 hours
 //
 // The session entry is intentionally kept alive for 24 hours (not the old 30 minutes) so
@@ -6600,8 +6617,12 @@ func (api *StreamingAPI) cleanupInactiveSessions() {
 	for range ticker.C {
 		now := time.Now()
 		api.cleanupInactiveSessionsAt(now)
+		api.heartbeatTerminalLeases(now)
 		if closed := api.cleanupStaleCodingAgentTmuxSessions(now); closed > 0 {
 			log.Printf("[ACTIVE_SESSION] Cleanup: Closed %d stale coding-agent tmux session(s)", closed)
+		}
+		if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+			registry.Prune(now)
 		}
 	}
 }

--- a/agent_go/cmd/server/session_lifecycle.go
+++ b/agent_go/cmd/server/session_lifecycle.go
@@ -313,7 +313,7 @@ func (api *StreamingAPI) handleStopSession(w http.ResponseWriter, r *http.Reques
 	// bookkeeping drifted from the terminal store's owner ID.
 	if r.URL.Query().Get("cancelAgents") == "true" && api.terminalStore != nil {
 		mainOwner := "main:" + sessionID
-		for _, snap := range api.terminalStore.List(sessionID) {
+		for _, snap := range api.terminalStore.ListRaw(sessionID) {
 			owner := strings.TrimSpace(snap.OwnerID)
 			if owner == "" || owner == sessionID || owner == mainOwner {
 				continue // chat / main-agent session already handled above

--- a/agent_go/cmd/server/session_lifecycle.go
+++ b/agent_go/cmd/server/session_lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	llmproviders "github.com/manishiitg/multi-llm-provider-go"
 
@@ -339,6 +340,10 @@ func (api *StreamingAPI) handleStopSession(w http.ResponseWriter, r *http.Reques
 				// terminals in their terminal state.
 				api.terminalStore.MarkFailed(snap.TerminalID)
 			}
+			if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+				registry.MarkClosed(tmux, closeReason, time.Now())
+			}
+			api.terminalStore.MarkProcessClosed(snap.TerminalID, closeReason)
 			log.Printf("[SESSION DEBUG] Tore down workflow sub-agent terminal owner=%s tmux=%s active=%v for stopped session %s", owner, tmux, snap.Active, sessionID)
 		}
 	}

--- a/agent_go/cmd/server/terminal_lease_coordinator.go
+++ b/agent_go/cmd/server/terminal_lease_coordinator.go
@@ -20,6 +20,7 @@ const (
 	tmuxOptionRunloopOwnerPID       = "@runloop_owner_pid"
 	tmuxOptionRunloopOwnerStartedAt = "@runloop_owner_started_at"
 	tmuxOptionRunloopHeartbeat      = "@runloop_heartbeat"
+	terminalLeaseTagAttempts        = 3
 )
 
 type ownedTmuxSession struct {
@@ -53,24 +54,40 @@ func (api *StreamingAPI) ensureTerminalLeaseRegistry() *terminalleases.Registry 
 }
 
 func markTerminalLeaseOwnership(lease terminalleases.Lease) {
+	markTerminalLeaseOwnershipAt(lease, time.Now())
+}
+
+func markTerminalLeaseOwnershipAt(lease terminalleases.Lease, now time.Time) {
 	if strings.TrimSpace(lease.TmuxSession) == "" || lease.OwnerPID <= 0 || strings.TrimSpace(lease.InstanceID) == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
-	defer cancel()
+	if now.IsZero() {
+		now = time.Now()
+	}
 	values := [][2]string{
 		{tmuxOptionRunloopInstanceID, lease.InstanceID},
 		{tmuxOptionRunloopOwnerPID, strconv.Itoa(lease.OwnerPID)},
 		{tmuxOptionRunloopOwnerStartedAt, strconv.FormatInt(lease.OwnerStartedAt.Unix(), 10)},
-		{tmuxOptionRunloopHeartbeat, strconv.FormatInt(time.Now().Unix(), 10)},
+		{tmuxOptionRunloopHeartbeat, strconv.FormatInt(now.Unix(), 10)},
 	}
-	for _, pair := range values {
-		if err := runTerminalTmuxCommand(ctx, "", "set-option", "-t", lease.TmuxSession, pair[0], pair[1]); err != nil {
-			if !isMissingTmuxTargetError(err) {
-				log.Printf("[TERMINAL_LEASE] failed to tag tmux=%q option=%s: %v", lease.TmuxSession, pair[0], err)
+	for attempt := 1; attempt <= terminalLeaseTagAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+		var tagErr error
+		for _, pair := range values {
+			if err := runTerminalTmuxCommand(ctx, "", "set-option", "-t", lease.TmuxSession, pair[0], pair[1]); err != nil {
+				tagErr = err
+				break
 			}
+		}
+		cancel()
+		if tagErr == nil || isMissingTmuxTargetError(tagErr) {
 			return
 		}
+		if attempt == terminalLeaseTagAttempts {
+			log.Printf("[TERMINAL_LEASE] failed to tag tmux=%q after %d attempts: %v", lease.TmuxSession, attempt, tagErr)
+			return
+		}
+		time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)
 	}
 }
 
@@ -86,14 +103,30 @@ func (api *StreamingAPI) heartbeatTerminalLeases(now time.Time) {
 		if lease.ProcessState == terminalleases.ProcessClosed || strings.TrimSpace(lease.TmuxSession) == "" {
 			continue
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
-		err := runTerminalTmuxCommand(ctx, "", "set-option", "-t", lease.TmuxSession,
-			tmuxOptionRunloopHeartbeat, strconv.FormatInt(now.Unix(), 10))
-		cancel()
-		if err != nil && !isMissingTmuxTargetError(err) {
-			log.Printf("[TERMINAL_LEASE] heartbeat failed tmux=%q: %v", lease.TmuxSession, err)
-		}
+		// Refresh every ownership field, not only the heartbeat. This repairs a
+		// partial initial tag write instead of leaving an unowned process forever.
+		markTerminalLeaseOwnershipAt(lease, now)
 	}
+}
+
+func tmuxSessionOwnedByRegistry(ctx context.Context, tmuxSession string, registry *terminalleases.Registry) bool {
+	if registry == nil || strings.TrimSpace(tmuxSession) == "" {
+		return false
+	}
+	out, err := runTerminalTmuxOutputCommand(ctx, "display-message", "-p", "-t", tmuxSession,
+		"#{session_name}\t#{@runloop_instance_id}\t#{@runloop_owner_pid}\t#{@runloop_owner_started_at}\t#{@runloop_heartbeat}")
+	if err != nil {
+		return false
+	}
+	rows := parseOwnedTmuxSessions(out)
+	if len(rows) != 1 {
+		return false
+	}
+	owner := rows[0]
+	return owner.Name == strings.TrimSpace(tmuxSession) &&
+		owner.InstanceID == registry.InstanceID() &&
+		owner.OwnerPID == registry.OwnerPID() &&
+		absInt64(owner.OwnerStartedAt-registry.OwnerStartedAt().Unix()) <= 2
 }
 
 // sweepOrphanedOwnedTmuxSessions only removes sessions carrying Runloop owner

--- a/agent_go/cmd/server/terminal_lease_coordinator.go
+++ b/agent_go/cmd/server/terminal_lease_coordinator.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"mcp-agent-builder-go/agent_go/internal/terminalleases"
+)
+
+const (
+	tmuxOptionRunloopInstanceID     = "@runloop_instance_id"
+	tmuxOptionRunloopOwnerPID       = "@runloop_owner_pid"
+	tmuxOptionRunloopOwnerStartedAt = "@runloop_owner_started_at"
+	tmuxOptionRunloopHeartbeat      = "@runloop_heartbeat"
+)
+
+type ownedTmuxSession struct {
+	Name           string
+	InstanceID     string
+	OwnerPID       int
+	OwnerStartedAt int64
+	Heartbeat      int64
+}
+
+func (api *StreamingAPI) ensureTerminalLeaseRegistry() *terminalleases.Registry {
+	if api == nil {
+		return nil
+	}
+	api.terminalLeaseMux.Lock()
+	defer api.terminalLeaseMux.Unlock()
+	if api.terminalLeaseRegistry == nil {
+		now := time.Now()
+		api.terminalLeaseRegistry = terminalleases.NewRegistry(
+			fmt.Sprintf("%d-%d", os.Getpid(), now.UnixNano()),
+			os.Getpid(),
+			now,
+		)
+		if api.terminalStore != nil {
+			for _, snapshot := range api.terminalStore.ListRaw("") {
+				api.terminalLeaseRegistry.Observe(snapshot, snapshot.UpdatedAt)
+			}
+		}
+	}
+	return api.terminalLeaseRegistry
+}
+
+func markTerminalLeaseOwnership(lease terminalleases.Lease) {
+	if strings.TrimSpace(lease.TmuxSession) == "" || lease.OwnerPID <= 0 || strings.TrimSpace(lease.InstanceID) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+	defer cancel()
+	values := [][2]string{
+		{tmuxOptionRunloopInstanceID, lease.InstanceID},
+		{tmuxOptionRunloopOwnerPID, strconv.Itoa(lease.OwnerPID)},
+		{tmuxOptionRunloopOwnerStartedAt, strconv.FormatInt(lease.OwnerStartedAt.Unix(), 10)},
+		{tmuxOptionRunloopHeartbeat, strconv.FormatInt(time.Now().Unix(), 10)},
+	}
+	for _, pair := range values {
+		if err := runTerminalTmuxCommand(ctx, "", "set-option", "-t", lease.TmuxSession, pair[0], pair[1]); err != nil {
+			if !isMissingTmuxTargetError(err) {
+				log.Printf("[TERMINAL_LEASE] failed to tag tmux=%q option=%s: %v", lease.TmuxSession, pair[0], err)
+			}
+			return
+		}
+	}
+}
+
+func (api *StreamingAPI) heartbeatTerminalLeases(now time.Time) {
+	registry := api.ensureTerminalLeaseRegistry()
+	if registry == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	for _, lease := range registry.List() {
+		if lease.ProcessState == terminalleases.ProcessClosed || strings.TrimSpace(lease.TmuxSession) == "" {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+		err := runTerminalTmuxCommand(ctx, "", "set-option", "-t", lease.TmuxSession,
+			tmuxOptionRunloopHeartbeat, strconv.FormatInt(now.Unix(), 10))
+		cancel()
+		if err != nil && !isMissingTmuxTargetError(err) {
+			log.Printf("[TERMINAL_LEASE] heartbeat failed tmux=%q: %v", lease.TmuxSession, err)
+		}
+	}
+}
+
+// sweepOrphanedOwnedTmuxSessions only removes sessions carrying Runloop owner
+// metadata whose owner PID is no longer alive. Untagged legacy sessions and
+// sessions owned by another live backend are deliberately preserved.
+func sweepOrphanedOwnedTmuxSessions(ctx context.Context) int {
+	out, err := runTerminalTmuxOutputCommand(ctx, "list-sessions", "-F",
+		"#{session_name}\t#{@runloop_instance_id}\t#{@runloop_owner_pid}\t#{@runloop_owner_started_at}\t#{@runloop_heartbeat}")
+	if err != nil {
+		if !isMissingTmuxTargetError(err) {
+			log.Printf("[TERMINAL_LEASE] startup ownership scan failed: %v", err)
+		}
+		return 0
+	}
+
+	closed := 0
+	for _, session := range parseOwnedTmuxSessions(out) {
+		if !isCodingAgentTmuxSessionName(session.Name) || session.InstanceID == "" || session.OwnerPID <= 0 {
+			continue
+		}
+		if ownedTmuxOwnerIsAlive(session) {
+			continue
+		}
+		if err := runTerminalTmuxCommand(ctx, "", "kill-session", "-t", session.Name); err != nil && !isMissingTmuxTargetError(err) {
+			log.Printf("[TERMINAL_LEASE] startup orphan kill failed tmux=%q owner_pid=%d: %v", session.Name, session.OwnerPID, err)
+			continue
+		}
+		closed++
+		log.Printf("[TERMINAL_LEASE] recovered orphan tmux=%q instance=%q owner_pid=%d", session.Name, session.InstanceID, session.OwnerPID)
+	}
+	return closed
+}
+
+func parseOwnedTmuxSessions(output string) []ownedTmuxSession {
+	var sessions []ownedTmuxSession
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) < 5 {
+			continue
+		}
+		ownerPID, _ := strconv.Atoi(strings.TrimSpace(fields[2]))
+		ownerStartedAt, _ := strconv.ParseInt(strings.TrimSpace(fields[3]), 10, 64)
+		heartbeat, _ := strconv.ParseInt(strings.TrimSpace(fields[4]), 10, 64)
+		sessions = append(sessions, ownedTmuxSession{
+			Name:           strings.TrimSpace(fields[0]),
+			InstanceID:     strings.TrimSpace(fields[1]),
+			OwnerPID:       ownerPID,
+			OwnerStartedAt: ownerStartedAt,
+			Heartbeat:      heartbeat,
+		})
+	}
+	return sessions
+}
+
+func processIsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func ownedTmuxOwnerIsAlive(session ownedTmuxSession) bool {
+	if !processIsAlive(session.OwnerPID) {
+		return false
+	}
+	if session.OwnerStartedAt <= 0 {
+		return true
+	}
+	startedAt, ok := processStartedAt(session.OwnerPID)
+	if !ok {
+		// Fail safe: an unreadable but live PID is not enough evidence to kill.
+		return true
+	}
+	return absInt64(startedAt.Unix()-session.OwnerStartedAt) <= 2
+}
+
+func processStartedAt(pid int) (time.Time, bool) {
+	if pid <= 0 {
+		return time.Time{}, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return time.Time{}, false
+	}
+	startedAt, err := time.ParseInLocation("Mon Jan _2 15:04:05 2006", strings.TrimSpace(string(out)), time.Local)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return startedAt, true
+}
+
+func absInt64(value int64) int64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/agent_go/cmd/server/terminal_lease_coordinator_test.go
+++ b/agent_go/cmd/server/terminal_lease_coordinator_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -109,6 +110,44 @@ func TestMarkTerminalLeaseOwnershipWritesOwnerMetadata(t *testing.T) {
 		if !found {
 			t.Fatalf("missing option %s in %v", option, commands)
 		}
+	}
+}
+
+func TestMarkTerminalLeaseOwnershipRetriesPartialTagWrite(t *testing.T) {
+	oldRun := runTerminalTmuxCommand
+	t.Cleanup(func() { runTerminalTmuxCommand = oldRun })
+	calls := 0
+	runTerminalTmuxCommand = func(_ context.Context, _ string, args ...string) error {
+		calls++
+		if calls == 1 {
+			return errors.New("temporary tmux failure")
+		}
+		return nil
+	}
+
+	markTerminalLeaseOwnership(testTerminalLease("mlp-codex-cli-int-retry"))
+
+	if calls != 5 {
+		t.Fatalf("commands = %d, want one failed command plus four successful tags", calls)
+	}
+}
+
+func TestTmuxSessionOwnedByRegistryRequiresMatchingOwnerTags(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	t.Cleanup(func() { runTerminalTmuxOutputCommand = oldOutput })
+	startedAt := time.Unix(100, 0)
+	registry := terminalleases.NewRegistry("instance-1", 1234, startedAt)
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		return "mlp-pi-cli-owned\tinstance-1\t1234\t100\t200", nil
+	}
+	if !tmuxSessionOwnedByRegistry(context.Background(), "mlp-pi-cli-owned", registry) {
+		t.Fatal("matching ownership tags should be accepted")
+	}
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		return "mlp-pi-cli-owned\tforeign-instance\t1234\t100\t200", nil
+	}
+	if tmuxSessionOwnedByRegistry(context.Background(), "mlp-pi-cli-owned", registry) {
+		t.Fatal("foreign ownership tags must be rejected")
 	}
 }
 

--- a/agent_go/cmd/server/terminal_lease_coordinator_test.go
+++ b/agent_go/cmd/server/terminal_lease_coordinator_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"mcp-agent-builder-go/agent_go/internal/terminalleases"
+)
+
+func TestSweepOrphanedOwnedTmuxSessionsKeepsLiveAndUntaggedOwners(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldRun := runTerminalTmuxCommand
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		runTerminalTmuxCommand = oldRun
+	})
+
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		startedAt, ok := processStartedAt(os.Getpid())
+		if !ok {
+			t.Fatal("could not resolve current process start time")
+		}
+		return strings.Join([]string{
+			fmt.Sprintf("mlp-codex-cli-int-live\tinstance-live\t%d\t%d\t1", os.Getpid(), startedAt.Unix()),
+			"mlp-claude-code-legacy\t\t\t\t",
+			"unrelated-session\tdead-instance\t999999\t1\t1",
+		}, "\n"), nil
+	}
+	var killed []string
+	runTerminalTmuxCommand = func(_ context.Context, _ string, args ...string) error {
+		killed = append(killed, strings.Join(args, " "))
+		return nil
+	}
+
+	if got := sweepOrphanedOwnedTmuxSessions(context.Background()); got != 0 {
+		t.Fatalf("closed = %d, want 0", got)
+	}
+	if len(killed) != 0 {
+		t.Fatalf("unexpected kills: %v", killed)
+	}
+}
+
+func TestSweepOrphanedOwnedTmuxSessionsKillsOnlyDeadTaggedOwner(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldRun := runTerminalTmuxCommand
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		runTerminalTmuxCommand = oldRun
+	})
+
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
+		return "mlp-pi-cli-int-orphan\tdead-instance\t999999\t1\t1", nil
+	}
+	var killed string
+	runTerminalTmuxCommand = func(_ context.Context, _ string, args ...string) error {
+		killed = strings.Join(args, " ")
+		return nil
+	}
+
+	if got := sweepOrphanedOwnedTmuxSessions(context.Background()); got != 1 {
+		t.Fatalf("closed = %d, want 1", got)
+	}
+	if killed != "kill-session -t mlp-pi-cli-int-orphan" {
+		t.Fatalf("kill args = %q", killed)
+	}
+}
+
+func TestParseOwnedTmuxSessionsRejectsIncompleteRows(t *testing.T) {
+	rows := parseOwnedTmuxSessions("short\trow\nmlp-agy-cli-int-1\tinstance\t42\t100\t200")
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].OwnerPID != 42 || rows[0].Heartbeat != 200 {
+		t.Fatalf("parsed row = %#v", rows[0])
+	}
+}
+
+func TestMarkTerminalLeaseOwnershipWritesOwnerMetadata(t *testing.T) {
+	oldRun := runTerminalTmuxCommand
+	t.Cleanup(func() { runTerminalTmuxCommand = oldRun })
+	var commands []string
+	runTerminalTmuxCommand = func(_ context.Context, _ string, args ...string) error {
+		commands = append(commands, strings.Join(args, " "))
+		return nil
+	}
+
+	markTerminalLeaseOwnership(testTerminalLease("mlp-cursor-cli-int-owned"))
+
+	if len(commands) != 4 {
+		t.Fatalf("commands = %d, want 4: %v", len(commands), commands)
+	}
+	for _, option := range []string{
+		tmuxOptionRunloopInstanceID,
+		tmuxOptionRunloopOwnerPID,
+		tmuxOptionRunloopOwnerStartedAt,
+		tmuxOptionRunloopHeartbeat,
+	} {
+		found := false
+		for _, command := range commands {
+			if strings.Contains(command, option) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing option %s in %v", option, commands)
+		}
+	}
+}
+
+func testTerminalLease(tmuxSession string) terminalleases.Lease {
+	return terminalleases.Lease{
+		TmuxSession:    tmuxSession,
+		InstanceID:     "instance-1",
+		OwnerPID:       1234,
+		OwnerStartedAt: time.Unix(100, 0),
+	}
+}

--- a/agent_go/cmd/server/terminal_routes.go
+++ b/agent_go/cmd/server/terminal_routes.go
@@ -439,6 +439,10 @@ func (api *StreamingAPI) handleDismissTerminal(w http.ResponseWriter, r *http.Re
 		http.Error(w, "Terminal not found", http.StatusNotFound)
 		return
 	}
+	if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+		registry.Observe(snapshot, snapshot.UpdatedAt)
+		registry.MarkSnapshotDismissed(terminalID)
+	}
 	_ = json.NewEncoder(w).Encode(map[string]bool{"dismissed": true})
 }
 
@@ -465,10 +469,13 @@ func (api *StreamingAPI) handleCompleteTerminal(w http.ResponseWriter, r *http.R
 	if before.Active && strings.TrimSpace(before.TmuxSession) != "" {
 		forceCompleteCodingAgentTmuxSession(before.TmuxSession)
 	}
+	if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+		registry.Observe(snapshot, snapshot.UpdatedAt)
+	}
 	_ = json.NewEncoder(w).Encode(terminalActionResponse{OK: true, Terminal: api.enrichTerminalSnapshot(r.Context(), newTerminalPlanTypeResolver(r.Context()), snapshot)})
 }
 
-// handleFailTerminal marks one view-only terminal snapshot failed.
+// handleFailTerminal fails the terminal and closes its backing process.
 // POST /api/terminals/{terminal_id}/fail
 func (api *StreamingAPI) handleFailTerminal(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -484,6 +491,16 @@ func (api *StreamingAPI) handleFailTerminal(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		http.Error(w, "Terminal not found", http.StatusNotFound)
 		return
+	}
+	if before.Active && strings.TrimSpace(before.TmuxSession) != "" {
+		if closeCodingAgentTmuxSessionByName(before.TmuxSession, "failed by operator") {
+			if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+				registry.MarkClosed(before.TmuxSession, "failed by operator", time.Now())
+			}
+			if archived, archivedOK := api.terminalStore.MarkProcessClosed(before.TerminalID, "failed by operator"); archivedOK {
+				snapshot = archived
+			}
+		}
 	}
 	_ = json.NewEncoder(w).Encode(terminalActionResponse{OK: true, Terminal: api.enrichTerminalSnapshot(r.Context(), newTerminalPlanTypeResolver(r.Context()), snapshot)})
 }
@@ -554,6 +571,12 @@ func (api *StreamingAPI) handleKillTerminal(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		http.Error(w, "Terminal not found", http.StatusNotFound)
 		return
+	}
+	if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+		registry.MarkClosed(snapshot.TmuxSession, "killed by operator", time.Now())
+	}
+	if archived, archivedOK := api.terminalStore.MarkProcessClosed(snapshot.TerminalID, "killed by operator"); archivedOK {
+		updated = archived
 	}
 	_ = json.NewEncoder(w).Encode(terminalActionResponse{OK: true, Terminal: api.enrichTerminalSnapshot(r.Context(), newTerminalPlanTypeResolver(r.Context()), updated)})
 }

--- a/agent_go/internal/terminalleases/registry.go
+++ b/agent_go/internal/terminalleases/registry.go
@@ -1,0 +1,288 @@
+package terminalleases
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"mcp-agent-builder-go/agent_go/internal/terminals"
+)
+
+const (
+	DefaultBoundedProcessGrace  = 30 * time.Second
+	DefaultClosedLeaseRetention = 30 * time.Minute
+)
+
+type Policy string
+
+const (
+	PolicyPersistent Policy = "persistent"
+	PolicyBounded    Policy = "bounded"
+)
+
+type ProcessState string
+
+const (
+	ProcessLive    ProcessState = "live"
+	ProcessClosing ProcessState = "closing"
+	ProcessClosed  ProcessState = "closed"
+)
+
+// Lease owns a live coding-agent tmux process independently from its UI snapshot.
+// Snapshot retention and dismissal must never decide whether the process exists.
+type Lease struct {
+	TerminalID        string
+	TmuxSession       string
+	SessionID         string
+	OwnerID           string
+	ExecutionID       string
+	ExecutionKind     string
+	WorkflowPath      string
+	Provider          string
+	Policy            Policy
+	ProcessState      ProcessState
+	InstanceID        string
+	OwnerPID          int
+	OwnerStartedAt    time.Time
+	LastActivity      time.Time
+	ProcessDeadline   *time.Time
+	SnapshotDeadline  *time.Time
+	SnapshotDismissed bool
+	CloseReason       string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type Registry struct {
+	mu             sync.RWMutex
+	instanceID     string
+	ownerPID       int
+	ownerStartedAt time.Time
+	byTmux         map[string]Lease
+	byTerminal     map[string]string
+}
+
+func NewRegistry(instanceID string, ownerPID int, ownerStartedAt time.Time) *Registry {
+	if ownerStartedAt.IsZero() {
+		ownerStartedAt = time.Now()
+	}
+	return &Registry{
+		instanceID:     strings.TrimSpace(instanceID),
+		ownerPID:       ownerPID,
+		ownerStartedAt: ownerStartedAt,
+		byTmux:         make(map[string]Lease),
+		byTerminal:     make(map[string]string),
+	}
+}
+
+func (r *Registry) InstanceID() string {
+	if r == nil {
+		return ""
+	}
+	return r.instanceID
+}
+
+func (r *Registry) OwnerPID() int {
+	if r == nil {
+		return 0
+	}
+	return r.ownerPID
+}
+
+func (r *Registry) OwnerStartedAt() time.Time {
+	if r == nil {
+		return time.Time{}
+	}
+	return r.ownerStartedAt
+}
+
+// Observe updates ownership from one terminal snapshot. acquired is true only
+// when this backend first learns about the tmux process, allowing the caller to
+// write ownership markers once instead of on every streaming token.
+func (r *Registry) Observe(snapshot terminals.Snapshot, now time.Time) (lease Lease, acquired bool) {
+	if r == nil {
+		return Lease{}, false
+	}
+	tmuxSession := strings.TrimSpace(snapshot.TmuxSession)
+	terminalID := strings.TrimSpace(snapshot.TerminalID)
+	if tmuxSession == "" || terminalID == "" {
+		return Lease{}, false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	lease, exists := r.byTmux[tmuxSession]
+	acquired = !exists || lease.InstanceID != r.instanceID
+	if !exists {
+		lease.CreatedAt = now
+	}
+	lease.TerminalID = terminalID
+	lease.TmuxSession = tmuxSession
+	lease.SessionID = strings.TrimSpace(snapshot.SessionID)
+	lease.OwnerID = strings.TrimSpace(snapshot.OwnerID)
+	lease.ExecutionID = strings.TrimSpace(snapshot.ExecutionID)
+	lease.ExecutionKind = strings.TrimSpace(snapshot.ExecutionKind)
+	lease.WorkflowPath = strings.TrimSpace(snapshot.WorkflowPath)
+	lease.Provider = providerFromTmuxSession(tmuxSession)
+	lease.Policy = policyForSnapshot(snapshot)
+	lease.InstanceID = r.instanceID
+	lease.OwnerPID = r.ownerPID
+	lease.OwnerStartedAt = r.ownerStartedAt
+	lease.SnapshotDeadline = cloneTime(snapshot.ClosesAt)
+	lease.LastActivity = snapshot.UpdatedAt
+	if lease.LastActivity.IsZero() {
+		lease.LastActivity = now
+	}
+	lease.UpdatedAt = now
+
+	if snapshot.Active {
+		lease.ProcessState = ProcessLive
+		lease.ProcessDeadline = nil
+		lease.CloseReason = ""
+	} else if lease.ProcessState != ProcessClosed {
+		lease.ProcessState = ProcessClosing
+		if lease.Policy == PolicyBounded && lease.ProcessDeadline == nil {
+			deadline := now.Add(DefaultBoundedProcessGrace)
+			lease.ProcessDeadline = &deadline
+		}
+	}
+
+	if previousTmux := r.byTerminal[terminalID]; previousTmux != "" && previousTmux != tmuxSession {
+		delete(r.byTmux, previousTmux)
+	}
+	r.byTmux[tmuxSession] = lease
+	r.byTerminal[terminalID] = tmuxSession
+	return lease, acquired
+}
+
+func (r *Registry) MarkSnapshotDismissed(terminalID string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tmuxSession := r.byTerminal[strings.TrimSpace(terminalID)]
+	lease, ok := r.byTmux[tmuxSession]
+	if !ok {
+		return false
+	}
+	lease.SnapshotDismissed = true
+	lease.UpdatedAt = time.Now()
+	r.byTmux[tmuxSession] = lease
+	return true
+}
+
+func (r *Registry) MarkClosed(tmuxSession, reason string, now time.Time) (Lease, bool) {
+	if r == nil {
+		return Lease{}, false
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lease, ok := r.byTmux[strings.TrimSpace(tmuxSession)]
+	if !ok {
+		return Lease{}, false
+	}
+	lease.ProcessState = ProcessClosed
+	lease.ProcessDeadline = nil
+	if lease.SnapshotDeadline == nil {
+		deadline := now.Add(DefaultClosedLeaseRetention)
+		lease.SnapshotDeadline = &deadline
+	}
+	lease.CloseReason = strings.TrimSpace(reason)
+	lease.UpdatedAt = now
+	r.byTmux[lease.TmuxSession] = lease
+	return lease, true
+}
+
+func (r *Registry) List() []Lease {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Lease, 0, len(r.byTmux))
+	for _, lease := range r.byTmux {
+		out = append(out, cloneLease(lease))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
+}
+
+func (r *Registry) GetByTerminal(terminalID string) (Lease, bool) {
+	if r == nil {
+		return Lease{}, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	lease, ok := r.byTmux[r.byTerminal[strings.TrimSpace(terminalID)]]
+	return cloneLease(lease), ok
+}
+
+func (r *Registry) Prune(now time.Time) int {
+	if r == nil {
+		return 0
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	removed := 0
+	for tmuxSession, lease := range r.byTmux {
+		if lease.ProcessState != ProcessClosed || lease.SnapshotDeadline == nil || now.Before(*lease.SnapshotDeadline) {
+			continue
+		}
+		delete(r.byTmux, tmuxSession)
+		delete(r.byTerminal, lease.TerminalID)
+		removed++
+	}
+	return removed
+}
+
+func policyForSnapshot(snapshot terminals.Snapshot) Policy {
+	if snapshot.ExecutionKind == "main_agent" || snapshot.Scope == "main_agent" || strings.HasPrefix(snapshot.OwnerID, "main:") {
+		return PolicyPersistent
+	}
+	return PolicyBounded
+}
+
+func providerFromTmuxSession(tmuxSession string) string {
+	switch {
+	case strings.HasPrefix(tmuxSession, "mlp-claude-code"):
+		return "claude-code"
+	case strings.HasPrefix(tmuxSession, "mlp-codex-cli"):
+		return "codex-cli"
+	case strings.HasPrefix(tmuxSession, "mlp-cursor-cli"):
+		return "cursor-cli"
+	case strings.HasPrefix(tmuxSession, "mlp-pi-cli"):
+		return "pi-cli"
+	case strings.HasPrefix(tmuxSession, "mlp-agy-cli"):
+		return "agy-cli"
+	default:
+		return "coding-cli"
+	}
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func cloneLease(lease Lease) Lease {
+	lease.ProcessDeadline = cloneTime(lease.ProcessDeadline)
+	lease.SnapshotDeadline = cloneTime(lease.SnapshotDeadline)
+	return lease
+}

--- a/agent_go/internal/terminalleases/registry_test.go
+++ b/agent_go/internal/terminalleases/registry_test.go
@@ -1,0 +1,129 @@
+package terminalleases
+
+import (
+	"testing"
+	"time"
+
+	"mcp-agent-builder-go/agent_go/internal/terminals"
+)
+
+func TestObserveSeparatesBoundedProcessDeadlineFromSnapshotDeadline(t *testing.T) {
+	now := time.Now()
+	snapshotDeadline := now.Add(30 * time.Minute)
+	registry := NewRegistry("instance-1", 1234, now.Add(-time.Minute))
+	snapshot := terminals.Snapshot{
+		TerminalID:    "terminal-1",
+		TmuxSession:   "mlp-codex-cli-int-1",
+		SessionID:     "session-1",
+		ExecutionKind: "workflow_step",
+		Active:        false,
+		ClosesAt:      &snapshotDeadline,
+		UpdatedAt:     now,
+	}
+
+	lease, acquired := registry.Observe(snapshot, now)
+	if !acquired {
+		t.Fatal("expected first observation to acquire the lease")
+	}
+	if lease.Policy != PolicyBounded || lease.ProcessState != ProcessClosing {
+		t.Fatalf("policy/state = %q/%q, want bounded/closing", lease.Policy, lease.ProcessState)
+	}
+	if lease.ProcessDeadline == nil || !lease.ProcessDeadline.Equal(now.Add(DefaultBoundedProcessGrace)) {
+		t.Fatalf("process deadline = %v, want %v", lease.ProcessDeadline, now.Add(DefaultBoundedProcessGrace))
+	}
+	if lease.SnapshotDeadline == nil || !lease.SnapshotDeadline.Equal(snapshotDeadline) {
+		t.Fatalf("snapshot deadline = %v, want %v", lease.SnapshotDeadline, snapshotDeadline)
+	}
+}
+
+func TestDismissedSnapshotDoesNotDeleteLiveLease(t *testing.T) {
+	now := time.Now()
+	registry := NewRegistry("instance-1", 1234, now)
+	registry.Observe(terminals.Snapshot{
+		TerminalID:    "terminal-1",
+		TmuxSession:   "mlp-pi-cli-int-1",
+		SessionID:     "session-1",
+		ExecutionKind: "main_agent",
+		Active:        true,
+		UpdatedAt:     now,
+	}, now)
+
+	if !registry.MarkSnapshotDismissed("terminal-1") {
+		t.Fatal("expected lease to be marked dismissed")
+	}
+	lease, ok := registry.GetByTerminal("terminal-1")
+	if !ok {
+		t.Fatal("dismissal deleted the process lease")
+	}
+	if !lease.SnapshotDismissed || lease.ProcessState != ProcessLive {
+		t.Fatalf("dismissed/state = %v/%q, want true/live", lease.SnapshotDismissed, lease.ProcessState)
+	}
+}
+
+func TestPersistentMainAgentDoesNotReceiveBoundedDeadline(t *testing.T) {
+	now := time.Now()
+	registry := NewRegistry("instance-1", 1234, now)
+	lease, _ := registry.Observe(terminals.Snapshot{
+		TerminalID:    "terminal-1",
+		TmuxSession:   "mlp-claude-code-1",
+		SessionID:     "session-1",
+		OwnerID:       "main:session-1",
+		ExecutionKind: "main_agent",
+		Active:        false,
+		UpdatedAt:     now,
+	}, now)
+
+	if lease.Policy != PolicyPersistent {
+		t.Fatalf("policy = %q, want persistent", lease.Policy)
+	}
+	if lease.ProcessDeadline != nil {
+		t.Fatalf("persistent lease received bounded deadline %v", lease.ProcessDeadline)
+	}
+}
+
+func TestClosedLeasePrunesOnlyAfterSnapshotDeadline(t *testing.T) {
+	now := time.Now()
+	snapshotDeadline := now.Add(time.Minute)
+	registry := NewRegistry("instance-1", 1234, now)
+	registry.Observe(terminals.Snapshot{
+		TerminalID:  "terminal-1",
+		TmuxSession: "mlp-agy-cli-int-1",
+		SessionID:   "session-1",
+		Active:      false,
+		ClosesAt:    &snapshotDeadline,
+		UpdatedAt:   now,
+	}, now)
+	registry.MarkClosed("mlp-agy-cli-int-1", "completed", now)
+
+	if got := registry.Prune(now.Add(30 * time.Second)); got != 0 {
+		t.Fatalf("early prune = %d, want 0", got)
+	}
+	if got := registry.Prune(now.Add(2 * time.Minute)); got != 1 {
+		t.Fatalf("expired prune = %d, want 1", got)
+	}
+}
+
+func TestClosedLeaseWithoutSnapshotDeadlineGetsBoundedRetention(t *testing.T) {
+	now := time.Now()
+	registry := NewRegistry("instance-1", 1234, now)
+	registry.Observe(terminals.Snapshot{
+		TerminalID:    "terminal-1",
+		TmuxSession:   "mlp-codex-cli-int-1",
+		SessionID:     "session-1",
+		ExecutionKind: "main_agent",
+		Active:        true,
+		UpdatedAt:     now,
+	}, now)
+
+	lease, ok := registry.MarkClosed("mlp-codex-cli-int-1", "completed", now)
+	if !ok {
+		t.Fatal("expected lease to close")
+	}
+	wantDeadline := now.Add(DefaultClosedLeaseRetention)
+	if lease.SnapshotDeadline == nil || !lease.SnapshotDeadline.Equal(wantDeadline) {
+		t.Fatalf("snapshot deadline = %v, want %v", lease.SnapshotDeadline, wantDeadline)
+	}
+	if got := registry.Prune(wantDeadline.Add(time.Second)); got != 1 {
+		t.Fatalf("expired prune = %d, want 1", got)
+	}
+}

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -47,6 +47,9 @@ type Snapshot struct {
 	ChunkIndex        int        `json:"chunk_index"`
 	Active            bool       `json:"active"`
 	State             string     `json:"state"`
+	ProcessState      string     `json:"process_state,omitempty"`
+	SnapshotKind      string     `json:"snapshot_kind,omitempty"`
+	CloseReason       string     `json:"close_reason,omitempty"`
 	ClosesAt          *time.Time `json:"closes_at,omitempty"`
 	RetentionSeconds  int        `json:"retention_seconds,omitempty"`
 	Status            Status     `json:"status"`
@@ -141,38 +144,54 @@ func NewStore() *Store {
 
 // HandleEvent ingests terminal streaming events emitted by coding-agent adapters.
 func (s *Store) HandleEvent(sessionID string, event storeevents.Event) {
+	s.handleEvent(sessionID, event)
+}
+
+// HandleEventWithChange preserves the callback-compatible HandleEvent API while
+// telling the server whether downstream terminal lifecycle work is necessary.
+func (s *Store) HandleEventWithChange(sessionID string, event storeevents.Event) bool {
+	return s.handleEvent(sessionID, event)
+}
+
+func (s *Store) handleEvent(sessionID string, event storeevents.Event) bool {
 	if s == nil {
-		return
+		return false
 	}
 	sessionID = firstNonEmpty(sessionID, event.SessionID)
 	if sessionID == "" {
-		return
+		return false
 	}
 
 	switch event.Type {
 	case "streaming_chunk":
 		content, chunkIndex, metadata, ok := terminalChunk(event)
 		if !ok || strings.TrimSpace(content) == "" || !isTerminalMetadata(metadata) {
-			return
+			return false
 		}
 		s.upsertTerminal(sessionID, event, metadata, content, chunkIndex)
+		return true
 	case "streaming_end":
 		metadata := metadataForEvent(event)
 		if !isTerminalMetadata(metadata) {
-			return
+			return false
 		}
 		s.markInactive(sessionID, terminalOwnerID(sessionID, event, metadata), metadata)
+		return true
 	case string(agentevents.ToolCallStart), string(agentevents.ToolCallEnd), string(agentevents.ToolCallError):
 		metadata := metadataForEvent(event)
 		if !isNonTmuxWorkflowTerminalMetadata(metadata) {
-			return
+			return false
 		}
 		s.upsertToolLine(sessionID, event, metadata)
+		return true
 	case "pre_validation_completed":
 		s.updatePreValidationStatus(sessionID, event)
+		return true
 	case "status_line":
 		s.handleStatusLine(sessionID, event)
+		return true
 	}
+	return false
 }
 
 func (s *Store) List(sessionID string) []Snapshot {
@@ -184,6 +203,9 @@ func (s *Store) List(sessionID string) []Snapshot {
 	var out []Snapshot
 	if strings.TrimSpace(sessionID) != "" {
 		for terminalID := range s.bySession[sessionID] {
+			if _, dismissed := s.dismissed[terminalID]; dismissed {
+				continue
+			}
 			if snapshot, ok := s.reconcileTerminalStateLocked(terminalID, now); ok {
 				out = append(out, snapshot)
 			}
@@ -191,6 +213,9 @@ func (s *Store) List(sessionID string) []Snapshot {
 	} else {
 		out = make([]Snapshot, 0, len(s.byID))
 		for terminalID := range s.byID {
+			if _, dismissed := s.dismissed[terminalID]; dismissed {
+				continue
+			}
 			if snapshot, ok := s.reconcileTerminalStateLocked(terminalID, now); ok {
 				out = append(out, snapshot)
 			}
@@ -220,6 +245,49 @@ func (s *Store) ListMetadata(sessionID string) []Snapshot {
 	var out []Snapshot
 	if strings.TrimSpace(sessionID) != "" {
 		for terminalID := range s.bySession[sessionID] {
+			if _, dismissed := s.dismissed[terminalID]; dismissed {
+				continue
+			}
+			if snapshot, ok := s.byID[terminalID]; ok {
+				out = append(out, snapshot)
+			}
+		}
+	} else {
+		out = make([]Snapshot, 0, len(s.byID))
+		for terminalID, snapshot := range s.byID {
+			if _, dismissed := s.dismissed[terminalID]; dismissed {
+				continue
+			}
+			out = append(out, snapshot)
+		}
+	}
+	out = dedupeCurrentMainAgentSnapshots(out)
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Active != out[j].Active {
+			return out[i].Active
+		}
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
+}
+
+// ListRaw returns ownership-bearing snapshots without pruning expired or
+// dismissed UI entries. Process cleanup must use this path rather than List:
+// hiding or expiring a rendered snapshot cannot erase knowledge of a live tmux
+// process before the lifecycle coordinator closes it.
+func (s *Store) ListRaw(sessionID string) []Snapshot {
+	if s == nil {
+		return nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []Snapshot
+	if sessionID != "" {
+		out = make([]Snapshot, 0, len(s.bySession[sessionID]))
+		for terminalID := range s.bySession[sessionID] {
 			if snapshot, ok := s.byID[terminalID]; ok {
 				out = append(out, snapshot)
 			}
@@ -230,12 +298,7 @@ func (s *Store) ListMetadata(sessionID string) []Snapshot {
 			out = append(out, snapshot)
 		}
 	}
-	out = dedupeCurrentMainAgentSnapshots(out)
-
 	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].Active != out[j].Active {
-			return out[i].Active
-		}
 		return out[i].UpdatedAt.After(out[j].UpdatedAt)
 	})
 	return out
@@ -300,7 +363,23 @@ func (s *Store) Get(terminalID string) (Snapshot, bool) {
 	defer s.mu.Unlock()
 	now := time.Now()
 	s.pruneExpiredLocked(now)
+	if _, dismissed := s.dismissed[terminalID]; dismissed {
+		return Snapshot{}, false
+	}
 	return s.reconcileTerminalStateLocked(terminalID, now)
+}
+
+// GetRaw returns a snapshot even when it is dismissed from the UI. It is for
+// lifecycle coordination only; HTTP handlers should continue to use Get.
+func (s *Store) GetRaw(terminalID string) (Snapshot, bool) {
+	terminalID = strings.TrimSpace(terminalID)
+	if s == nil || terminalID == "" {
+		return Snapshot{}, false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	snapshot, ok := s.byID[terminalID]
+	return snapshot, ok
 }
 
 func (s *Store) RemoveSession(sessionID string) {
@@ -331,7 +410,8 @@ func (s *Store) Dismiss(terminalID string) bool {
 	if _, ok := s.byID[terminalID]; !ok {
 		return false
 	}
-	s.removeTerminalLocked(terminalID)
+	// Dismissal is presentation-only. Keep the snapshot's ownership metadata so
+	// a live or closing tmux process remains visible to the lease/reaper path.
 	s.dismissed[terminalID] = struct{}{}
 	return true
 }
@@ -380,8 +460,52 @@ func (s *Store) MarkStale(terminalID string) (Snapshot, bool) {
 	now := time.Now()
 	snapshot.Active = false
 	snapshot.State = "stale"
+	snapshot.ProcessState = "closed"
+	snapshot.SnapshotKind = "archived"
 	snapshot.TmuxSession = ""
 	snapshot.UpdatedAt = now
+	s.byID[terminalID] = snapshot
+	return snapshot, true
+}
+
+// MarkArchived records that the backing process was deliberately reconciled
+// and closed while retaining the read-only capture until its snapshot deadline.
+func (s *Store) MarkArchived(terminalID, reason string) (Snapshot, bool) {
+	snapshot, ok := s.MarkStale(terminalID)
+	if !ok {
+		return Snapshot{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, ok = s.byID[strings.TrimSpace(terminalID)]
+	if !ok {
+		return Snapshot{}, false
+	}
+	snapshot.CloseReason = strings.TrimSpace(reason)
+	snapshot.UpdatedAt = time.Now()
+	s.byID[snapshot.TerminalID] = snapshot
+	return snapshot, true
+}
+
+// MarkProcessClosed separates process liveness from the terminal outcome. It
+// preserves completed/failed state while converting the capture to an archive.
+func (s *Store) MarkProcessClosed(terminalID, reason string) (Snapshot, bool) {
+	terminalID = strings.TrimSpace(terminalID)
+	if s == nil || terminalID == "" {
+		return Snapshot{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snapshot, ok := s.byID[terminalID]
+	if !ok {
+		return Snapshot{}, false
+	}
+	snapshot.Active = false
+	snapshot.ProcessState = "closed"
+	snapshot.SnapshotKind = "archived"
+	snapshot.CloseReason = strings.TrimSpace(reason)
+	snapshot.TmuxSession = ""
+	snapshot.UpdatedAt = time.Now()
 	s.byID[terminalID] = snapshot
 	return snapshot, true
 }
@@ -421,6 +545,8 @@ func (s *Store) UpsertStaticSnapshot(sessionID string, snapshot Snapshot) (Snaps
 	snapshot.OwnerID = ownerID
 	snapshot.TmuxSession = ""
 	snapshot.Active = false
+	snapshot.ProcessState = "closed"
+	snapshot.SnapshotKind = "archived"
 	if strings.TrimSpace(snapshot.State) == "" || snapshot.State == "running" || snapshot.State == "closing" {
 		snapshot.State = "stale"
 	}
@@ -480,6 +606,10 @@ func (s *Store) markTerminalState(terminalID, state string) (Snapshot, bool) {
 	now := time.Now()
 	snapshot.Active = false
 	snapshot.State = state
+	if strings.TrimSpace(snapshot.TmuxSession) != "" {
+		snapshot.ProcessState = "closing"
+		snapshot.SnapshotKind = "live"
+	}
 	snapshot.ClosesAt = nil
 	snapshot.RetentionSeconds = 0
 	snapshot.UpdatedAt = now
@@ -630,9 +760,6 @@ func (s *Store) upsertTerminal(sessionID string, event storeevents.Event, metada
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.dismissed[terminalID]; ok {
-		return
-	}
 
 	current, exists := s.byID[terminalID]
 	if forcedAt, forced := s.forcedInactive[terminalID]; forced {
@@ -725,6 +852,8 @@ func (s *Store) upsertTerminal(sessionID string, event storeevents.Event, metada
 	current.TmuxSession = firstNonEmpty(
 		stringValue(metadata, "tmux_session"),
 		stringValue(metadata, "tmux_session_name"),
+		stringValue(metadata, "pi_interactive_session"),
+		stringValue(metadata, "agy_interactive_session"),
 		stringValue(metadata, "claude_code_interactive_session"),
 		stringValue(metadata, "codex_interactive_session"),
 		stringValue(metadata, "gemini_interactive_session"),
@@ -746,6 +875,9 @@ func (s *Store) upsertTerminal(sessionID string, event storeevents.Event, metada
 	current.ChunkIndex = chunkIndex
 	current.Active = true
 	current.State = terminalStateFromContent(lifecycleContent, true)
+	current.ProcessState = "live"
+	current.SnapshotKind = "live"
+	current.CloseReason = ""
 	current.ClosesAt = nil
 	current.RetentionSeconds = 0
 	previousStatus := current.Status
@@ -1080,6 +1212,7 @@ func (s *Store) removeTerminalLocked(terminalID string) {
 	}
 	delete(s.byID, terminalID)
 	delete(s.forcedInactive, terminalID)
+	delete(s.dismissed, terminalID)
 	if snapshot.SessionID == "" {
 		return
 	}
@@ -1226,6 +1359,9 @@ func (s *Store) markInactive(sessionID, ownerID string, metadata map[string]inte
 	if state == "running" {
 		snapshot.Active = true
 		snapshot.State = "running"
+		snapshot.ProcessState = "live"
+		snapshot.SnapshotKind = "live"
+		snapshot.CloseReason = ""
 		snapshot.ClosesAt = nil
 		snapshot.RetentionSeconds = 0
 		snapshot.UpdatedAt = now
@@ -1233,6 +1369,10 @@ func (s *Store) markInactive(sessionID, ownerID string, metadata map[string]inte
 		return
 	}
 	snapshot.Active = false
+	if strings.TrimSpace(snapshot.TmuxSession) != "" {
+		snapshot.ProcessState = "closing"
+		snapshot.SnapshotKind = "live"
+	}
 	// Retention is caller-decided: whoever emits the streaming events
 	// attaches terminal_retention_seconds to metadata when the
 	// terminal is transient (workflow step, sub-agent, one-shot CLI
@@ -1279,6 +1419,8 @@ func (s *Store) findInactiveTargetLocked(sessionID, ownerID string, metadata map
 	tmuxSession := firstNonEmpty(
 		stringValue(metadata, "tmux_session"),
 		stringValue(metadata, "tmux_session_name"),
+		stringValue(metadata, "pi_interactive_session"),
+		stringValue(metadata, "agy_interactive_session"),
 		stringValue(metadata, "claude_code_interactive_session"),
 		stringValue(metadata, "codex_interactive_session"),
 		stringValue(metadata, "gemini_interactive_session"),
@@ -2108,6 +2250,7 @@ func (s *Store) handleStatusLine(sessionID string, event storeevents.Event) {
 		stringValue(statusMeta, "tmux_session"),
 		stringValue(statusMeta, "tmux_session_name"),
 		stringValue(statusMeta, "pi_interactive_session"),
+		stringValue(statusMeta, "agy_interactive_session"),
 		stringValue(statusMeta, "claude_code_interactive_session"),
 		stringValue(statusMeta, "codex_interactive_session"),
 		stringValue(statusMeta, "gemini_interactive_session"),

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -314,7 +314,9 @@ func (s *Store) SessionHasBusyCodingTmux(sessionID string) bool {
 	if s == nil {
 		return false
 	}
-	for _, snapshot := range s.List(sessionID) {
+	// Dismissal only hides a terminal from the UI. A dismissed live pane still
+	// owns runtime work and must remain visible to busy/input routing.
+	for _, snapshot := range s.ListRaw(sessionID) {
 		if strings.TrimSpace(snapshot.TmuxSession) == "" {
 			continue
 		}
@@ -346,7 +348,7 @@ func (s *Store) SessionHasRetainedCodingTmux(sessionID string) bool {
 	if s == nil || sessionID == "" {
 		return false
 	}
-	for _, snapshot := range s.List(sessionID) {
+	for _, snapshot := range s.ListRaw(sessionID) {
 		if !snapshot.Active {
 			continue
 		}
@@ -471,19 +473,24 @@ func (s *Store) MarkStale(terminalID string) (Snapshot, bool) {
 // MarkArchived records that the backing process was deliberately reconciled
 // and closed while retaining the read-only capture until its snapshot deadline.
 func (s *Store) MarkArchived(terminalID, reason string) (Snapshot, bool) {
-	snapshot, ok := s.MarkStale(terminalID)
-	if !ok {
+	terminalID = strings.TrimSpace(terminalID)
+	if s == nil || terminalID == "" {
 		return Snapshot{}, false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	snapshot, ok = s.byID[strings.TrimSpace(terminalID)]
+	snapshot, ok := s.byID[terminalID]
 	if !ok {
 		return Snapshot{}, false
 	}
+	snapshot.Active = false
+	snapshot.State = "stale"
+	snapshot.ProcessState = "closed"
+	snapshot.SnapshotKind = "archived"
+	snapshot.TmuxSession = ""
 	snapshot.CloseReason = strings.TrimSpace(reason)
 	snapshot.UpdatedAt = time.Now()
-	s.byID[snapshot.TerminalID] = snapshot
+	s.byID[terminalID] = snapshot
 	return snapshot, true
 }
 

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -2362,6 +2362,33 @@ func TestSessionHasRetainedCodingTmuxDoesNotRequireBusyContent(t *testing.T) {
 	}
 }
 
+func TestDismissedLiveCodingTmuxRemainsOperationallyVisible(t *testing.T) {
+	store := NewStore()
+	store.HandleEvent("session-1", terminalEventWithMetadata(
+		"main:session-1",
+		cursorBusyPaneFixture,
+		0,
+		map[string]interface{}{
+			"tmux_session":   "mlp-codex-cli-dismissed",
+			"execution_kind": "main_agent",
+		},
+		time.Now(),
+	))
+	terminalID := "session-1:main:session-1"
+	if !store.Dismiss(terminalID) {
+		t.Fatal("expected terminal dismissal to succeed")
+	}
+	if store.SessionHasBusyCodingTmux("session-1") != true {
+		t.Fatal("dismissed live pane must remain visible to busy routing")
+	}
+	if store.SessionHasRetainedCodingTmux("session-1") != true {
+		t.Fatal("dismissed live pane must remain visible to lifecycle routing")
+	}
+	if _, visible := store.Get(terminalID); visible {
+		t.Fatal("dismissed pane should remain hidden from presentation")
+	}
+}
+
 func TestDeriveStatusLabelsCursor(t *testing.T) {
 	status := DeriveStatus(cursorBusyPaneFixture, map[string]interface{}{"provider": "cursor-cli"})
 	if status.ProviderLabel != "Cursor CLI" {

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -1923,20 +1923,26 @@ func TestStoreLaterFailureOverridesEarlierCompletionText(t *testing.T) {
 	}
 }
 
-func TestStoreDismissRemovesTerminalAndSuppressesFutureChunks(t *testing.T) {
+func TestStoreDismissHidesTerminalButRetainsOwnershipAndFutureChunks(t *testing.T) {
 	store := NewStore()
 	store.HandleEvent("session-1", terminalEvent("streaming_chunk", "exec-1", "screen one", 1))
 
 	if !store.Dismiss("session-1:exec-1") {
-		t.Fatalf("expected dismiss to remove terminal")
+		t.Fatalf("expected dismiss to hide terminal")
 	}
 	if _, ok := store.Get("session-1:exec-1"); ok {
-		t.Fatalf("terminal should be removed after dismiss")
+		t.Fatalf("terminal should be hidden after dismiss")
+	}
+	if raw, ok := store.GetRaw("session-1:exec-1"); !ok || raw.Content != "screen one" {
+		t.Fatalf("dismissal lost ownership snapshot: ok=%v content=%q", ok, raw.Content)
 	}
 
 	store.HandleEvent("session-1", terminalEvent("streaming_chunk", "exec-1", "screen two", 2))
 	if _, ok := store.Get("session-1:exec-1"); ok {
-		t.Fatalf("dismissed terminal should not be recreated by future chunks")
+		t.Fatalf("dismissed terminal should stay hidden")
+	}
+	if raw, ok := store.GetRaw("session-1:exec-1"); !ok || raw.Content != "screen two" {
+		t.Fatalf("future chunk did not update hidden ownership snapshot: ok=%v content=%q", ok, raw.Content)
 	}
 }
 

--- a/docs/core/terminal_lifecycle.md
+++ b/docs/core/terminal_lifecycle.md
@@ -1,0 +1,40 @@
+# Terminal lifecycle
+
+Runloop tracks a coding-agent terminal as two separate resources:
+
+1. **Process lease**: ownership of the live tmux session.
+2. **Terminal snapshot**: the read-only capture rendered in the UI.
+
+The process lease is authoritative for cleanup. Hiding or expiring a snapshot
+does not release a live process. Bounded workflow-step processes receive a
+short shutdown grace after completion, while their snapshots can remain visible
+for the longer provider display-retention period. Main-agent sessions are
+persistent and use the idle backstop instead of the bounded deadline.
+
+Every observed coding-agent tmux session is tagged with:
+
+- `@runloop_instance_id`
+- `@runloop_owner_pid`
+- `@runloop_owner_started_at`
+- `@runloop_heartbeat`
+
+Startup recovery only removes tagged sessions whose owner PID/start-time pair
+is no longer live. It preserves untagged legacy sessions and sessions owned by
+another running backend or test process.
+
+Terminal API state exposes:
+
+- `process_state`: `live`, `closing`, or `closed`
+- `snapshot_kind`: `live` or `archived`
+- `close_reason`: the lifecycle reconciliation reason, when available
+
+Operator actions follow these semantics:
+
+- **Dismiss** hides only the snapshot.
+- **Complete** asks the provider to finish and moves the lease toward closing.
+- **Fail** closes the process and records a failed archived capture.
+- **Kill** force-closes the process and records a failed archived capture.
+
+SSE event buffers are retained for 30 minutes after a session reaches a terminal
+state. Session identity remains available for 24 hours so chat history can be
+resumed without retaining the full event stream.

--- a/frontend/src/components/TerminalCenter.tsx
+++ b/frontend/src/components/TerminalCenter.tsx
@@ -1002,6 +1002,9 @@ function formatCloseCountdown(seconds: number): string {
 
 function terminalState(terminal: TerminalSnapshot): string {
   if (isArchivedTurnTerminal(terminal)) return 'completed'
+  if (terminal.snapshot_kind === 'archived' && terminal.process_state === 'closed') {
+    return terminal.state === 'failed' ? 'failed' : 'archived'
+  }
   if (!terminal.active && terminalSecondsUntilClose(terminal) > 0) return 'closing'
   if (terminal.state === 'closing' && terminalSecondsUntilClose(terminal) <= 0) return 'completed'
   if (terminal.active && terminal.state === 'idle') return 'running'
@@ -1019,6 +1022,8 @@ function terminalStateLabel(terminal: TerminalSnapshot): string {
       return 'failed'
     case 'stale':
       return 'stale'
+    case 'archived':
+      return 'archived'
     case 'closing':
       // The tmux process is already gone (killed 30s after task end);
       // what this countdown measures is when the read-only snapshot
@@ -1040,6 +1045,10 @@ function terminalStateDescription(terminal: TerminalSnapshot): string {
       return 'Failed: the coding agent or automation step ended with an error.'
     case 'stale':
       return 'Stale: no terminal updates were received for a long time; this pane may have lost its lifecycle event.'
+    case 'archived':
+      return terminal.close_reason
+        ? `Archived terminal capture: ${terminal.close_reason}. The tmux process is closed.`
+        : 'Archived terminal capture: the tmux process is closed and this view is read-only.'
     case 'closing':
       return `Snapshot: the agent finished and this read-only view will be removed in ${formatCloseCountdown(terminalSecondsUntilClose(terminal))}.`
     default:
@@ -1057,6 +1066,8 @@ function terminalDotClass(terminal: TerminalSnapshot, theme: TerminalTheme): str
       return 'bg-red-400'
     case 'stale':
       return 'bg-zinc-400'
+    case 'archived':
+      return theme.dotCompleted
     case 'closing':
       return theme.dotClosing
     default:
@@ -1069,6 +1080,8 @@ function terminalStateTextClass(terminal: TerminalSnapshot, theme: TerminalTheme
     case 'running':
       return theme.stateRunning
     case 'completed':
+      return theme.stateCompleted
+    case 'archived':
       return theme.stateCompleted
     case 'failed':
       return 'text-red-300'
@@ -1147,6 +1160,9 @@ function terminalDebugText(terminal: TerminalSnapshot): string {
     terminal.execution_kind ? `execution_kind=${terminal.execution_kind}` : '',
     terminal.step_type ? `step_type=${terminal.step_type}` : '',
     terminal.state ? `state=${terminal.state}` : '',
+    terminal.process_state ? `process_state=${terminal.process_state}` : '',
+    terminal.snapshot_kind ? `snapshot_kind=${terminal.snapshot_kind}` : '',
+    terminal.close_reason ? `close_reason=${terminal.close_reason}` : '',
     terminal.closes_at ? `closes_at=${terminal.closes_at}` : '',
     terminal.retention_seconds ? `retention_seconds=${terminal.retention_seconds}` : '',
     `title=${formatTerminalTitle(terminal)}`,

--- a/frontend/src/services/api-types.ts
+++ b/frontend/src/services/api-types.ts
@@ -596,6 +596,9 @@ export interface TerminalSnapshot {
   chunk_index: number
   active: boolean
   state?: 'running' | 'completed' | 'failed' | 'idle' | 'closing' | 'stale' | string
+  process_state?: 'live' | 'closing' | 'closed' | string
+  snapshot_kind?: 'live' | 'archived' | string
+  close_reason?: string
   closes_at?: string
   retention_seconds?: number
   status: TerminalStatus


### PR DESCRIPTION
## Summary
- add a backend `TerminalLeaseRegistry` so live tmux ownership is independent from rendered terminal snapshots
- tag tmux sessions with backend instance/PID/start-time ownership and replace unsafe prefix-only startup cleanup with dead-owner recovery
- make dismiss presentation-only, keep bounded process grace separate from snapshot retention, and archive only after confirmed process closure
- route the reaper, rate-limit watchdog, session stop, and operator fail/kill actions through the lease lifecycle
- expose `process_state`, `snapshot_kind`, and `close_reason` to label archived captures in the UI
- align SSE retention to 30 minutes and document the lifecycle contract

## Verification
- `go test -race ./internal/terminalleases ./internal/terminals ./cmd/server -run ... -count=1`
- `go vet ./internal/terminalleases ./internal/terminals ./cmd/server`
- `npm run build`
- repository pre-commit suite: golangci-lint, frontend, agent, workspace, and Electron builds

## Scope
This is the builder-side foundation for #141. The issue should remain open for cross-repo Pi/Agy generation metadata normalization and mixed-provider lifecycle E2E coverage.

Related to #141.