### PR TITLE
Harden terminal and workspace integration

### DIFF
--- a/agent_go/cmd/server/terminal_live_attach.go
+++ b/agent_go/cmd/server/terminal_live_attach.go
@@ -307,9 +307,12 @@ func (st *liveAttachStream) start() {
 	ctx, cancel := context.WithCancel(context.Background())
 	st.cancel = cancel
 	go func() {
-		defer cancel()
-		defer st.mgr.dropStream(st)
+		// Defers run in reverse order. Publish done only after the attach context
+		// is canceled and the manager/subscriber cleanup has completed, so callers
+		// cannot observe a finished stream that is still registered.
 		defer close(st.done)
+		defer st.mgr.dropStream(st)
+		defer cancel()
 		liveAttachAttachFn(st, ctx)
 	}()
 }

--- a/scripts/desktop-release.sh
+++ b/scripts/desktop-release.sh
@@ -178,6 +178,15 @@ package_version="$(node -p "require('./desktop/package.json').version")"
 lock_version="$(node -p "require('./desktop/package-lock.json').version")"
 echo "==> Desktop metadata: package=$package_version lock=$lock_version target=$version"
 
+for metadata_version in "$package_version" "$lock_version"; do
+  if [[ ! "$metadata_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    die "desktop version metadata is not plain semver: $metadata_version"
+  fi
+done
+if semver_gt "$package_version" "$version" || semver_gt "$lock_version" "$version"; then
+  die "$tag would downgrade desktop version metadata (package=$package_version lock=$lock_version)"
+fi
+
 if $dry_run; then
   if [[ "$package_version" != "$version" || "$lock_version" != "$version" ]]; then
     echo "==> Dry run: would update and commit desktop version metadata to $version"

--- a/workspace/handlers/diff_patch.go
+++ b/workspace/handlers/diff_patch.go
@@ -389,7 +389,26 @@ func correctAgentGeneratedDiff(diffContent, currentContent string) string {
 					currentHunk.oldCount++
 					currentHunk.newCount++
 				} else if strings.HasPrefix(line, "-") {
-					currentHunk.oldCount++
+					// Agents sometimes omit the diff context prefix for Markdown
+					// bullets. If the removal payload is absent but the complete
+					// bullet exists, this is context rather than a deletion.
+					payloadExists := false
+					lineExists := false
+					for _, fl := range currentLines {
+						if fl == line[1:] {
+							payloadExists = true
+						}
+						if fl == line {
+							lineExists = true
+						}
+					}
+					if !payloadExists && lineExists {
+						line = " " + line
+						currentHunk.oldCount++
+						currentHunk.newCount++
+					} else {
+						currentHunk.oldCount++
+					}
 				} else if strings.HasPrefix(line, "+") {
 					currentHunk.newCount++
 				}
@@ -549,6 +568,15 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 	fmt.Printf("🔍 Trying fallback approach for agent-generated diffs\n")
 
 	lines := strings.Split(diffContent, "\n")
+	hasOldHeader := false
+	hasNewHeader := false
+	for _, line := range lines {
+		hasOldHeader = hasOldHeader || strings.HasPrefix(line, "--- ")
+		hasNewHeader = hasNewHeader || strings.HasPrefix(line, "+++ ")
+	}
+	if !hasOldHeader || !hasNewHeader {
+		return "", fmt.Errorf("missing or malformed diff headers (---/+++)")
+	}
 
 	resultLines := strings.Split(currentContent, "\n")
 
@@ -560,7 +588,7 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 	var currentHunk *hunk
 
-	for _, line := range lines {
+	for lineIndex, line := range lines {
 
 		if strings.HasPrefix(line, "@@") {
 
@@ -582,11 +610,15 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 				currentHunk.lines = append(currentHunk.lines, line)
 
-			} else if line == "" && len(currentHunk.lines) > 0 {
+			} else if line == "" && len(currentHunk.lines) > 0 && lineIndex < len(lines)-1 {
 
 				// Empty line inside hunk is treated as context
 
 				currentHunk.lines = append(currentHunk.lines, " ")
+
+			} else if line != "" {
+
+				return "", fmt.Errorf("malformed hunk line %q: context, removals, and additions must use a diff prefix", line)
 
 			}
 
@@ -631,27 +663,7 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 		}
 
 		if len(expectedLines) == 0 {
-
-			// Pure addition hunk, apply to bottom
-
-			var additions []string
-
-			for _, hl := range h.lines {
-
-				if strings.HasPrefix(hl, "+") {
-
-					additions = append(additions, hl[1:])
-
-				}
-
-			}
-
-			newResult, _ := applyAdditionsToBottom(strings.Join(resultLines, "\n"), additions)
-
-			resultLines = strings.Split(newResult, "\n")
-
-			continue
-
+			return "", fmt.Errorf("pure-addition fallback hunk has no context; provide an exact unified diff so insertion location is unambiguous")
 		}
 
 		fmt.Printf("🔍 Attempting to match hunk with %d expected lines against %d file lines\n", len(expectedLines), len(resultLines))
@@ -662,27 +674,10 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 		minMismatches := len(expectedLines) + 1
 
+		// Fallback ignores line numbers, so require an exact content match.
+		// Whitespace is normalized below, but content mismatches must never be
+		// guessed because removals could otherwise target the wrong block.
 		maxAllowedMismatches := 0
-
-		if len(expectedLines) >= 4 {
-
-			// For larger hunks, allow ~15-20% mismatch
-
-			maxAllowedMismatches = len(expectedLines) / 6
-
-			if maxAllowedMismatches < 1 {
-
-				maxAllowedMismatches = 1
-
-			}
-
-			if maxAllowedMismatches > 3 {
-
-				maxAllowedMismatches = 3 // Cap at 3 mismatches max
-
-			}
-
-		}
 
 		for i := 0; i <= len(resultLines)-len(expectedLines); i++ {
 
@@ -724,7 +719,7 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 			matchIndex = bestMatchIndex
 
-			fmt.Printf("✅ Found fuzzy match at line %d with %d mismatches\n", matchIndex+1, minMismatches)
+			fmt.Printf("✅ Found exact fallback match at line %d\n", matchIndex+1)
 
 		}
 

--- a/workspace/handlers/diff_patch.go
+++ b/workspace/handlers/diff_patch.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -218,9 +219,13 @@ func validateDiffFormat(diffContent string) error {
 		if inHunk && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, "+")) {
 			// This is a valid diff line
 			continue
-		} else if inHunk && line == "" {
-			// Empty line ends the hunk
+		} else if inHunk && line == "" && i == len(lines)-1 {
+			// strings.Split exposes the required trailing newline as one final
+			// empty element. A blank line inside a hunk must still carry a space
+			// context prefix; accepting it here can silently truncate the patch.
 			inHunk = false
+		} else if inHunk && line == "" {
+			return fmt.Errorf("malformed diff line %d: blank context lines must start with a space", i+1)
 		} else if inHunk && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "+") && line != "" {
 			// Invalid line in hunk
 			return fmt.Errorf("malformed diff line %d: %q - diff lines must start with space (context), - (removal), or + (addition)", i+1, line)
@@ -282,9 +287,10 @@ func applyDiffPatch(currentContent, diffContent string) (string, error) {
 	}
 	patchFile.Close()
 
-	// Apply patch using the standard patch command
-	// Use -F 3 to be more lenient with context matches (fuzz factor)
-	cmd := exec.Command("patch", "-u", "-F", "3", tempFile.Name(), patchFile.Name())
+	// Apply only against complete context. The exact-match fallback below can
+	// recover stale line numbers without allowing patch(1) to discard context
+	// and place an otherwise ambiguous hunk under the wrong duplicate heading.
+	cmd := exec.Command("patch", "-u", "-F", "0", tempFile.Name(), patchFile.Name())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Provide more specific error messages based on patch output
@@ -308,11 +314,88 @@ func applyDiffPatch(currentContent, diffContent string) (string, error) {
 	return string(patchedContent), nil
 }
 
-// correctAgentGeneratedDiff attempts to fix common agent-generated diff patterns
+// safeMalformedContextLines identifies context lines where an agent omitted the
+// unified-diff prefix. A line is repairable only when the hunk's complete
+// old-side sequence has an explicit context/removal anchor and occurs exactly
+// once as a contiguous block in the current file.
+func safeMalformedContextLines(diffLines, currentLines []string) map[int]bool {
+	safe := make(map[int]bool)
+	for start := 0; start < len(diffLines); start++ {
+		if !strings.HasPrefix(diffLines[start], "@@") {
+			continue
+		}
+
+		var oldSide []string
+		var candidates []int
+		hasAnchor := false
+		end := start + 1
+		for ; end < len(diffLines); end++ {
+			line := diffLines[end]
+			if strings.HasPrefix(line, "@@") || strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") {
+				break
+			}
+			if line == "" {
+				if end == len(diffLines)-1 {
+					break
+				}
+				oldSide = append(oldSide, "")
+				candidates = append(candidates, end)
+				continue
+			}
+			switch line[0] {
+			case ' ':
+				oldSide = append(oldSide, line[1:])
+				hasAnchor = true
+			case '-':
+				payload := line[1:]
+				payloadExists := slices.Contains(currentLines, payload)
+				if strings.HasPrefix(line, "- ") && !payloadExists && slices.Contains(currentLines, line) {
+					oldSide = append(oldSide, line)
+					candidates = append(candidates, end)
+				} else {
+					oldSide = append(oldSide, payload)
+					hasAnchor = true
+				}
+			case '+':
+				// Additions do not participate in old-side matching.
+			default:
+				if slices.Contains(currentLines, line) {
+					oldSide = append(oldSide, line)
+					candidates = append(candidates, end)
+				} else {
+					oldSide = nil
+					candidates = nil
+					end = len(diffLines)
+				}
+			}
+		}
+		if !hasAnchor || len(candidates) == 0 || len(oldSide) == 0 {
+			continue
+		}
+
+		matches := 0
+		for i := 0; i+len(oldSide) <= len(currentLines); i++ {
+			if slices.Equal(currentLines[i:i+len(oldSide)], oldSide) {
+				matches++
+			}
+		}
+		if matches == 1 {
+			for _, candidate := range candidates {
+				safe[candidate] = true
+			}
+		}
+		start = end - 1
+	}
+	return safe
+}
+
+// correctAgentGeneratedDiff repairs hunk counts and only the malformed bullet
+// context pattern that can be proven against the current file.
 func correctAgentGeneratedDiff(diffContent, currentContent string) string {
 	lines := strings.Split(diffContent, "\n")
 	corrected := make([]string, 0, len(lines))
 	currentLines := strings.Split(currentContent, "\n")
+	safeContext := safeMalformedContextLines(lines, currentLines)
 
 	type hunkInfo struct {
 		index    int
@@ -375,34 +458,10 @@ func correctAgentGeneratedDiff(diffContent, currentContent string) string {
 		if currentHunk != nil {
 			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
 				if strings.HasPrefix(line, " ") {
-					// Try to find matching line in file to fix whitespace/indentation
-					content := line[1:]
-					trimmedContent := strings.TrimSpace(content)
-					if len(trimmedContent) > 0 {
-						for _, fl := range currentLines {
-							if strings.TrimSpace(fl) == trimmedContent {
-								line = " " + fl // Use the actual line from the file
-								break
-							}
-						}
-					}
 					currentHunk.oldCount++
 					currentHunk.newCount++
 				} else if strings.HasPrefix(line, "-") {
-					// Agents sometimes omit the diff context prefix for Markdown
-					// bullets. If the removal payload is absent but the complete
-					// bullet exists, this is context rather than a deletion.
-					payloadExists := false
-					lineExists := false
-					for _, fl := range currentLines {
-						if fl == line[1:] {
-							payloadExists = true
-						}
-						if fl == line {
-							lineExists = true
-						}
-					}
-					if !payloadExists && lineExists {
+					if safeContext[i] {
 						line = " " + line
 						currentHunk.oldCount++
 						currentHunk.newCount++
@@ -413,32 +472,10 @@ func correctAgentGeneratedDiff(diffContent, currentContent string) string {
 					currentHunk.newCount++
 				}
 				corrected = append(corrected, line)
-			} else if len(strings.TrimSpace(line)) > 0 && !strings.HasPrefix(line, "---") && !strings.HasPrefix(line, "+++") && !strings.HasPrefix(line, "@@") {
-				// Line without prefix - try to guess if it's context or addition
-				trimmedContent := strings.TrimSpace(line)
-				foundInFile := false
-				for _, fl := range currentLines {
-					if strings.TrimSpace(fl) == trimmedContent {
-						foundInFile = true
-						line = " " + fl // Treat as context
-						break
-					}
-				}
-				if !foundInFile {
-					if !strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "-") && !strings.HasPrefix(line, " ") {
-						line = "+ " + line // Treat as addition
-					}
-					currentHunk.newCount++
-				} else {
-					currentHunk.oldCount++
-					currentHunk.newCount++
-				}
-				corrected = append(corrected, line)
-			} else if line == "" && i < len(lines)-1 {
-				// Treat empty line as context if it's inside a hunk
+			} else if safeContext[i] {
 				currentHunk.oldCount++
 				currentHunk.newCount++
-				corrected = append(corrected, " ")
+				corrected = append(corrected, " "+line)
 			} else {
 				// Non-diff line ends the hunk
 				corrected[currentHunk.index] = fmt.Sprintf("@@ -%s,%d +%s,%d @@",
@@ -470,6 +507,8 @@ func correctAgentGeneratedDiff(diffContent, currentContent string) string {
 // applyDiffPatchFlexible tries multiple approaches to apply diffs
 func applyDiffPatchFlexible(currentContent, diffContent string) (string, error) {
 	fmt.Printf("🔍 Attempting flexible diff patch approach\n")
+	currentContent = normalizeLineEndings(currentContent)
+	diffContent = normalizeLineEndings(diffContent)
 
 	var result string
 	var err error
@@ -485,7 +524,13 @@ func applyDiffPatchFlexible(currentContent, diffContent string) (string, error) 
 			fmt.Printf("✅ Corrected diff applied successfully\n")
 			return validateAndRepairJSON(result), nil
 		}
-		fmt.Printf("⚠️ Corrected diff failed, trying original: %v\n", err)
+		fmt.Printf("⚠️ Corrected diff failed strict patch, trying exact fallback: %v\n", err)
+		result, fallbackErr := applyAgentGeneratedDiffFallback(currentContent, correctedDiff)
+		if fallbackErr == nil {
+			fmt.Printf("✅ Corrected diff applied through exact fallback\n")
+			return validateAndRepairJSON(result), nil
+		}
+		fmt.Printf("⚠️ Corrected diff fallback failed, trying original: %v\n", fallbackErr)
 	}
 
 	// Try the original diff

--- a/workspace/handlers/diff_patch.go
+++ b/workspace/handlers/diff_patch.go
@@ -517,7 +517,7 @@ func applyDiffPatchFlexible(currentContent, diffContent string) (string, error) 
 	correctedDiff := correctAgentGeneratedDiff(diffContent, currentContent)
 	if correctedDiff != diffContent {
 		fmt.Printf("🔧 Applied automatic corrections to agent-generated diff\n")
-		fmt.Printf("🔍 Corrected diff:\n%s\n", correctedDiff)
+		fmt.Printf("🔍 Corrected diff:\n%s\n", diffPatchErrorPreview(correctedDiff))
 		// Try the corrected diff first
 		result, err = applyDiffPatch(currentContent, correctedDiff)
 		if err == nil {
@@ -716,6 +716,7 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 		// Fuzzy match: find position with minimum mismatches
 
 		bestMatchIndex := -1
+		exactMatchCount := 0
 
 		minMismatches := len(expectedLines) + 1
 
@@ -744,6 +745,10 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 			}
 
+			if mismatches == 0 {
+				exactMatchCount++
+			}
+
 			if mismatches < minMismatches {
 
 				minMismatches = mismatches
@@ -752,12 +757,9 @@ func applyAgentGeneratedDiffFallback(currentContent, diffContent string) (string
 
 			}
 
-			if mismatches == 0 {
-
-				break // Perfect match!
-
-			}
-
+		}
+		if exactMatchCount > 1 {
+			return "", fmt.Errorf("fallback hunk context is ambiguous: %d exact matches; provide current line numbers or more unique context", exactMatchCount)
 		}
 
 		if minMismatches <= maxAllowedMismatches {

--- a/workspace/handlers/diff_patch_test.go
+++ b/workspace/handlers/diff_patch_test.go
@@ -60,7 +60,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 - Complete project analysis`,
 		},
 		{
-			name: "Diff without newline ending (should fail validation)",
+			name: "Diff without newline ending is normalized",
 			currentContent: `# Todo List
 
 ## Objective`,
@@ -68,8 +68,12 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 +++ b/todo.md
 @@ -1,2 +1,3 @@
  # Todo List
-+**No Newline**: This should fail validation`,
-			expectedError: true, // Should fail validation due to missing newline
++**No Newline**: This should be normalized`,
+			expectedError: false,
+			expectedResult: `# Todo List
+**No Newline**: This should be normalized
+
+## Objective`,
 		},
 		{
 			name: "Diff with proper newline ending",
@@ -120,7 +124,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 			expectedError: true, // Should fail due to context mismatch
 		},
 		{
-			name: "Simplified diff format (should fail with patch command)",
+			name: "Simplified diff format with exact context",
 			currentContent: `# Todo List
 
 ## Objective
@@ -137,7 +141,16 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 
  ## Objective
 `,
-			expectedError: true, // Simplified diffs should fail - this is expected
+			expectedError: false,
+			expectedResult: `# Todo List
+**Simplified Patch**: This was added via simplified diff.
+
+## Objective
+- Complete project analysis
+- Generate comprehensive report
+
+## Notes
+- Leverages tavily-search for comprehensive research`,
 		},
 		{
 			name: "Single addition only (simplified format - should fail)",
@@ -188,7 +201,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name: "Context lines with minus instead of space (should be auto-corrected)",
+			name: "Ambiguous non-contiguous bullet context is rejected",
 			currentContent: `# Todo List
 
 ## Objective
@@ -200,12 +213,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 - Complete project analysis
 +- Test patch: Added via AI agent
 `,
-			expectedError: false, // Should be auto-corrected and succeed
-			expectedResult: `# Todo List
-
-## Objective
-- Complete project analysis
-- Test patch: Added via AI agent`,
+			expectedError: true,
 		},
 		{
 			name: "Real agent-generated diff pattern (should be auto-corrected)",
@@ -228,7 +236,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 - Test patch: Added via diff tool`,
 		},
 		{
-			name: "Agent diff with invalid line references (should be auto-corrected)",
+			name: "Ambiguous invalid line references are rejected",
 			currentContent: `## Notes
 - Each todo builds on previous research to create comprehensive analysis
 - Success criteria are measurable and tied to specific deliverables
@@ -239,11 +247,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 @@ -last,2 +last-1,1 @@
  - Dependencies ensure logical progression of analysis depth
 -Updated for testing.`,
-			expectedError: false, // Should be auto-corrected and succeed
-			expectedResult: `## Notes
-- Each todo builds on previous research to create comprehensive analysis
-- Success criteria are measurable and tied to specific deliverables
-- Dependencies ensure logical progression of analysis depth`,
+			expectedError: true,
 		},
 	}
 
@@ -396,9 +400,9 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 `,
 			expected: `--- a/todo.md
 +++ b/todo.md
-@@ -1,3 +1,4 @@
+@@ -1,2 +1,3 @@
  # Todo List
-  Complete project analysis
+ - Complete project analysis
 +- Test patch: Added via AI agent
 `,
 		},
@@ -417,8 +421,7 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 @@ -1,3 +1,4 @@
  # Todo List
 +**New addition**: Added via unified diff.
-
- ## Objective
+` + " \n" + ` ## Objective
 `,
 		},
 		{
@@ -433,10 +436,10 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 `,
 			expected: `--- a/todo.md
 +++ b/todo.md
-@@ -1,4 +1,5 @@
+@@ -1,3 +1,4 @@
  # Todo List
-  Complete project analysis
-  Generate comprehensive report
+ - Complete project analysis
+ - Generate comprehensive report
 +- Test patch: Added via AI agent
 `,
 		},

--- a/workspace/handlers/diff_patch_test.go
+++ b/workspace/handlers/diff_patch_test.go
@@ -225,6 +225,22 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name: "Duplicate exact fallback context is rejected",
+			currentContent: `## Section
+same value
+
+## Section
+same value`,
+			diffContent: `--- a/todo.md
++++ b/todo.md
+@@ -100,2 +100,3 @@
+ ## Section
+ same value
++new value
+`,
+			expectedError: true,
+		},
+		{
 			name: "Real agent-generated diff pattern (should be auto-corrected)",
 			currentContent: `## Notes
 - Each todo builds on previous research to create comprehensive analysis

--- a/workspace/handlers/diff_patch_test.go
+++ b/workspace/handlers/diff_patch_test.go
@@ -153,7 +153,7 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 - Leverages tavily-search for comprehensive research`,
 		},
 		{
-			name: "Single addition only (simplified format - should fail)",
+			name: "Simplified addition with unique full-file context",
 			currentContent: `# Todo List
 
 ## Objective
@@ -175,7 +175,16 @@ func TestApplyDiffPatchFlexible(t *testing.T) {
 ## Notes
 - Leverages tavily-search for comprehensive research
 `,
-			expectedError: true, // Simplified diffs should fail - this is expected
+			expectedError: false,
+			expectedResult: `# Todo List
+**Single Addition**: This is a test.
+
+## Objective
+- Complete project analysis
+- Generate comprehensive report
+
+## Notes
+- Leverages tavily-search for comprehensive research`,
 		},
 		{
 			name: "Empty diff (should fail validation)",
@@ -327,8 +336,7 @@ func TestValidateDiffFormat(t *testing.T) {
 @@ -1,3 +1,4 @@
  # Header
 +New line
-
- ## Section
+` + " \n" + ` ## Section
 `,
 			expectError: false,
 		},
@@ -390,7 +398,24 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "Correct context lines with minus instead of space",
+			name: "Correct contiguous bullet context with an explicit anchor",
+			input: `--- a/todo.md
++++ b/todo.md
+@@ -3,2 +3,3 @@
+ ## Objective
+- Complete project analysis
++- Test patch: Added via AI agent
+`,
+			expected: `--- a/todo.md
++++ b/todo.md
+@@ -3,2 +3,3 @@
+ ## Objective
+ - Complete project analysis
++- Test patch: Added via AI agent
+`,
+		},
+		{
+			name: "Do not correct non-contiguous bullet context",
 			input: `--- a/todo.md
 +++ b/todo.md
 @@ -1,3 +1,4 @@
@@ -400,9 +425,9 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 `,
 			expected: `--- a/todo.md
 +++ b/todo.md
-@@ -1,2 +1,3 @@
+@@ -1,2 +1,2 @@
  # Todo List
- - Complete project analysis
+- Complete project analysis
 +- Test patch: Added via AI agent
 `,
 		},
@@ -413,8 +438,7 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 @@ -1,3 +1,4 @@
  # Todo List
 +**New addition**: Added via unified diff.
-
- ## Objective
+` + " \n" + ` ## Objective
 `,
 			expected: `--- a/todo.md
 +++ b/todo.md
@@ -425,19 +449,19 @@ func TestCorrectAgentGeneratedDiff(t *testing.T) {
 `,
 		},
 		{
-			name: "Multiple context line corrections",
+			name: "Multiple contiguous bullet context corrections",
 			input: `--- a/todo.md
 +++ b/todo.md
-@@ -1,4 +1,5 @@
- # Todo List
+@@ -3,3 +3,4 @@
+ ## Objective
 - Complete project analysis
 - Generate comprehensive report
 +- Test patch: Added via AI agent
 `,
 			expected: `--- a/todo.md
 +++ b/todo.md
-@@ -1,3 +1,4 @@
- # Todo List
+@@ -3,3 +3,4 @@
+ ## Objective
  - Complete project analysis
  - Generate comprehensive report
 +- Test patch: Added via AI agent

--- a/workspace/security/isolator.go
+++ b/workspace/security/isolator.go
@@ -79,6 +79,38 @@ func (iso *Isolator) sandboxPath(path string) string {
 	return canonicalPath(path)
 }
 
+func pathWithin(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// sandboxAllowedPath resolves an allow-list entry without letting a path that
+// was granted inside the workspace escape through a symlink. Absolute paths
+// outside BaseDir remain valid because callers use them for explicit host
+// grants such as Downloads access.
+func (iso *Isolator) sandboxAllowedPath(path string) (string, bool) {
+	baseDir := filepath.Clean(iso.getBaseDir())
+	canonicalBaseDir := canonicalPath(baseDir)
+	workspaceScoped := !filepath.IsAbs(path)
+
+	resolvedPath := path
+	if workspaceScoped {
+		resolvedPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
+	} else {
+		resolvedPath = filepath.Clean(path)
+		workspaceScoped = pathWithin(resolvedPath, baseDir) || pathWithin(resolvedPath, canonicalBaseDir)
+	}
+
+	canonicalAllowedPath := canonicalPath(resolvedPath)
+	if workspaceScoped && !pathWithin(canonicalAllowedPath, canonicalBaseDir) {
+		return "", false
+	}
+	return canonicalAllowedPath, true
+}
+
 // ExecuteIsolated runs a command with filesystem restrictions
 // Uses unshare on Linux, sandbox-exec on macOS
 // Returns the command, a cleanup function, and an error
@@ -210,7 +242,10 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Allowed read paths\n")
 		sb.WriteString("(allow file-read*\n")
 		for _, path := range iso.ReadPaths {
-			fullPath := iso.sandboxPath(path)
+			fullPath, ok := iso.sandboxAllowedPath(path)
+			if !ok {
+				continue
+			}
 			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n\n")
@@ -221,7 +256,10 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Allowed write paths\n")
 		sb.WriteString("(allow file-read* file-write*\n")
 		for _, path := range iso.WritePaths {
-			fullPath := iso.sandboxPath(path)
+			fullPath, ok := iso.sandboxAllowedPath(path)
+			if !ok {
+				continue
+			}
 			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n\n")

--- a/workspace/security/isolator.go
+++ b/workspace/security/isolator.go
@@ -24,7 +24,6 @@ type Isolator struct {
 	BaseDir           string // Workspace base directory (default: /app/workspace-docs)
 }
 
-
 const defaultBaseDir = "/app/workspace-docs"
 
 // getBaseDir returns the configured base directory or the default
@@ -33,6 +32,51 @@ func (iso *Isolator) getBaseDir() string {
 		return iso.BaseDir
 	}
 	return defaultBaseDir
+}
+
+// canonicalPath returns the kernel-visible spelling of a path. macOS exposes
+// /var and /tmp through symlinks to /private; sandbox-exec rules written with
+// the unresolved spelling do not protect the resolved path.
+func canonicalPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = filepath.Clean(path)
+	}
+	if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
+		return resolved
+	}
+
+	// Write targets may not exist yet. Resolve the nearest existing ancestor,
+	// then append the missing suffix without changing its meaning.
+	ancestor := absPath
+	var suffix []string
+	for {
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return filepath.Clean(absPath)
+		}
+		suffix = append([]string{filepath.Base(ancestor)}, suffix...)
+		ancestor = parent
+		if resolved, err := filepath.EvalSymlinks(ancestor); err == nil {
+			parts := append([]string{resolved}, suffix...)
+			return filepath.Join(parts...)
+		}
+	}
+}
+
+func sandboxQuoted(path string) string {
+	path = strings.ReplaceAll(path, `\`, `\\`)
+	return strings.ReplaceAll(path, `"`, `\"`)
+}
+
+func (iso *Isolator) sandboxPath(path string) string {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(iso.getBaseDir(), strings.TrimSuffix(path, "/"))
+	}
+	return canonicalPath(path)
 }
 
 // ExecuteIsolated runs a command with filesystem restrictions
@@ -123,18 +167,15 @@ func (iso *Isolator) generateSandboxProfile() string {
 	sb.WriteString("(version 1)\n")
 	sb.WriteString("(allow default)\n\n")
 
-	baseDir := iso.getBaseDir()
+	baseDir := canonicalPath(iso.getBaseDir())
 
 	// Mode 1: BlockedPaths only (deny-list mode for chat)
 	if len(iso.BlockedPaths) > 0 && len(iso.ReadPaths) == 0 && len(iso.WritePaths) == 0 {
 		sb.WriteString("; Deny-list mode: block specific paths\n")
 		sb.WriteString("(deny file-read* file-write*\n")
 		for _, path := range iso.BlockedPaths {
-			fullPath := path
-			if !strings.HasPrefix(path, "/") {
-				fullPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
-			}
-			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", fullPath))
+			fullPath := iso.sandboxPath(path)
+			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n\n")
 
@@ -147,19 +188,20 @@ func (iso *Isolator) generateSandboxProfile() string {
 	// .env files) then re-allow only workspace-docs subpaths within it.
 	// Everything else (home dir tool configs, system paths) stays accessible
 	// so CLIs like aws, gcloud, kubectl, docker etc. work normally.
-	projectRoot := filepath.Dir(baseDir)
+	projectRoot := canonicalPath(filepath.Dir(baseDir))
 	sb.WriteString("; Deny project root (source code, server configs, .env)\n")
-	sb.WriteString(fmt.Sprintf("(deny file-read* file-write* (subpath \"%s\"))\n\n", projectRoot))
+	sb.WriteString(fmt.Sprintf("(deny file-read* file-write* (subpath \"%s\"))\n\n", sandboxQuoted(projectRoot)))
 
-	// Allow the shell to read the working directory and its parents for getcwd().
-	workDir := iso.WorkDir
+	// getcwd() only needs directory metadata. Granting file-read* on WorkDir
+	// would expose its entire subtree and bypass the allow-list.
+	workDir := canonicalPath(iso.WorkDir)
 	if workDir != "" {
-		sb.WriteString("; Allow working directory access\n")
-		sb.WriteString(fmt.Sprintf("(allow file-read* (subpath \"%s\"))\n", workDir))
-		for dir := filepath.Dir(workDir); strings.HasPrefix(dir, baseDir) && dir != baseDir; dir = filepath.Dir(dir) {
-			sb.WriteString(fmt.Sprintf("(allow file-read-data (literal \"%s\"))\n", dir))
+		sb.WriteString("; Allow working directory metadata for getcwd\n")
+		sb.WriteString(fmt.Sprintf("(allow file-read-metadata (literal \"%s\"))\n", sandboxQuoted(workDir)))
+		for dir := filepath.Dir(workDir); strings.HasPrefix(dir, baseDir+string(filepath.Separator)); dir = filepath.Dir(dir) {
+			sb.WriteString(fmt.Sprintf("(allow file-read-metadata (literal \"%s\"))\n", sandboxQuoted(dir)))
 		}
-		sb.WriteString(fmt.Sprintf("(allow file-read-data (literal \"%s\"))\n", baseDir))
+		sb.WriteString(fmt.Sprintf("(allow file-read-metadata (literal \"%s\"))\n", sandboxQuoted(baseDir)))
 		sb.WriteString("\n")
 	}
 
@@ -168,11 +210,8 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Allowed read paths\n")
 		sb.WriteString("(allow file-read*\n")
 		for _, path := range iso.ReadPaths {
-			fullPath := path
-			if !strings.HasPrefix(path, "/") {
-				fullPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
-			}
-			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", fullPath))
+			fullPath := iso.sandboxPath(path)
+			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n\n")
 	}
@@ -182,11 +221,8 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Allowed write paths\n")
 		sb.WriteString("(allow file-read* file-write*\n")
 		for _, path := range iso.WritePaths {
-			fullPath := path
-			if !strings.HasPrefix(path, "/") {
-				fullPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
-			}
-			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", fullPath))
+			fullPath := iso.sandboxPath(path)
+			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n\n")
 	}
@@ -196,11 +232,8 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Explicit deny for blocked paths (overrides allows)\n")
 		sb.WriteString("(deny file-read* file-write*\n")
 		for _, path := range iso.BlockedPaths {
-			fullPath := path
-			if !strings.HasPrefix(path, "/") {
-				fullPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
-			}
-			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", fullPath))
+			fullPath := iso.sandboxPath(path)
+			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n")
 	}
@@ -211,11 +244,8 @@ func (iso *Isolator) generateSandboxProfile() string {
 		sb.WriteString("; Explicit deny for write-only blocked paths (reads allowed)\n")
 		sb.WriteString("(deny file-write*\n")
 		for _, path := range iso.BlockedWritePaths {
-			fullPath := path
-			if !strings.HasPrefix(path, "/") {
-				fullPath = filepath.Join(baseDir, strings.TrimSuffix(path, "/"))
-			}
-			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", fullPath))
+			fullPath := iso.sandboxPath(path)
+			sb.WriteString(fmt.Sprintf("  (subpath \"%s\")\n", sandboxQuoted(fullPath)))
 		}
 		sb.WriteString(")\n")
 	}
@@ -357,7 +387,6 @@ func (iso *Isolator) generateMountScript(command string, args []string) string {
 		}
 		sb.WriteString("\n")
 	}
-
 
 	// Change to working directory
 	sb.WriteString(fmt.Sprintf("cd \"%s\"\n", iso.WorkDir))

--- a/workspace/security/isolator_test.go
+++ b/workspace/security/isolator_test.go
@@ -463,6 +463,107 @@ func TestDownloadsRequiresExplicitPermission(t *testing.T) {
 	}
 }
 
+func TestSandboxAllowPathsRejectWorkspaceSymlinkEscapes(t *testing.T) {
+	root := t.TempDir()
+	baseDir := filepath.Join(root, "workspace-docs")
+	outsideDir := filepath.Join(root, "repo-secrets")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("mkdir outside target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("secret"), 0644); err != nil {
+		t.Fatalf("write outside secret: %v", err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(baseDir, "escaped-read")); err != nil {
+		t.Fatalf("create read symlink: %v", err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(baseDir, "escaped-write")); err != nil {
+		t.Fatalf("create write symlink: %v", err)
+	}
+
+	iso := &Isolator{
+		ReadPaths:  []string{"escaped-read"},
+		WritePaths: []string{filepath.Join(baseDir, "escaped-write")},
+		WorkDir:    baseDir,
+		BaseDir:    baseDir,
+	}
+
+	profile := iso.generateSandboxProfile()
+	canonicalOutside := canonicalPath(outsideDir)
+	if strings.Contains(profile, fmt.Sprintf("(subpath \"%s\")", canonicalOutside)) {
+		t.Fatalf("workspace symlink escape was re-allowed in sandbox profile:\n%s", profile)
+	}
+
+	if path, ok := iso.sandboxAllowedPath("escaped-read"); ok || path != "" {
+		t.Fatalf("relative workspace symlink escape accepted: path=%q ok=%v", path, ok)
+	}
+	if path, ok := iso.sandboxAllowedPath(filepath.Join(baseDir, "escaped-write")); ok || path != "" {
+		t.Fatalf("absolute workspace symlink escape accepted: path=%q ok=%v", path, ok)
+	}
+
+	if runtime.GOOS == "darwin" {
+		t.Run("RealSandboxBlocksEscapedRead", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd, cleanup, err := iso.ExecuteIsolated(ctx, "cat", []string{filepath.Join(baseDir, "escaped-read", "secret.txt")})
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err != nil {
+				t.Fatalf("prepare isolated read: %v", err)
+			}
+			if output, err := cmd.CombinedOutput(); err == nil {
+				t.Fatalf("sandbox read escaped through workspace symlink: %s", output)
+			}
+		})
+
+		t.Run("RealSandboxBlocksEscapedWrite", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			createdPath := filepath.Join(baseDir, "escaped-write", "created.txt")
+			cmd, cleanup, err := iso.ExecuteIsolated(ctx, "touch", []string{createdPath})
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err != nil {
+				t.Fatalf("prepare isolated write: %v", err)
+			}
+			if output, err := cmd.CombinedOutput(); err == nil {
+				t.Fatalf("sandbox write escaped through workspace symlink: %s", output)
+			}
+			if _, err := os.Stat(filepath.Join(outsideDir, "created.txt")); !os.IsNotExist(err) {
+				t.Fatalf("escaped write created outside file: %v", err)
+			}
+		})
+	}
+}
+
+func TestSandboxAllowPathsPreserveExplicitExternalGrant(t *testing.T) {
+	root := t.TempDir()
+	baseDir := filepath.Join(root, "workspace-docs")
+	externalDir := filepath.Join(t.TempDir(), "Downloads")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.MkdirAll(externalDir, 0755); err != nil {
+		t.Fatalf("mkdir external grant: %v", err)
+	}
+
+	iso := &Isolator{BaseDir: baseDir, WorkDir: baseDir, ReadPaths: []string{externalDir}}
+	allowedPath, ok := iso.sandboxAllowedPath(externalDir)
+	if !ok {
+		t.Fatal("explicit external absolute grant was rejected")
+	}
+	if allowedPath != canonicalPath(externalDir) {
+		t.Fatalf("external grant canonicalized incorrectly: got %q want %q", allowedPath, canonicalPath(externalDir))
+	}
+	if !strings.Contains(iso.generateSandboxProfile(), fmt.Sprintf("(subpath \"%s\")", sandboxQuoted(allowedPath))) {
+		t.Fatal("explicit external absolute grant missing from sandbox profile")
+	}
+}
+
 // TestDenyListSymlinkFixup tests that Mode 1 (deny-list) preserves symlinks
 // pointing into blocked paths by generating fixup mount/allow commands.
 func TestDenyListSymlinkFixup(t *testing.T) {

--- a/workspace/security/isolator_test.go
+++ b/workspace/security/isolator_test.go
@@ -14,13 +14,13 @@ import (
 
 // TestEnvironment holds test fixtures
 type TestEnvironment struct {
-	TempDir       string
-	ReadOnlyDir   string
-	ReadWriteDir  string
-	ForbiddenDir  string
-	DownloadsDir  string
-	CleanupFuncs  []func()
-	t             *testing.T
+	TempDir      string
+	ReadOnlyDir  string
+	ReadWriteDir string
+	ForbiddenDir string
+	DownloadsDir string
+	CleanupFuncs []func()
+	t            *testing.T
 }
 
 // Setup creates test directories and files
@@ -86,6 +86,7 @@ func TestIsolatorOSDetection(t *testing.T) {
 		ReadPaths:  []string{env.ReadOnlyDir},
 		WritePaths: []string{env.ReadWriteDir},
 		WorkDir:    env.TempDir,
+		BaseDir:    env.TempDir,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -152,6 +153,7 @@ func TestMacOSSandboxProfile(t *testing.T) {
 		ReadPaths:  []string{env.ReadOnlyDir},
 		WritePaths: []string{env.ReadWriteDir},
 		WorkDir:    env.TempDir,
+		BaseDir:    env.TempDir,
 	}
 
 	profile := isolator.generateSandboxProfile()
@@ -169,11 +171,21 @@ func TestMacOSSandboxProfile(t *testing.T) {
 	}
 
 	// Verify paths are included
-	if !strings.Contains(profile, env.ReadOnlyDir) {
-		t.Errorf("Read-only path not in profile: %s", env.ReadOnlyDir)
+	canonicalReadOnly := canonicalPath(env.ReadOnlyDir)
+	if !strings.Contains(profile, canonicalReadOnly) {
+		t.Errorf("Read-only path not in profile: %s", canonicalReadOnly)
 	}
-	if !strings.Contains(profile, env.ReadWriteDir) {
-		t.Errorf("Read-write path not in profile: %s", env.ReadWriteDir)
+	canonicalReadWrite := canonicalPath(env.ReadWriteDir)
+	if !strings.Contains(profile, canonicalReadWrite) {
+		t.Errorf("Read-write path not in profile: %s", canonicalReadWrite)
+	}
+
+	canonicalWorkDir := canonicalPath(env.TempDir)
+	if strings.Contains(profile, fmt.Sprintf("(allow file-read* (subpath \"%s\"))", canonicalWorkDir)) {
+		t.Error("sandbox profile grants broad read access to the working directory")
+	}
+	if !strings.Contains(profile, fmt.Sprintf("(allow file-read-metadata (literal \"%s\"))", canonicalWorkDir)) {
+		t.Error("sandbox profile must grant only working-directory metadata access")
 	}
 
 	t.Logf("✓ Sandbox profile generated correctly:\n%s", profile)
@@ -413,8 +425,9 @@ func TestMacOSSandboxIsolation(t *testing.T) {
 	})
 }
 
-// TestDownloadsFolderException tests that Downloads is always accessible
-func TestDownloadsFolderException(t *testing.T) {
+// TestDownloadsRequiresExplicitPermission ensures a shared folder name does not
+// bypass the same allow-list applied to every other workspace path.
+func TestDownloadsRequiresExplicitPermission(t *testing.T) {
 	env := &TestEnvironment{}
 	if err := env.Setup(t); err != nil {
 		t.Fatalf("Failed to setup test environment: %v", err)
@@ -425,24 +438,27 @@ func TestDownloadsFolderException(t *testing.T) {
 	// Actual enforcement requires /app/workspace-docs structure
 
 	isolator := &Isolator{
-		ReadPaths:  []string{}, // No paths allowed
-		WritePaths: []string{}, // No paths allowed
-		WorkDir:    env.TempDir,
+		WorkDir: env.TempDir,
+		BaseDir: env.TempDir,
 	}
 
 	if runtime.GOOS == "darwin" {
 		profile := isolator.generateSandboxProfile()
-		if !strings.Contains(profile, "Downloads") {
-			t.Error("Downloads folder not found in macOS sandbox profile")
-		} else {
-			t.Log("✓ Downloads folder included in macOS sandbox profile")
+		if strings.Contains(profile, canonicalPath(env.DownloadsDir)) {
+			t.Error("Downloads must not be implicitly allowed in macOS sandbox profile")
+		}
+		isolator.ReadPaths = []string{env.DownloadsDir}
+		if !strings.Contains(isolator.generateSandboxProfile(), canonicalPath(env.DownloadsDir)) {
+			t.Error("explicit Downloads read permission missing from macOS sandbox profile")
 		}
 	} else if runtime.GOOS == "linux" {
 		script := isolator.generateMountScript("echo", []string{"test"})
-		if !strings.Contains(script, "Downloads") {
-			t.Error("Downloads folder not found in Linux mount script")
-		} else {
-			t.Log("✓ Downloads folder included in Linux mount script")
+		if strings.Contains(script, env.DownloadsDir) {
+			t.Error("Downloads must not be implicitly allowed in Linux mount script")
+		}
+		isolator.ReadPaths = []string{env.DownloadsDir}
+		if !strings.Contains(isolator.generateMountScript("echo", []string{"test"}), env.DownloadsDir) {
+			t.Error("explicit Downloads read permission missing from Linux mount script")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- make live terminal completion observable only after stream registry and subscriber cleanup finishes
- canonicalize macOS sandbox paths and restrict working-directory access to metadata so allow-list rules cannot be bypassed through `/private` symlink resolution
- make malformed agent diff recovery conservative: require headers, exact context, and unambiguous insertion points
- reject desktop releases that would downgrade package or lockfile version metadata
- update regression coverage for terminal lifecycle, sandbox behavior, and safe patch fallback

## Root causes

The terminal stream closed its `done` channel before deferred registry cleanup, allowing reconnects and tests to observe a finished-but-still-registered stream. The macOS sandbox profile used unresolved `/var` and `/tmp` paths and granted broad read access to the work directory. The legacy patch fallback also guessed through content mismatches and context-free additions. A review audit additionally found that the release preflight compared only against GitHub Latest, not a newer version already committed to `main`.

## Validation

- `go test ./...` and `go vet ./...` in `agent_go`
- targeted `go test -race` for scheduler, cost ledger, terminal leases, terminals, and server
- 50 repeated race runs of terminal live-attach lifecycle tests
- `go test ./...` and `go vet ./...` in `workspace`
- `npm test` in `frontend` (102 tests)
- `npm run build` in `frontend` (bundle budget passed)
- `bash -n` and `shellcheck` for the release script
- repository pre-commit lint and build hooks passed

This is the final integration cleanup after PRs #143-#156; follow-up roadmap work in #155 remains intentionally separate.