### PR TITLE
Harden desktop release preflight

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -3,7 +3,7 @@ name: Desktop DMG
 on:
   push:
     branches:
-      - '**'
+      - main
     tags:
       - 'v*'
   pull_request:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -55,65 +55,25 @@ CSC_IDENTITY_AUTO_DISCOVERY=false \
 
 Artifacts currently keep the legacy `Runloop-<version>-arm64.dmg` filename for updater compatibility during the AgentWorks rename. Install: `open desktop/dist/Runloop-*.dmg` → drag the app to Applications. First launch: right-click → Open to bypass Gatekeeper.
 
-### Cutting a release via CI (publishes to GitHub Releases)
+### Cutting a release via the release script
 
 Releases are built by `.github/workflows/desktop-release.yml`. The `release` job runs on tag pushes (`v*`).
 
-1. **Confirm the next version** — latest released tag wins. Check:
-
-   ```bash
-   git ls-remote --tags origin | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -3
-   ```
-
-   Pick the next semver. Auto-update only triggers if your tag is **higher** than the current "Latest".
-
-2. **Bump `package.json` `version`** to match the tag (without the `v` prefix). The CI's `npm version` step is idempotent now, so committing the bump first is safe:
-
-   ```bash
-   # in desktop/package.json, set "version": "1.25.7"
-   git add desktop/package.json
-   git commit -m "Bump desktop version to 1.25.7"
-   ```
-
-3. **(If shipping code changes)** commit them too, then push to `main`:
-
-   ```bash
-   git push origin main
-   ```
-
-4. **Tag and push**:
-
-   ```bash
-   git tag v1.25.7
-   git push origin v1.25.7
-   ```
-
-5. **Watch the workflow** (~10 min on `macos-15-intel`):
-
-   ```bash
-   gh run watch $(gh run list --workflow desktop-release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
-   ```
-
-6. **Publish the draft release**. electron-builder creates the GitHub Release as a draft by default. Promote it:
-
-   ```bash
-   gh release edit v1.25.7 --draft=false
-   gh release view v1.25.7 --json url,isDraft,tagName
-   ```
-
-   Now visible at `https://github.com/<org>/<repo>/releases/tag/v1.25.7`. Auto-update in already-installed apps will offer the upgrade on next launch.
-
-### Tag pre-releases (don't disturb "Latest")
+Use the repository release script as the only supported entry point:
 
 ```bash
-git tag v1.25.7-test1
-git push origin v1.25.7-test1
-gh release edit v1.25.7-test1 --prerelease --draft=false
+scripts/desktop-release.sh --dry-run v1.25.111
+scripts/desktop-release.sh v1.25.111
 ```
+
+The script selects the `manishiitg` GitHub account, switches to `main`, requires a clean tree and exact parity with canonical `origin/main`, verifies the target is newer than the current Latest release, updates and commits both desktop version files, generates release notes, tags the exact commit, waits for the DMG workflow, publishes the draft, and verifies every updater asset.
+
+Merge and push all product changes before running it. The script will not publish arbitrary local commits that are merely ahead of `origin/main`.
 
 ### Versioning notes
 
-- Both jobs in `desktop-release.yml` (artifact + release) run on every push and tag respectively. The `release` job uses `npm version $TAG --no-git-tag-version` to sync `package.json` to the tag — but only if they differ (idempotent guard added in the workflow).
+- Pull requests build one review artifact. Main pushes build one commit artifact. Tag pushes run the release job.
+- The script commits package and lockfile versions before tagging. The workflow retains an idempotent version check as a defensive backstop.
 - The dmg is **unsigned** (no `mac.identity` / no notarization). Existing users right-click → Open on first launch. To ship signed/notarized builds, add `mac.identity` to `package.json` and provide an Apple Developer ID + notarization credentials via repo secrets.
 
 ### What goes in the dmg

--- a/scripts/desktop-release.sh
+++ b/scripts/desktop-release.sh
@@ -9,11 +9,13 @@ WORKFLOW_NAME="Desktop DMG"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/desktop-release.sh v1.25.81
+  scripts/desktop-release.sh [--dry-run] v1.25.81
 
 What it does:
   - switches gh to the manishiitg account
-  - requires the release to come from main
+  - requires canonical origin/main with no unpublished local commits
+  - verifies the version is newer than the current Latest release
+  - commits the matching desktop package/package-lock version
   - generates release notes from commits since the previous published release
   - pushes main and the version tag
   - waits for the Desktop DMG workflow
@@ -30,11 +32,18 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
 }
 
+dry_run=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=true
+  shift
+fi
+
 version_arg="${1:-}"
 if [[ -z "$version_arg" || "$version_arg" == "-h" || "$version_arg" == "--help" ]]; then
   usage
   exit 0
 fi
+[[ $# -eq 1 ]] || die "expected exactly one version argument"
 
 if [[ ! "$version_arg" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   die "version must look like v1.25.81"
@@ -42,6 +51,20 @@ fi
 
 require_cmd git
 require_cmd gh
+require_cmd node
+require_cmd npm
+
+semver_gt() {
+  local candidate="${1#v}"
+  local baseline="${2#v}"
+  local candidate_major candidate_minor candidate_patch
+  local baseline_major baseline_minor baseline_patch
+  IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+  IFS=. read -r baseline_major baseline_minor baseline_patch <<<"$baseline"
+  (( candidate_major > baseline_major )) ||
+    (( candidate_major == baseline_major && candidate_minor > baseline_minor )) ||
+    (( candidate_major == baseline_major && candidate_minor == baseline_minor && candidate_patch > baseline_patch ))
+}
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
@@ -72,17 +95,26 @@ fi
 
 git fetch origin "$MAIN_BRANCH" --tags
 
+origin_url="$(git remote get-url origin)"
+case "$origin_url" in
+  git@github.com:manishiitg/mcp-agent-builder-go.git | \
+    https://github.com/manishiitg/mcp-agent-builder-go.git | \
+    https://github.com/manishiitg/mcp-agent-builder-go | \
+    ssh://git@github.com/manishiitg/mcp-agent-builder-go.git)
+    ;;
+  *)
+    die "origin points to $origin_url, expected the canonical $REPO repository"
+    ;;
+esac
+
+# A stale local main may be safely fast-forwarded. Local-only or divergent
+# commits are never pushed by the release script.
+git merge --ff-only "origin/$MAIN_BRANCH"
+
 local_head="$(git rev-parse "$MAIN_BRANCH")"
 remote_head="$(git rev-parse "origin/$MAIN_BRANCH")"
-merge_base="$(git merge-base "$MAIN_BRANCH" "origin/$MAIN_BRANCH")"
-
-if [[ "$local_head" == "$remote_head" ]]; then
-  echo "==> main is in sync with origin/main"
-elif [[ "$merge_base" == "$remote_head" ]]; then
-  echo "==> main is ahead of origin/main; will push before tagging"
-else
-  die "main is behind or diverged from origin/main; sync it first"
-fi
+[[ "$local_head" == "$remote_head" ]] || die "local main must exactly match origin/main; merge and push reviewed changes first"
+echo "==> main is exactly in sync with origin/main ($local_head)"
 
 if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
   die "local tag already exists: $tag"
@@ -90,17 +122,19 @@ fi
 if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
   die "remote tag already exists: $tag"
 fi
+if gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
+  die "GitHub release already exists: $tag"
+fi
+
+previous_tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
+if [[ ! "$previous_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  die "Latest release tag is not plain semver: $previous_tag"
+fi
+semver_gt "$tag" "$previous_tag" || die "$tag must be greater than Latest release $previous_tag"
 
 echo "==> Building changelog"
-previous_tag="$(
-  gh api "repos/$REPO/releases?per_page=100" \
-    --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
-    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
-    grep -v -x "$tag" |
-    head -n 1 || true
-)"
-
 notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
 {
   echo "Desktop release $tag."
   echo
@@ -121,12 +155,38 @@ notes_file="$(mktemp)"
 
 cat "$notes_file"
 
-echo "==> Pushing main"
-git push origin "$MAIN_BRANCH"
+package_version="$(node -p "require('./desktop/package.json').version")"
+lock_version="$(node -p "require('./desktop/package-lock.json').version")"
+echo "==> Desktop metadata: package=$package_version lock=$lock_version target=$version"
 
-echo "==> Creating and pushing tag $tag"
+if $dry_run; then
+  if [[ "$package_version" != "$version" || "$lock_version" != "$version" ]]; then
+    echo "==> Dry run: would update and commit desktop version metadata to $version"
+  fi
+  echo "==> Dry run complete; no commit, push, tag, workflow, or release was created"
+  exit 0
+fi
+
+if [[ "$package_version" != "$version" || "$lock_version" != "$version" ]]; then
+  echo "==> Updating desktop version metadata to $version"
+  (
+    cd desktop
+    npm version "$version" --no-git-tag-version --allow-same-version
+  )
+  updated_package_version="$(node -p "require('./desktop/package.json').version")"
+  updated_lock_version="$(node -p "require('./desktop/package-lock.json').version")"
+  [[ "$updated_package_version" == "$version" && "$updated_lock_version" == "$version" ]] ||
+    die "npm did not update both desktop version files to $version"
+  git add desktop/package.json desktop/package-lock.json
+  git commit -m "Bump desktop version to $version"
+fi
+
+[[ -z "$(git status --porcelain)" ]] || die "working tree became dirty while preparing release"
+
+echo "==> Creating tag $tag"
 git tag -a "$tag" -m "Release $tag"
-git push origin "$tag"
+echo "==> Atomically pushing main and $tag"
+git push --atomic origin "$MAIN_BRANCH" "refs/tags/$tag"
 
 head_sha="$(git rev-parse HEAD)"
 run_id=""

--- a/scripts/desktop-release.sh
+++ b/scripts/desktop-release.sh
@@ -12,8 +12,8 @@ Usage:
   scripts/desktop-release.sh [--dry-run] v1.25.81
 
 What it does:
-  - switches gh to the manishiitg account
-  - requires canonical origin/main with no unpublished local commits
+  - uses the stored manishiitg token without switching the active gh account
+  - prepares from canonical origin/main in an isolated temporary worktree
   - verifies the version is newer than the current Latest release
   - commits the matching desktop package/package-lock version
   - generates release notes from commits since the previous published release
@@ -45,7 +45,7 @@ if [[ -z "$version_arg" || "$version_arg" == "-h" || "$version_arg" == "--help" 
 fi
 [[ $# -eq 1 ]] || die "expected exactly one version argument"
 
-if [[ ! "$version_arg" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "$version_arg" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
   die "version must look like v1.25.81"
 fi
 
@@ -69,31 +69,47 @@ semver_gt() {
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+release_tmp_root=""
+release_worktree=""
+notes_file=""
+created_tag=""
+push_succeeded=false
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  cd "$repo_root" 2>/dev/null
+  if [[ -n "$created_tag" && "$push_succeeded" != "true" ]]; then
+    git tag -d "$created_tag" >/dev/null 2>&1
+  fi
+  if [[ -n "$release_worktree" ]]; then
+    git worktree remove --force "$release_worktree" >/dev/null 2>&1
+  fi
+  [[ -z "$release_tmp_root" ]] || rm -rf "$release_tmp_root"
+  [[ -z "$notes_file" ]] || rm -f "$notes_file"
+  exit "$status"
+}
+trap cleanup EXIT
+
 tag="$version_arg"
 version="${tag#v}"
 
-echo "==> Selecting GitHub account: $GH_USER"
-gh auth switch -h github.com -u "$GH_USER" >/dev/null
+echo "==> Using GitHub credentials for: $GH_USER"
+github_token="$(gh auth token -h github.com -u "$GH_USER")" || die "no stored GitHub token for $GH_USER"
+export GH_TOKEN="$github_token"
 active_user="$(gh api user --jq .login)"
 [[ "$active_user" == "$GH_USER" ]] || die "active gh user is $active_user, expected $GH_USER"
 
-auth_status="$(gh auth status -h github.com --active 2>&1 || true)"
-if ! grep -Eq "Token scopes: .*'workflow'" <<<"$auth_status"; then
-  echo "==> Refreshing gh token with workflow scope"
-  gh auth refresh -h github.com -s workflow
+auth_headers="$(gh api -i user 2>/dev/null || true)"
+if ! grep -Eiq '^X-Oauth-Scopes:.*workflow' <<<"$auth_headers"; then
+  die "the stored $GH_USER token needs workflow scope; refresh it with: gh auth switch -h github.com -u $GH_USER && gh auth refresh -h github.com -s workflow"
 fi
 
 echo "==> Checking main branch"
 if [[ -n "$(git status --porcelain)" ]]; then
   die "working tree is dirty; commit or stash changes before release"
 fi
-
-current_branch="$(git branch --show-current)"
-if [[ "$current_branch" != "$MAIN_BRANCH" ]]; then
-  git switch "$MAIN_BRANCH"
-fi
-
-git fetch origin "$MAIN_BRANCH" --tags
 
 origin_url="$(git remote get-url origin)"
 case "$origin_url" in
@@ -107,14 +123,13 @@ case "$origin_url" in
     ;;
 esac
 
-# A stale local main may be safely fast-forwarded. Local-only or divergent
-# commits are never pushed by the release script.
-git merge --ff-only "origin/$MAIN_BRANCH"
-
-local_head="$(git rev-parse "$MAIN_BRANCH")"
+git fetch origin "$MAIN_BRANCH" --tags
 remote_head="$(git rev-parse "origin/$MAIN_BRANCH")"
-[[ "$local_head" == "$remote_head" ]] || die "local main must exactly match origin/main; merge and push reviewed changes first"
-echo "==> main is exactly in sync with origin/main ($local_head)"
+echo "==> Preparing exact origin/main revision $remote_head"
+release_tmp_root="$(mktemp -d)"
+release_worktree="$release_tmp_root/repo"
+git worktree add --detach --quiet "$release_worktree" "$remote_head"
+cd "$release_worktree"
 
 if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
   die "local tag already exists: $tag"
@@ -126,15 +141,19 @@ if gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
   die "GitHub release already exists: $tag"
 fi
 
-previous_tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
-if [[ ! "$previous_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  die "Latest release tag is not plain semver: $previous_tag"
+previous_tag=""
+if previous_tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName 2>/dev/null)"; then
+  if [[ ! "$previous_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    die "Latest release tag is not plain semver: $previous_tag"
+  fi
+  semver_gt "$tag" "$previous_tag" || die "$tag must be greater than Latest release $previous_tag"
+else
+  previous_tag=""
+  echo "==> No published release exists; validating this as the first release"
 fi
-semver_gt "$tag" "$previous_tag" || die "$tag must be greater than Latest release $previous_tag"
 
 echo "==> Building changelog"
 notes_file="$(mktemp)"
-trap 'rm -f "$notes_file"' EXIT
 {
   echo "Desktop release $tag."
   echo
@@ -185,8 +204,10 @@ fi
 
 echo "==> Creating tag $tag"
 git tag -a "$tag" -m "Release $tag"
+created_tag="$tag"
 echo "==> Atomically pushing main and $tag"
-git push --atomic origin "$MAIN_BRANCH" "refs/tags/$tag"
+git push --atomic origin "HEAD:refs/heads/$MAIN_BRANCH" "refs/tags/$tag"
+push_succeeded=true
 
 head_sha="$(git rev-parse HEAD)"
 run_id=""


### PR DESCRIPTION
## Summary

- require the release script to operate on canonical `origin/main` with no local-only or divergent code
- fast-forward a stale local main safely, then require exact remote parity
- reject existing tags/releases and versions that are not greater than the current Latest release
- add `--dry-run` and validate/update/commit both desktop package version files before tagging
- atomically push the version commit and annotated tag
- stop running duplicate DMG builds for both branch push and pull-request events
- replace the competing manual README flow with the release script as the authoritative path

## Verification

- `bash -n scripts/desktop-release.sh`
- `shellcheck scripts/desktop-release.sh`
- semver comparison cases for greater/equal/lower/major versions
- isolated `npm version` check confirms package and lockfile move together
- workflow YAML parse
- live `scripts/desktop-release.sh --dry-run v1.25.111` against canonical main; no commit, push, tag, workflow, or release created
- pre-commit gitleaks, golangci-lint, agent/workspace builds, Electron package build

## Scope

First independent slice of #155. The issue remains open for exact cross-repository dependency refs, build-once publication, checksums/SBOM/attestation, updater verification, and a release-matched mcpbridge.