### PR TITLE
Enforce fail-closed workspace permission guards

### DIFF
--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -6646,6 +6646,7 @@ func (api *StreamingAPI) cleanupInactiveSessionsAt(now time.Time) {
 	}
 
 	for _, sessionID := range sessionsToEvictRuntime {
+		workspace.ClearSessionShellConfig(sessionID)
 		if api.runtimeCoordinator != nil {
 			api.runtimeCoordinator.Evict(sessionID)
 		}

--- a/agent_go/cmd/server/session_lifecycle.go
+++ b/agent_go/cmd/server/session_lifecycle.go
@@ -397,6 +397,14 @@ func (api *StreamingAPI) handleClearSession(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Clearing a live session would remove its shell permission contract while
+	// the agent can still issue tool calls. Stop the session first so cancellation
+	// and tmux teardown complete before its guard is discarded.
+	if api.sessionHasActiveWork(sessionID) {
+		http.Error(w, "Session is still active; stop it before clearing conversation history", http.StatusConflict)
+		return
+	}
+
 	// Clear conversation and coding-agent resume state guarded by the same
 	// mutex used by query/resume paths.
 	api.conversationMux.Lock()
@@ -425,4 +433,16 @@ func (api *StreamingAPI) handleClearSession(w http.ResponseWriter, r *http.Reque
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Session cleared (conversation history and orchestrator state removed)"))
+}
+
+func (api *StreamingAPI) sessionHasActiveWork(sessionID string) bool {
+	if api == nil || strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	if api.hasActiveTurnCancel(sessionID) || api.sessionHasLiveCodingTmux(sessionID) ||
+		api.hasRunningTrackedExecutionForSession(sessionID) || api.isSessionBusy(sessionID) ||
+		api.isSyntheticTurn(sessionID) {
+		return true
+	}
+	return api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID)
 }

--- a/agent_go/cmd/server/session_lifecycle.go
+++ b/agent_go/cmd/server/session_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"log"
 	"mcp-agent-builder-go/agent_go/pkg/browser"
+	"mcp-agent-builder-go/agent_go/pkg/workspace"
 	"net/http"
 	"os"
 	"strings"
@@ -342,6 +343,11 @@ func (api *StreamingAPI) handleStopSession(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Permission state is scoped to the lifetime of the chat session. Keeping it
+	// after stop can leak stale workspace roots, secrets, or browser grants into a
+	// later session that reuses the same ID.
+	workspace.ClearSessionShellConfig(sessionID)
+
 	// Note: Conversation history and orchestrator state are preserved to allow resuming the conversation
 	// Use /api/session/clear if you want to clear conversation history
 
@@ -415,6 +421,7 @@ func (api *StreamingAPI) handleClearSession(w http.ResponseWriter, r *http.Reque
 
 	// Kill headless browser processes for this session
 	api.cleanupBrowserSessions(sessionID)
+	workspace.ClearSessionShellConfig(sessionID)
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Session cleared (conversation history and orchestrator state removed)"))

--- a/agent_go/cmd/server/shutdown_cleanup_test.go
+++ b/agent_go/cmd/server/shutdown_cleanup_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	agent "mcp-agent-builder-go/agent_go/pkg/agentwrapper"
+	"mcp-agent-builder-go/agent_go/pkg/workspace"
 )
 
 type shutdownTestWorkshopSession struct {
@@ -95,6 +96,9 @@ func TestCancelActiveWorkForShutdown(t *testing.T) {
 }
 
 func TestHandleStopSessionCancelsActiveWorkAndPreventsPaneReuse(t *testing.T) {
+	workspace.SetSessionFolderGuard("session-1", []string{"Workflow/test"}, []string{"Workflow/test"})
+	defer workspace.ClearSessionShellConfig("session-1")
+
 	agentCanceled := false
 	workflowCanceled := false
 	backgroundCanceled := false
@@ -223,6 +227,9 @@ func TestHandleStopSessionCancelsActiveWorkAndPreventsPaneReuse(t *testing.T) {
 	}
 	if _, ok := api.workflowObjectives["session-1"]; ok {
 		t.Fatalf("workflow objective was not cleared")
+	}
+	if got := workspace.GetSessionShellConfig("session-1"); got != nil {
+		t.Fatalf("session shell config was not cleared: %+v", got)
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "Session stopped") {
 		t.Fatalf("unexpected stop response body: %q", body)

--- a/agent_go/cmd/server/shutdown_cleanup_test.go
+++ b/agent_go/cmd/server/shutdown_cleanup_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/manishiitg/multi-llm-provider-go/llmtypes"
 	agent "mcp-agent-builder-go/agent_go/pkg/agentwrapper"
 	"mcp-agent-builder-go/agent_go/pkg/workspace"
 )
@@ -312,6 +313,40 @@ func TestHandleCancelCurrentTurnRecordsInterruptionBetweenTurns(t *testing.T) {
 	}
 	if !api.consumeSessionTurnInterrupted(sessionID) {
 		t.Fatalf("cancel between turns did not preserve the user's sequence-stop intent")
+	}
+}
+
+func TestHandleClearSessionRefusesActiveWorkAndPreservesGuard(t *testing.T) {
+	const sessionID = "session-clear-active"
+	workspace.SetSessionFolderGuard(sessionID, []string{"Workflow/test"}, []string{"Workflow/test"})
+	defer workspace.ClearSessionShellConfig(sessionID)
+
+	api := &StreamingAPI{
+		agentCancelFuncs: map[string]context.CancelFunc{
+			sessionID: func() {},
+		},
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+		conversationHistory: map[string][]llmtypes.MessageContent{
+			sessionID: {},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/session/clear", nil)
+	req.Header.Set("X-Session-ID", sessionID)
+	rec := httptest.NewRecorder()
+
+	api.handleClearSession(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("clear status = %d body=%s, want 409", rec.Code, rec.Body.String())
+	}
+	if workspace.GetSessionShellConfig(sessionID) == nil {
+		t.Fatal("active clear removed the session permission guard")
+	}
+	if _, ok := api.conversationHistory[sessionID]; !ok {
+		t.Fatal("active clear removed conversation history")
 	}
 }
 

--- a/agent_go/pkg/browser/executor.go
+++ b/agent_go/pkg/browser/executor.go
@@ -324,7 +324,8 @@ func (e *Executor) HandleAgentBrowser(ctx context.Context, args map[string]inter
 	}
 
 	// Folder guard priority: session config > context system 1 > context system 2
-	if sessionCfg != nil && len(sessionCfg.WritePaths) > 0 {
+	if sessionCfg != nil && (sessionCfg.FolderGuardSet || len(sessionCfg.ReadPaths) > 0 || len(sessionCfg.WritePaths) > 0 ||
+		len(sessionCfg.BlockedPaths) > 0 || len(sessionCfg.BlockedWritePaths) > 0) {
 		readPaths := sessionCfg.WritePaths
 		if len(sessionCfg.ReadPaths) > 0 {
 			readPaths = common.DeduplicateStrings(append(sessionCfg.ReadPaths, sessionCfg.WritePaths...))
@@ -333,9 +334,10 @@ func (e *Executor) HandleAgentBrowser(ctx context.Context, args map[string]inter
 			Enabled:           true,
 			WritePaths:        sessionCfg.WritePaths,
 			ReadPaths:         readPaths,
+			BlockedPaths:      sessionCfg.BlockedPaths,
 			BlockedWritePaths: sessionCfg.BlockedWritePaths,
 		}
-	} else if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok && len(allowedWrites) > 0 {
+	} else if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok {
 		// Context System 1: chat/plan/prototype mode
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
 		readPaths := allowedWrites
@@ -343,11 +345,13 @@ func (e *Executor) HandleAgentBrowser(ctx context.Context, args map[string]inter
 			readPaths = common.DeduplicateStrings(append(ctxReads, allowedWrites...))
 		}
 		folderGuard = &FolderGuardConfig{
-			Enabled:    true,
-			WritePaths: allowedWrites,
-			ReadPaths:  readPaths,
+			Enabled:           true,
+			WritePaths:        allowedWrites,
+			ReadPaths:         readPaths,
+			BlockedPaths:      browserContextGuardPaths(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: browserContextGuardPaths(ctx, common.FolderGuardBlockedWritePathsKey),
 		}
-	} else if ctxWrites, ok := ctx.Value(common.FolderGuardWritePathsKey).([]string); ok && len(ctxWrites) > 0 {
+	} else if ctxWrites, ok := ctx.Value(common.FolderGuardWritePathsKey).([]string); ok {
 		// Context System 2: workflow orchestrator
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
 		readPaths := ctxWrites
@@ -355,10 +359,15 @@ func (e *Executor) HandleAgentBrowser(ctx context.Context, args map[string]inter
 			readPaths = common.DeduplicateStrings(append(ctxReads, ctxWrites...))
 		}
 		folderGuard = &FolderGuardConfig{
-			Enabled:    true,
-			WritePaths: ctxWrites,
-			ReadPaths:  readPaths,
+			Enabled:           true,
+			WritePaths:        ctxWrites,
+			ReadPaths:         readPaths,
+			BlockedPaths:      browserContextGuardPaths(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: browserContextGuardPaths(ctx, common.FolderGuardBlockedWritePathsKey),
 		}
+	}
+	if folderGuard != nil && len(folderGuard.ReadPaths) == 0 && len(folderGuard.WritePaths) == 0 {
+		return "", fmt.Errorf("ACCESS DENIED: agent_browser has no granted workspace paths")
 	}
 
 	// Execute via client
@@ -559,6 +568,11 @@ func (e *Executor) HandleAgentBrowser(ctx context.Context, args map[string]inter
 	}
 
 	return output, nil
+}
+
+func browserContextGuardPaths(ctx context.Context, key common.ContextKey) []string {
+	paths, _ := ctx.Value(key).([]string)
+	return append([]string(nil), paths...)
 }
 
 func (e *Executor) listCDPTabs(ctx context.Context, session, cdpURL string, opts *ExecuteOptions) (string, error) {

--- a/agent_go/pkg/common/types.go
+++ b/agent_go/pkg/common/types.go
@@ -10,10 +10,11 @@ import (
 
 // FolderGuardConfig represents folder access restrictions
 type FolderGuardConfig struct {
-	Enabled      bool     `json:"enabled"`
-	ReadPaths    []string `json:"read_paths"`
-	WritePaths   []string `json:"write_paths"`
-	BlockedPaths []string `json:"blocked_paths"`
+	Enabled           bool     `json:"enabled"`
+	ReadPaths         []string `json:"read_paths"`
+	WritePaths        []string `json:"write_paths"`
+	BlockedPaths      []string `json:"blocked_paths"`
+	BlockedWritePaths []string `json:"blocked_write_paths,omitempty"`
 }
 
 // ContextKey is a custom type for context keys to avoid collisions
@@ -26,6 +27,8 @@ const (
 	FolderGuardWritePathsKey ContextKey = "folder_guard_write_paths"
 	// FolderGuardBlockedPathsKey is the context key for blocked paths (deny list)
 	FolderGuardBlockedPathsKey ContextKey = "folder_guard_blocked_paths"
+	// FolderGuardBlockedWritePathsKey is the context key for write-only deny paths.
+	FolderGuardBlockedWritePathsKey ContextKey = "folder_guard_blocked_write_paths"
 	// FolderGuardAllowedWriteFolderKey is the context key for allowed write folders ([]string) in chat/plan mode
 	FolderGuardAllowedWriteFolderKey ContextKey = "folder_guard_allowed_write_folder"
 	// UserIDKey is the context key for the user ID (used for auth/database scoping)
@@ -100,15 +103,10 @@ func GrantSessionCDPHostDownloadsReadOnly(sessionID, browserMode string) string 
 	if strings.TrimSpace(sessionID) == "" || hostDownloads == "" {
 		return ""
 	}
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.ReadPaths = DeduplicateStrings(append(cfg.ReadPaths, hostDownloads))
-	cfg.BlockedWritePaths = DeduplicateStrings(append(cfg.BlockedWritePaths, hostDownloads))
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.ReadPaths = DeduplicateStrings(append(cfg.ReadPaths, hostDownloads))
+		cfg.BlockedWritePaths = DeduplicateStrings(append(cfg.BlockedWritePaths, hostDownloads))
+	})
 	log.Printf("[SHELL] Granted read-only host Downloads for CDP session %s: %s", sessionID, hostDownloads)
 	return hostDownloads
 }
@@ -148,8 +146,10 @@ func PopulateMCPBridgeShortEnv(env map[string]string) {
 // agent can read plan.json but not raw-write it.
 type SessionShellConfig struct {
 	WorkingDir        string   // Default working directory (relative to workspace-docs)
+	FolderGuardSet    bool     // An explicit guard exists; empty capabilities must fail closed
 	ReadPaths         []string // Folder guard read paths for Isolator
 	WritePaths        []string // Folder guard write paths for Isolator
+	BlockedPaths      []string // Deny reads and writes
 	BlockedWritePaths []string // Deny writes; reads allowed (flows to FolderGuardConfig.BlockedWritePaths)
 	BrowserMode       string   // Resolved browser mode: "playwright", "headless", "cdp", ""
 	BrowserSessionID  string   // Shared browser identity for browser tools when "default" session is used
@@ -165,16 +165,50 @@ var (
 	sessionShellConfigsMu sync.RWMutex
 )
 
-// SetSessionWorkingDir sets the default working directory for a session.
-func SetSessionWorkingDir(sessionID, dir string) {
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneSessionShellConfig(cfg *SessionShellConfig) *SessionShellConfig {
+	if cfg == nil {
+		return &SessionShellConfig{}
+	}
+	copy := *cfg
+	copy.ReadPaths = cloneStrings(cfg.ReadPaths)
+	copy.WritePaths = cloneStrings(cfg.WritePaths)
+	copy.BlockedPaths = cloneStrings(cfg.BlockedPaths)
+	copy.BlockedWritePaths = cloneStrings(cfg.BlockedWritePaths)
+	copy.Env = cloneStringMap(cfg.Env)
+	return &copy
+}
+
+func updateSessionShellConfig(sessionID string, update func(*SessionShellConfig)) {
 	sessionShellConfigsMu.Lock()
 	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.WorkingDir = dir
+	cfg := cloneSessionShellConfig(sessionShellConfigs[sessionID])
+	update(cfg)
+	sessionShellConfigs[sessionID] = cfg
+}
+
+// SetSessionWorkingDir sets the default working directory for a session.
+func SetSessionWorkingDir(sessionID, dir string) {
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.WorkingDir = dir
+	})
 	log.Printf("[SHELL] Set default working dir for session %s: %s", sessionID, dir)
 }
 
@@ -183,16 +217,21 @@ func SetSessionWorkingDir(sessionID, dir string) {
 // to set those independently, so existing callers don't need updating when a
 // session adds a deny prefix later.
 func SetSessionFolderGuard(sessionID string, readPaths, writePaths []string) {
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.ReadPaths = readPaths
-	cfg.WritePaths = writePaths
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.FolderGuardSet = true
+		cfg.ReadPaths = cloneStrings(readPaths)
+		cfg.WritePaths = cloneStrings(writePaths)
+	})
 	log.Printf("[SHELL] Set folder guard for session %s: read=%v write=%v", sessionID, readPaths, writePaths)
+}
+
+// SetSessionFolderGuardBlockedPaths sets hard deny prefixes for both reads and writes.
+func SetSessionFolderGuardBlockedPaths(sessionID string, blockedPaths []string) {
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.FolderGuardSet = true
+		cfg.BlockedPaths = cloneStrings(blockedPaths)
+	})
+	log.Printf("[SHELL] Set folder guard blocked paths for session %s: %v", sessionID, blockedPaths)
 }
 
 // SetSessionFolderGuardBlockedWritePaths sets the write-denied prefix list for
@@ -203,14 +242,10 @@ func SetSessionFolderGuard(sessionID string, readPaths, writePaths []string) {
 // #workflow setup to grant `Workflow/<name>/` as a broad write prefix while
 // denying writes to `Workflow/<name>/planning/`.
 func SetSessionFolderGuardBlockedWritePaths(sessionID string, blockedWritePaths []string) {
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.BlockedWritePaths = blockedWritePaths
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.FolderGuardSet = true
+		cfg.BlockedWritePaths = cloneStrings(blockedWritePaths)
+	})
 	log.Printf("[SHELL] Set folder guard blocked-write paths for session %s: %v", sessionID, blockedWritePaths)
 }
 
@@ -222,21 +257,14 @@ func SetSessionShellEnv(sessionID string, env map[string]string) {
 	if len(env) == 0 {
 		return
 	}
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	merged := make(map[string]string, len(cfg.Env)+len(env))
-	for k, v := range cfg.Env {
-		merged[k] = v
-	}
-	for k, v := range env {
-		merged[k] = v
-	}
-	cfg.Env = merged
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string, len(env))
+		}
+		for key, value := range env {
+			cfg.Env[key] = value
+		}
+	})
 	log.Printf("[SHELL] Set %d shell env var(s) for session %s", len(env), sessionID)
 }
 
@@ -259,14 +287,9 @@ func GetSessionShellEnv(sessionID string) map[string]string {
 // SetSessionBrowserMode stores the resolved browser mode for a session.
 // Used by execute_shell_command to show context-aware error messages when blocking agent-browser CLI calls.
 func SetSessionBrowserMode(sessionID, mode string) {
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.BrowserMode = mode
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.BrowserMode = mode
+	})
 	log.Printf("[SHELL] Set browser mode for session %s: %s", sessionID, mode)
 }
 
@@ -286,14 +309,9 @@ func GetSessionBrowserMode(sessionID string) string {
 // Browser tools can use this to converge on a stable browser state while keeping tool routing
 // scoped to the original chat/workflow session.
 func SetSessionBrowserSessionID(sessionID, browserSessionID string) {
-	sessionShellConfigsMu.Lock()
-	defer sessionShellConfigsMu.Unlock()
-	cfg := sessionShellConfigs[sessionID]
-	if cfg == nil {
-		cfg = &SessionShellConfig{}
-		sessionShellConfigs[sessionID] = cfg
-	}
-	cfg.BrowserSessionID = browserSessionID
+	updateSessionShellConfig(sessionID, func(cfg *SessionShellConfig) {
+		cfg.BrowserSessionID = browserSessionID
+	})
 	log.Printf("[SHELL] Set browser session ID for session %s: %s", sessionID, browserSessionID)
 }
 
@@ -304,13 +322,14 @@ func SetSessionBrowserSessionID(sessionID, browserSessionID string) {
 // write restrictions AND the same blocked-write exceptions. Returns true if a
 // guard was copied.
 func CopySessionFolderGuard(fromSessionID, toSessionID string) bool {
-	sessionShellConfigsMu.RLock()
-	src := sessionShellConfigs[fromSessionID]
-	sessionShellConfigsMu.RUnlock()
-	if src == nil || (len(src.ReadPaths) == 0 && len(src.WritePaths) == 0) {
+	src := GetSessionShellConfig(fromSessionID)
+	if src == nil || (!src.FolderGuardSet && len(src.ReadPaths) == 0 && len(src.WritePaths) == 0 && len(src.BlockedPaths) == 0 && len(src.BlockedWritePaths) == 0) {
 		return false
 	}
 	SetSessionFolderGuard(toSessionID, src.ReadPaths, src.WritePaths)
+	if len(src.BlockedPaths) > 0 {
+		SetSessionFolderGuardBlockedPaths(toSessionID, src.BlockedPaths)
+	}
 	if len(src.BlockedWritePaths) > 0 {
 		SetSessionFolderGuardBlockedWritePaths(toSessionID, src.BlockedWritePaths)
 	}
@@ -329,7 +348,11 @@ func ClearSessionShellConfig(sessionID string) {
 func GetSessionShellConfig(sessionID string) *SessionShellConfig {
 	sessionShellConfigsMu.RLock()
 	defer sessionShellConfigsMu.RUnlock()
-	return sessionShellConfigs[sessionID]
+	cfg := sessionShellConfigs[sessionID]
+	if cfg == nil {
+		return nil
+	}
+	return cloneSessionShellConfig(cfg)
 }
 
 // ResolveBrowserSessionID returns the effective browser session to use for browser tools.

--- a/agent_go/pkg/common/types_test.go
+++ b/agent_go/pkg/common/types_test.go
@@ -79,3 +79,56 @@ func TestSetSessionShellEnvMergesAndCopies(t *testing.T) {
 		t.Fatal("nil env should be a no-op")
 	}
 }
+
+func TestSessionShellConfigIsImmutableAcrossCallers(t *testing.T) {
+	sessionID := "immutable-shell-config"
+	defer ClearSessionShellConfig(sessionID)
+	reads := []string{"Workflow/demo"}
+	writes := []string{"Workflow/demo/output"}
+	SetSessionFolderGuard(sessionID, reads, writes)
+	SetSessionFolderGuardBlockedPaths(sessionID, []string{"Workflow/demo/secrets"})
+	SetSessionFolderGuardBlockedWritePaths(sessionID, []string{"Workflow/demo/planning"})
+
+	reads[0] = "Workflow/other"
+	writes[0] = "Workflow/other/output"
+	first := GetSessionShellConfig(sessionID)
+	first.ReadPaths[0] = "mutated-read"
+	first.WritePaths[0] = "mutated-write"
+	first.BlockedPaths[0] = "mutated-block"
+	first.BlockedWritePaths[0] = "mutated-write-block"
+
+	second := GetSessionShellConfig(sessionID)
+	if got := second.ReadPaths[0]; got != "Workflow/demo" {
+		t.Fatalf("stored read path mutated: %q", got)
+	}
+	if got := second.WritePaths[0]; got != "Workflow/demo/output" {
+		t.Fatalf("stored write path mutated: %q", got)
+	}
+	if got := second.BlockedPaths[0]; got != "Workflow/demo/secrets" {
+		t.Fatalf("stored blocked path mutated: %q", got)
+	}
+	if got := second.BlockedWritePaths[0]; got != "Workflow/demo/planning" {
+		t.Fatalf("stored blocked-write path mutated: %q", got)
+	}
+}
+
+func TestCopySessionFolderGuardPreservesDenyOnlyGuard(t *testing.T) {
+	const source = "deny-only-source"
+	const target = "deny-only-target"
+	defer ClearSessionShellConfig(source)
+	defer ClearSessionShellConfig(target)
+
+	SetSessionFolderGuardBlockedPaths(source, []string{"Workflow/demo/secrets"})
+	SetSessionFolderGuardBlockedWritePaths(source, []string{"Workflow/demo/planning"})
+	if !CopySessionFolderGuard(source, target) {
+		t.Fatal("deny-only guard should be copied")
+	}
+
+	copied := GetSessionShellConfig(target)
+	if copied == nil || len(copied.BlockedPaths) != 1 || copied.BlockedPaths[0] != "Workflow/demo/secrets" {
+		t.Fatalf("blocked paths not copied: %+v", copied)
+	}
+	if len(copied.BlockedWritePaths) != 1 || copied.BlockedWritePaths[0] != "Workflow/demo/planning" {
+		t.Fatalf("blocked write paths not copied: %+v", copied)
+	}
+}

--- a/agent_go/pkg/orchestrator/base_orchestrator_folder_guard.go
+++ b/agent_go/pkg/orchestrator/base_orchestrator_folder_guard.go
@@ -335,9 +335,14 @@ func (bo *BaseOrchestrator) wrapWorkspaceToolsWithPaths(snapshotReadPaths, snaps
 
 			// Inject event emitter into context before calling executor
 			ctx = context.WithValue(ctx, virtualtools.WorkspaceEventEmitterKey, bo.contextAwareBridge)
-			// Inject snapshotted folder guard paths into context for shell execution
-			ctx = context.WithValue(ctx, virtualtools.FolderGuardReadPathsKey, snapshotReadPaths)
-			ctx = context.WithValue(ctx, virtualtools.FolderGuardWritePathsKey, snapshotWritePaths)
+			// Explicit guard paths are capabilities, including an intentionally empty
+			// write list. In legacy workspace-path mode, leave these keys absent so the
+			// executor uses the validated workspacePath grant instead of interpreting
+			// empty, non-nil slices as a deny-all contract.
+			if useFolderGuardPaths {
+				ctx = context.WithValue(ctx, virtualtools.FolderGuardReadPathsKey, snapshotReadPaths)
+				ctx = context.WithValue(ctx, virtualtools.FolderGuardWritePathsKey, snapshotWritePaths)
+			}
 			// Inject browser downloads path into context for agent-browser executor
 			if bo.browserDownloadsPath != "" {
 				ctx = context.WithValue(ctx, common.BrowserDownloadsPathKey, bo.browserDownloadsPath)

--- a/agent_go/pkg/orchestrator/base_orchestrator_folder_guard_test.go
+++ b/agent_go/pkg/orchestrator/base_orchestrator_folder_guard_test.go
@@ -1,0 +1,57 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	virtualtools "mcp-agent-builder-go/agent_go/cmd/server/virtual-tools"
+)
+
+func TestWorkspacePathFallbackDoesNotInjectEmptyCapabilitySlices(t *testing.T) {
+	bo := &BaseOrchestrator{}
+	bo.SetWorkspacePath("Workflow/demo")
+
+	called := false
+	executors := bo.WrapWorkspaceToolsWithFolderGuard(map[string]interface{}{
+		"execute_shell_command": func(ctx context.Context, _ map[string]interface{}) (string, error) {
+			called = true
+			if _, ok := ctx.Value(virtualtools.FolderGuardReadPathsKey).([]string); ok {
+				t.Fatal("workspacePath fallback injected an explicit read capability")
+			}
+			if _, ok := ctx.Value(virtualtools.FolderGuardWritePathsKey).([]string); ok {
+				t.Fatal("workspacePath fallback injected an explicit write capability")
+			}
+			return "ok", nil
+		},
+	})
+
+	executor := executors["execute_shell_command"].(func(context.Context, map[string]interface{}) (string, error))
+	if _, err := executor(context.Background(), map[string]interface{}{}); err != nil {
+		t.Fatalf("fallback executor failed: %v", err)
+	}
+	if !called {
+		t.Fatal("fallback executor was not called")
+	}
+}
+
+func TestExplicitReadOnlyGuardInjectsEmptyWriteCapability(t *testing.T) {
+	bo := &BaseOrchestrator{}
+	executors := bo.WrapWorkspaceToolsWithExplicitPaths(
+		[]string{"Workflow/demo"},
+		[]string{},
+		map[string]interface{}{
+			"execute_shell_command": func(ctx context.Context, _ map[string]interface{}) (string, error) {
+				writes, ok := ctx.Value(virtualtools.FolderGuardWritePathsKey).([]string)
+				if !ok || len(writes) != 0 {
+					t.Fatalf("explicit read-only guard lost empty write capability: %#v", writes)
+				}
+				return "ok", nil
+			},
+		},
+	)
+
+	executor := executors["execute_shell_command"].(func(context.Context, map[string]interface{}) (string, error))
+	if _, err := executor(context.Background(), map[string]interface{}{}); err != nil {
+		t.Fatalf("read-only executor failed: %v", err)
+	}
+}

--- a/agent_go/pkg/workspace/client.go
+++ b/agent_go/pkg/workspace/client.go
@@ -111,54 +111,86 @@ func (c *Client) resolveEffectiveFolderGuard(ctx context.Context) *FolderGuardCo
 	}
 	if sessionID != "" {
 		sessionCfg := GetSessionShellConfig(sessionID)
-		if sessionCfg != nil && len(sessionCfg.WritePaths) > 0 {
+		if sessionCfg != nil && sessionConfigHasFolderGuard(sessionCfg) {
 			readPaths := sessionCfg.WritePaths
 			if len(sessionCfg.ReadPaths) > 0 {
 				readPaths = deduplicateStrings(append(sessionCfg.ReadPaths, sessionCfg.WritePaths...))
 			}
 			log.Printf("[FOLDER_GUARD_RESOLVE] SessionConfig for file op: session=%s WritePaths=%v ReadPaths=%v", sessionID, sessionCfg.WritePaths, readPaths)
 			return &FolderGuardConfig{
-				Enabled:    true,
-				WritePaths: sessionCfg.WritePaths,
-				ReadPaths:  readPaths,
+				Enabled:           true,
+				WritePaths:        clonePathList(sessionCfg.WritePaths),
+				ReadPaths:         clonePathList(readPaths),
+				BlockedPaths:      clonePathList(sessionCfg.BlockedPaths),
+				BlockedWritePaths: clonePathList(sessionCfg.BlockedWritePaths),
 			}
 		}
 	}
 
 	// 2. Context System 1: chat/plan/prototype mode
-	if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok && len(allowedWrites) > 0 {
+	if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok {
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
 		readPaths := allowedWrites
 		if hasCtxReads && len(ctxReads) > 0 {
 			readPaths = deduplicateStrings(append(ctxReads, allowedWrites...))
 		}
 		return &FolderGuardConfig{
-			Enabled:    true,
-			WritePaths: allowedWrites,
-			ReadPaths:  readPaths,
+			Enabled:           true,
+			WritePaths:        clonePathList(allowedWrites),
+			ReadPaths:         clonePathList(readPaths),
+			BlockedPaths:      contextPathList(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: contextPathList(ctx, common.FolderGuardBlockedWritePathsKey),
 		}
 	}
 
 	// 3. Context System 2: workflow orchestrator
-	if ctxWrites, ok := ctx.Value(common.FolderGuardWritePathsKey).([]string); ok && len(ctxWrites) > 0 {
+	if ctxWrites, ok := ctx.Value(common.FolderGuardWritePathsKey).([]string); ok {
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
 		readPaths := ctxWrites
 		if hasCtxReads && len(ctxReads) > 0 {
 			readPaths = deduplicateStrings(append(ctxReads, ctxWrites...))
 		}
 		return &FolderGuardConfig{
-			Enabled:    true,
-			WritePaths: ctxWrites,
-			ReadPaths:  readPaths,
+			Enabled:           true,
+			WritePaths:        clonePathList(ctxWrites),
+			ReadPaths:         clonePathList(readPaths),
+			BlockedPaths:      contextPathList(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: contextPathList(ctx, common.FolderGuardBlockedWritePathsKey),
 		}
 	}
 
 	// 4. Client-level fallback
 	if c.FolderGuard != nil && c.FolderGuard.Enabled {
-		return c.FolderGuard
+		return cloneFolderGuard(c.FolderGuard)
 	}
 
 	return nil // No folder guard at all
+}
+
+func sessionConfigHasFolderGuard(config *SessionShellConfig) bool {
+	return config != nil && (config.FolderGuardSet || len(config.ReadPaths) > 0 || len(config.WritePaths) > 0 ||
+		len(config.BlockedPaths) > 0 || len(config.BlockedWritePaths) > 0)
+}
+
+func clonePathList(paths []string) []string {
+	return append([]string(nil), paths...)
+}
+
+func contextPathList(ctx context.Context, key common.ContextKey) []string {
+	paths, _ := ctx.Value(key).([]string)
+	return clonePathList(paths)
+}
+
+func cloneFolderGuard(guard *FolderGuardConfig) *FolderGuardConfig {
+	if guard == nil {
+		return nil
+	}
+	copy := *guard
+	copy.ReadPaths = clonePathList(guard.ReadPaths)
+	copy.WritePaths = clonePathList(guard.WritePaths)
+	copy.BlockedPaths = clonePathList(guard.BlockedPaths)
+	copy.BlockedWritePaths = clonePathList(guard.BlockedWritePaths)
+	return &copy
 }
 
 // ValidatePathWithContext checks if a path is allowed based on the effective folder guard
@@ -229,9 +261,13 @@ func validatePathAgainstGuard(guard *FolderGuardConfig, inputPath string, isWrit
 		allowedPaths = append(guard.ReadPaths, guard.WritePaths...)
 	}
 
-	// Empty allowed paths means allow all (when folder guard is enabled but no paths specified)
+	// An enabled guard with no capability for this operation is an explicit deny.
 	if len(allowedPaths) == 0 {
-		return nil
+		opType := "read"
+		if isWrite {
+			opType = "write"
+		}
+		return fmt.Errorf("ACCESS DENIED: no workspace %s paths were granted", opType)
 	}
 
 	// Check if path is under any allowed path
@@ -463,6 +499,9 @@ func (c *Client) UploadBinary(ctx context.Context, folderPath, fileName string, 
 // DownloadFile downloads a file from the workspace and returns its raw bytes.
 // filePath is the workspace path (e.g. "Chats/generated-images/image-1234.png").
 func (c *Client) DownloadFile(ctx context.Context, filePath string) ([]byte, error) {
+	if err := c.ValidatePathWithContext(ctx, filePath, false); err != nil {
+		return nil, err
+	}
 	encodedPath := strings.ReplaceAll(filePath, "/", "%2F")
 	return c.request(ctx, "GET", "/api/documents/"+encodedPath+"/raw", nil)
 }

--- a/agent_go/pkg/workspace/client.go
+++ b/agent_go/pkg/workspace/client.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -502,7 +503,7 @@ func (c *Client) DownloadFile(ctx context.Context, filePath string) ([]byte, err
 	if err := c.ValidatePathWithContext(ctx, filePath, false); err != nil {
 		return nil, err
 	}
-	encodedPath := strings.ReplaceAll(filePath, "/", "%2F")
+	encodedPath := url.PathEscape(filePath)
 	return c.request(ctx, "GET", "/api/documents/"+encodedPath+"/raw", nil)
 }
 

--- a/agent_go/pkg/workspace/client_test.go
+++ b/agent_go/pkg/workspace/client_test.go
@@ -1,8 +1,11 @@
 package workspace
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"mcp-agent-builder-go/agent_go/pkg/common"
 )
 
 // TestValidatePathAgainstGuard_BlockedWritePaths verifies the write-only deny
@@ -77,6 +80,39 @@ func TestValidatePathAgainstGuard_BlockedWritePaths(t *testing.T) {
 				t.Fatalf("expected error containing %q, got: %v", tc.wantError, err)
 			}
 		})
+	}
+}
+
+func TestValidatePathAgainstGuardEmptyCapabilitiesFailClosed(t *testing.T) {
+	guard := &FolderGuardConfig{Enabled: true}
+	if err := validatePathAgainstGuard(guard, "Workflow/demo/report.html", false); err == nil || !strings.Contains(err.Error(), "no workspace read paths") {
+		t.Fatalf("empty read capability should fail closed, got %v", err)
+	}
+	if err := validatePathAgainstGuard(guard, "Workflow/demo/report.html", true); err == nil || !strings.Contains(err.Error(), "no workspace write paths") {
+		t.Fatalf("empty write capability should fail closed, got %v", err)
+	}
+}
+
+func TestResolveEffectiveFolderGuardPreservesReadOnlyAndDenyPaths(t *testing.T) {
+	sessionID := "read-only-session-guard"
+	SetSessionFolderGuard(sessionID, []string{"Workflow/demo"}, nil)
+	SetSessionFolderGuardBlockedPaths(sessionID, []string{"Workflow/demo/secrets"})
+	SetSessionFolderGuardBlockedWritePaths(sessionID, []string{"Workflow/demo/planning"})
+	defer ClearSessionShellConfig(sessionID)
+
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	guard := NewClient("http://unused").resolveEffectiveFolderGuard(ctx)
+	if guard == nil || len(guard.ReadPaths) != 1 || len(guard.WritePaths) != 0 {
+		t.Fatalf("read-only guard was not preserved: %#v", guard)
+	}
+	if len(guard.BlockedPaths) != 1 || len(guard.BlockedWritePaths) != 1 {
+		t.Fatalf("deny paths were dropped: %#v", guard)
+	}
+	if err := validatePathAgainstGuard(guard, "Workflow/demo/report.html", false); err != nil {
+		t.Fatalf("granted read should pass: %v", err)
+	}
+	if err := validatePathAgainstGuard(guard, "Workflow/demo/report.html", true); err == nil {
+		t.Fatal("read-only session unexpectedly gained write access")
 	}
 }
 

--- a/agent_go/pkg/workspace/delete_workspace_file.go
+++ b/agent_go/pkg/workspace/delete_workspace_file.go
@@ -19,7 +19,7 @@ func (c *Client) DeleteWorkspaceFile(ctx context.Context, params DeleteWorkspace
 	}
 
 	// Validate path against folder guard (write operation)
-	if err := c.ValidatePath(params.Filepath, true); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.Filepath, true); err != nil {
 		return DeleteFileResult{}, err
 	}
 

--- a/agent_go/pkg/workspace/diff_patch_workspace_file.go
+++ b/agent_go/pkg/workspace/diff_patch_workspace_file.go
@@ -32,6 +32,9 @@ func (c *Client) DiffPatchWorkspaceFile(ctx context.Context, params DiffPatchWor
 	// The workspace HTTP handler does its own validation with the real docs-dir,
 	// but the filepath goes into the URL path so it must be relative.
 	params.Filepath = stripWorkspacePrefix(params.Filepath)
+	if err := c.ValidatePathWithContext(ctx, params.Filepath, true); err != nil {
+		return DiffPatchResult{}, err
+	}
 
 	// Build API URL for diff patching
 	apiURL := c.BaseURL + "/api/documents/" + encodeWorkspaceDocumentPath(params.Filepath) + "/diff"

--- a/agent_go/pkg/workspace/diff_patch_workspace_file_test.go
+++ b/agent_go/pkg/workspace/diff_patch_workspace_file_test.go
@@ -1,8 +1,10 @@
 package workspace
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +57,20 @@ func TestEncodeWorkspaceDocumentPath(t *testing.T) {
 	want := "Workflow/my%20flow/learnings/file%20%231.md"
 	if got != want {
 		t.Fatalf("encoded path = %q, want %q", got, want)
+	}
+}
+
+func TestDiffPatchWorkspaceFileValidatesInternally(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", WithFolderGuard(&FolderGuardConfig{
+		Enabled:    true,
+		WritePaths: []string{"Workflow/allowed"},
+	}))
+
+	_, err := client.DiffPatchWorkspaceFile(context.Background(), DiffPatchWorkspaceFileParams{
+		Filepath: "Workflow/blocked/report.html",
+		Diff:     "--- a/report.html\n+++ b/report.html\n@@ -0,0 +1 @@\n+hello\n",
+	})
+	if err == nil || !strings.Contains(err.Error(), "ACCESS DENIED") {
+		t.Fatalf("diff patch should be denied before making an HTTP request, got %v", err)
 	}
 }

--- a/agent_go/pkg/workspace/execute_shell_command.go
+++ b/agent_go/pkg/workspace/execute_shell_command.go
@@ -30,6 +30,11 @@ func SetSessionFolderGuard(sessionID string, readPaths, writePaths []string) {
 	common.SetSessionFolderGuard(sessionID, readPaths, writePaths)
 }
 
+// SetSessionFolderGuardBlockedPaths delegates to the common hard-deny policy.
+func SetSessionFolderGuardBlockedPaths(sessionID string, blockedPaths []string) {
+	common.SetSessionFolderGuardBlockedPaths(sessionID, blockedPaths)
+}
+
 // SetSessionFolderGuardBlockedWritePaths delegates to the common version.
 // BlockedWritePaths are the authoritative write-only deny list — they flow
 // through to the isolator's FolderGuardConfig.BlockedWritePaths and are enforced
@@ -297,7 +302,7 @@ func (c *Client) ExecuteShellCommand(ctx context.Context, params ExecuteShellCom
 	// Populate folder guard configuration for the Isolator.
 	// params.FolderGuard is never set by callers — it's always nil on entry.
 	// Priority: session config > context keys > client-level fallback.
-	if sessionCfg != nil && (len(sessionCfg.ReadPaths) > 0 || len(sessionCfg.WritePaths) > 0) {
+	if sessionConfigHasFolderGuard(sessionCfg) {
 		// Session config: set by SetSessionFolderGuard() — highest priority.
 		// Covers CLI/Gemini providers that bypass the Go folder guard context wrappers.
 		// BlockedWritePaths flow through as the write-only deny list enforced by the
@@ -311,10 +316,11 @@ func (c *Client) ExecuteShellCommand(ctx context.Context, params ExecuteShellCom
 			Enabled:           true,
 			WritePaths:        sessionCfg.WritePaths,
 			ReadPaths:         readPaths,
+			BlockedPaths:      sessionCfg.BlockedPaths,
 			BlockedWritePaths: sessionCfg.BlockedWritePaths,
 		}
 		log.Printf("[FOLDER_GUARD_RESOLVE] SessionConfig: session=%s WritePaths=%v ReadPaths=%v BlockedWritePaths=%v cmd=%s", sessionID, sessionCfg.WritePaths, readPaths, sessionCfg.BlockedWritePaths, redactedCommandForLog)
-	} else if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok && len(allowedWrites) > 0 {
+	} else if allowedWrites, ok := ctx.Value(common.FolderGuardAllowedWriteFolderKey).([]string); ok {
 		// Context System 1: chat/plan/prototype mode
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
 		readPaths := allowedWrites
@@ -322,35 +328,39 @@ func (c *Client) ExecuteShellCommand(ctx context.Context, params ExecuteShellCom
 			readPaths = deduplicateStrings(append(ctxReads, allowedWrites...))
 		}
 		params.FolderGuard = &FolderGuardConfig{
-			Enabled:    true,
-			WritePaths: allowedWrites,
-			ReadPaths:  readPaths,
+			Enabled:           true,
+			WritePaths:        allowedWrites,
+			ReadPaths:         readPaths,
+			BlockedPaths:      contextPathList(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: contextPathList(ctx, common.FolderGuardBlockedWritePathsKey),
 		}
 		log.Printf("[FOLDER_GUARD_RESOLVE] System1 (chat/plan/prototype): URL=%s WritePaths=%v ReadPaths=%v cmd=%s", c.BaseURL, allowedWrites, readPaths, redactedCommandForLog)
 	} else if ctxWrites, ok := ctx.Value(common.FolderGuardWritePathsKey).([]string); ok {
 		// Context System 2: workflow orchestrator
 		ctxReads, hasCtxReads := ctx.Value(common.FolderGuardReadPathsKey).([]string)
-		if len(ctxWrites) == 0 && (!hasCtxReads || len(ctxReads) == 0) {
-			log.Printf("[FOLDER_GUARD_RESOLVE] NO folder guard at all: URL=%s cmd=%s", c.BaseURL, redactedCommandForLog)
-		} else {
-			readPaths := ctxWrites
-			if hasCtxReads && len(ctxReads) > 0 {
-				readPaths = deduplicateStrings(append(ctxReads, ctxWrites...))
-			}
-			params.FolderGuard = &FolderGuardConfig{
-				Enabled:    true,
-				WritePaths: ctxWrites,
-				ReadPaths:  readPaths,
-			}
-			log.Printf("[FOLDER_GUARD_RESOLVE] System2 (workflow): URL=%s WritePaths=%v ReadPaths=%v cmd=%s", c.BaseURL, ctxWrites, readPaths, redactedCommandForLog)
+		readPaths := ctxWrites
+		if hasCtxReads && len(ctxReads) > 0 {
+			readPaths = deduplicateStrings(append(ctxReads, ctxWrites...))
 		}
+		params.FolderGuard = &FolderGuardConfig{
+			Enabled:           true,
+			WritePaths:        ctxWrites,
+			ReadPaths:         readPaths,
+			BlockedPaths:      contextPathList(ctx, common.FolderGuardBlockedPathsKey),
+			BlockedWritePaths: contextPathList(ctx, common.FolderGuardBlockedWritePathsKey),
+		}
+		log.Printf("[FOLDER_GUARD_RESOLVE] System2 (workflow): URL=%s WritePaths=%v ReadPaths=%v cmd=%s", c.BaseURL, ctxWrites, readPaths, redactedCommandForLog)
 	} else if c.FolderGuard != nil && c.FolderGuard.Enabled {
 		// Client-level fallback — no session config, no context keys.
-		params.FolderGuard = c.FolderGuard
+		params.FolderGuard = cloneFolderGuard(c.FolderGuard)
 		log.Printf("[FOLDER_GUARD_RESOLVE] FALLBACK to client-level guard: URL=%s ReadPaths=%v WritePaths=%v BlockedPaths=%v cmd=%s",
 			c.BaseURL, c.FolderGuard.ReadPaths, c.FolderGuard.WritePaths, c.FolderGuard.BlockedPaths, redactedCommandForLog)
 	} else {
 		log.Printf("[FOLDER_GUARD_RESOLVE] NO folder guard at all: URL=%s cmd=%s", c.BaseURL, redactedCommandForLog)
+	}
+	if params.FolderGuard != nil && params.FolderGuard.Enabled &&
+		len(params.FolderGuard.ReadPaths) == 0 && len(params.FolderGuard.WritePaths) == 0 {
+		return ShellCommandResult{}, fmt.Errorf("ACCESS DENIED: execute_shell_command has no granted workspace paths")
 	}
 
 	// Block absolute host paths when folder guard is active.

--- a/agent_go/pkg/workspace/execute_shell_command_test.go
+++ b/agent_go/pkg/workspace/execute_shell_command_test.go
@@ -353,6 +353,47 @@ func TestExecuteShellCommand_PassesCDPHostDownloadsReadOnlyGuard(t *testing.T) {
 	}
 }
 
+func TestExecuteShellCommandPreservesReadOnlySessionGuard(t *testing.T) {
+	sessionID := "test-read-only-shell-guard"
+	common.SetSessionFolderGuard(sessionID, []string{"Workflow/demo"}, nil)
+	defer ClearSessionShellConfig(sessionID)
+
+	var got ExecuteShellCommandParams
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"data":    map[string]interface{}{"stdout": "ok", "exit_code": 0},
+		})
+	}))
+	defer server.Close()
+
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	if _, err := NewClient(server.URL).ExecuteShellCommand(ctx, ExecuteShellCommandParams{
+		Command: "cat Workflow/demo/report.html",
+	}); err != nil {
+		t.Fatalf("read-only shell command failed: %v", err)
+	}
+	if got.FolderGuard == nil || len(got.FolderGuard.ReadPaths) != 1 || len(got.FolderGuard.WritePaths) != 0 {
+		t.Fatalf("read-only guard was not preserved: %#v", got.FolderGuard)
+	}
+}
+
+func TestExecuteShellCommandRejectsExplicitEmptySessionGuard(t *testing.T) {
+	sessionID := "test-empty-shell-guard"
+	common.SetSessionFolderGuard(sessionID, []string{}, []string{})
+	defer ClearSessionShellConfig(sessionID)
+
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	_, err := NewClient("http://127.0.0.1:1").ExecuteShellCommand(ctx, ExecuteShellCommandParams{
+		Command: "pwd",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no granted workspace paths") {
+		t.Fatalf("explicit empty guard should fail before HTTP, got %v", err)
+	}
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/agent_go/pkg/workspace/list_workspace_files.go
+++ b/agent_go/pkg/workspace/list_workspace_files.go
@@ -15,7 +15,7 @@ type ListWorkspaceFilesParams struct {
 // ListWorkspaceFiles lists files using the REST API: GET /api/documents
 func (c *Client) ListWorkspaceFiles(ctx context.Context, params ListWorkspaceFilesParams) (ListFilesResult, error) {
 	// Validate folder path against folder guard (read operation)
-	if err := c.ValidatePath(params.Folder, false); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.Folder, false); err != nil {
 		return ListFilesResult{}, err
 	}
 

--- a/agent_go/pkg/workspace/move_workspace_file.go
+++ b/agent_go/pkg/workspace/move_workspace_file.go
@@ -24,10 +24,10 @@ func (c *Client) MoveWorkspaceFile(ctx context.Context, params MoveWorkspaceFile
 	}
 
 	// Validate both paths against folder guard (write operations)
-	if err := c.ValidatePath(params.SourceFilepath, true); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.SourceFilepath, true); err != nil {
 		return MoveFileResult{}, fmt.Errorf("source path validation failed: %w", err)
 	}
-	if err := c.ValidatePath(params.DestinationFilepath, true); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.DestinationFilepath, true); err != nil {
 		return MoveFileResult{}, fmt.Errorf("destination path validation failed: %w", err)
 	}
 

--- a/agent_go/pkg/workspace/query_workflow_db.go
+++ b/agent_go/pkg/workspace/query_workflow_db.go
@@ -31,7 +31,7 @@ type queryAPIResponse struct {
 // keyed by column name. The connection is opened read-only server-side.
 func (c *Client) QueryWorkflowDB(ctx context.Context, params QueryWorkflowDBParams) ([]map[string]interface{}, error) {
 	// Read operation against the db file — validate the path against the read guard.
-	if err := c.ValidatePath(params.DBPath, false); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.DBPath, false); err != nil {
 		return nil, err
 	}
 

--- a/agent_go/pkg/workspace/read_workspace_file.go
+++ b/agent_go/pkg/workspace/read_workspace_file.go
@@ -29,7 +29,7 @@ type documentAPIResponse struct {
 // ReadWorkspaceFile reads a file using the REST API: GET /api/documents/*filepath
 func (c *Client) ReadWorkspaceFile(ctx context.Context, params ReadWorkspaceFileParams) (ReadFileResult, error) {
 	// Validate path against folder guard (read operation)
-	if err := c.ValidatePath(params.Filepath, false); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.Filepath, false); err != nil {
 		return ReadFileResult{}, err
 	}
 

--- a/agent_go/pkg/workspace/update_workspace_file.go
+++ b/agent_go/pkg/workspace/update_workspace_file.go
@@ -20,7 +20,7 @@ func (c *Client) UpdateWorkspaceFile(ctx context.Context, params UpdateWorkspace
 	}
 
 	// Validate path against folder guard (write operation)
-	if err := c.ValidatePath(params.Filepath, true); err != nil {
+	if err := c.ValidatePathWithContext(ctx, params.Filepath, true); err != nil {
 		return UpdateFileResult{}, err
 	}
 

--- a/workspace/utils/path.go
+++ b/workspace/utils/path.go
@@ -22,9 +22,9 @@ func IsValidFilePath(filePath, docsDir string) bool {
 
 	resolvedRoot, err := filepath.EvalSymlinks(cleanDocsDir)
 	if err != nil {
-		// A non-existent root cannot contain an observable symlink escape. The
-		// workspace server creates its root before serving requests.
-		return os.IsNotExist(err)
+		// The server must establish its workspace root before serving paths. If the
+		// root cannot be resolved, no containment guarantee can be made.
+		return false
 	}
 	resolvedCandidate, err := resolveExistingPathPrefix(cleanPath, cleanDocsDir)
 	return err == nil && pathWithinRoot(resolvedCandidate, resolvedRoot)

--- a/workspace/utils/path.go
+++ b/workspace/utils/path.go
@@ -11,27 +11,50 @@ import (
 
 // IsValidFilePath validates that the file path is safe and within the docs directory
 func IsValidFilePath(filePath, docsDir string) bool {
-	// Clean the path to resolve any .. or . components
-	cleanPath := filepath.Clean(filePath)
-	cleanDocsDir := filepath.Clean(docsDir)
-
-	// Check if the file path is within the docs directory
-	relPath, err := filepath.Rel(cleanDocsDir, cleanPath)
+	cleanPath, err := filepath.Abs(filepath.Clean(filePath))
 	if err != nil {
 		return false
 	}
-
-	// Check for directory traversal attempts
-	if strings.HasPrefix(relPath, "..") {
+	cleanDocsDir, err := filepath.Abs(filepath.Clean(docsDir))
+	if err != nil || !pathWithinRoot(cleanPath, cleanDocsDir) {
 		return false
 	}
 
-	// Check for invalid characters
-	if strings.Contains(relPath, "..") {
+	resolvedRoot, err := filepath.EvalSymlinks(cleanDocsDir)
+	if err != nil {
+		// A non-existent root cannot contain an observable symlink escape. The
+		// workspace server creates its root before serving requests.
+		return os.IsNotExist(err)
+	}
+	resolvedCandidate, err := resolveExistingPathPrefix(cleanPath, cleanDocsDir)
+	return err == nil && pathWithinRoot(resolvedCandidate, resolvedRoot)
+}
+
+func resolveExistingPathPrefix(candidate, root string) (string, error) {
+	current := candidate
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			return filepath.EvalSymlinks(current)
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		if current == root {
+			return filepath.EvalSymlinks(root)
+		}
+		parent := filepath.Dir(current)
+		if parent == current || !pathWithinRoot(parent, root) {
+			return "", fmt.Errorf("path %q escapes workspace root %q", candidate, root)
+		}
+		current = parent
+	}
+}
+
+func pathWithinRoot(candidate, root string) bool {
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil {
 		return false
 	}
-
-	return true
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 // GetRelativePath converts a full internal path to a relative path for API responses
@@ -149,6 +172,9 @@ func ResolveUserPath(docsDir, requestedPath, userID string) (string, error) {
 	cleanRoot := filepath.Clean(docsDir)
 	if resolved != cleanRoot && !strings.HasPrefix(resolved, cleanRoot+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %q escapes the workspace root", requestedPath)
+	}
+	if !IsValidFilePath(resolved, docsDir) {
+		return "", fmt.Errorf("path %q resolves outside the workspace root", requestedPath)
 	}
 
 	return resolved, nil

--- a/workspace/utils/path_test.go
+++ b/workspace/utils/path_test.go
@@ -291,3 +291,36 @@ func TestIsValidFilePath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidFilePathRejectsSymlinkEscape(t *testing.T) {
+	docsDir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(docsDir, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	if IsValidFilePath(filepath.Join(docsDir, "escape", "secret.txt"), docsDir) {
+		t.Fatal("existing file through an escaping symlink must be rejected")
+	}
+	if IsValidFilePath(filepath.Join(docsDir, "escape", "new.txt"), docsDir) {
+		t.Fatal("new file under an escaping symlink must be rejected")
+	}
+}
+
+func TestIsValidFilePathAllowsSymlinkInsideWorkspace(t *testing.T) {
+	docsDir := t.TempDir()
+	target := filepath.Join(docsDir, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(docsDir, "inside")); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsValidFilePath(filepath.Join(docsDir, "inside", "new.txt"), docsDir) {
+		t.Fatal("symlink that remains inside the workspace should be allowed")
+	}
+}

--- a/workspace/utils/path_test.go
+++ b/workspace/utils/path_test.go
@@ -204,6 +204,14 @@ func TestResolveUserPath(t *testing.T) {
 	})
 }
 
+func TestIsValidFilePathRejectsMissingWorkspaceRoot(t *testing.T) {
+	parent := t.TempDir()
+	missingRoot := filepath.Join(parent, "not-created")
+	if IsValidFilePath(filepath.Join(missingRoot, "report.html"), missingRoot) {
+		t.Fatal("missing workspace root must fail closed")
+	}
+}
+
 // --- ConvertToUserRelativePath ---
 
 func TestConvertToUserRelativePath(t *testing.T) {
@@ -271,17 +279,17 @@ func TestSanitizeInputPath(t *testing.T) {
 // --- IsValidFilePath ---
 
 func TestIsValidFilePath(t *testing.T) {
-	docsDir := "/app/workspace-docs"
+	docsDir := t.TempDir()
 
 	tests := []struct {
 		name     string
 		filePath string
 		want     bool
 	}{
-		{"valid-subpath", "/app/workspace-docs/Chats/session.json", true},
-		{"traversal-attack", "/app/workspace-docs/../etc/passwd", false},
+		{"valid-subpath", filepath.Join(docsDir, "Chats", "session.json"), true},
+		{"traversal-attack", filepath.Join(docsDir, "..", "etc", "passwd"), false},
 		{"outside-docsdir", "/etc/passwd", false},
-		{"exactly-docsdir", "/app/workspace-docs", true},
+		{"exactly-docsdir", docsDir, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- make per-session workspace permissions immutable copy-on-write snapshots and preserve hard deny / write-deny paths when deriving child sessions
- keep explicit empty and read-only guards fail-closed across file tools, shell execution, and browser execution
- validate every workspace file operation internally with the request/session context, including diff patch and downloads
- reject workspace paths that escape through existing symlinks
- clear session permission state on stop, clear, and retained-session eviction

## Verification

- `go test -race ./pkg/common ./pkg/workspace ./pkg/browser -count=1`
- `go test -race ./cmd/server -run ^TestHandleStopSessionCancelsActiveWorkAndPreventsPaneReuse$ -count=1`
- `go test -race ./utils -count=1` (workspace server)
- `go vet ./pkg/common ./pkg/workspace ./pkg/browser ./cmd/server`
- pre-commit: gitleaks, golangci-lint, agent/workspace builds, Electron package build

## Known baseline failures

The broad workspace `handlers` suite still has existing flexible-diff expectation failures, and `security` has an existing macOS Downloads sandbox-profile assertion failure. Neither is introduced by this branch.

## Scope

This is the builder-side fail-closed foundation for #142. The issue intentionally remains open for signed workspace API authentication/capability leases, a dedicated backup operation, environment credential brokering, and end-to-end adversarial coverage.