### PR TITLE
Allow dedicated plan tools through write guard

### DIFF
--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_agent.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_agent.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	workspacepkg "github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
 	mcpagent "github.com/manishiitg/mcpagent/agent"
 	loggerv2 "github.com/manishiitg/mcpagent/logger/v2"
 
@@ -4483,6 +4484,8 @@ func registerPlanModificationTools(
 	agentName string, // e.g., "planning agent" or "plan improvement agent"
 	unlockLearningsFunc func(context.Context, string, int) error, // Optional: function to unlock learnings after plan modifications
 ) error {
+	writeFile = withPlanMutationWriteAccess(workspacePath, writeFile)
+
 	// Note: human_feedback is already registered via WorkspaceTools (created by createCustomTools in server.go)
 	// No need to register it again here to avoid duplicate registration errors
 
@@ -4774,6 +4777,13 @@ func registerPlanModificationTools(
 	}
 
 	return nil
+}
+
+func withPlanMutationWriteAccess(workspacePath string, writeFile func(context.Context, string, string) error) func(context.Context, string, string) error {
+	planningPath := normalizePathForWorkspaceAPI("planning", workspacePath)
+	return func(ctx context.Context, path, content string) error {
+		return writeFile(workspacepkg.WithSystemManagedWritePaths(ctx, planningPath), path, content)
+	}
 }
 
 // createAddTodoTaskRouteExecutor creates an executor function for add_todo_task_route tool

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_write_access_test.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_write_access_test.go
@@ -1,0 +1,40 @@
+package step_based_workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/common"
+	workspacepkg "github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
+)
+
+func TestPlanMutationWriteAccessDoesNotUnblockGeneralFileWrites(t *testing.T) {
+	const sessionID = "plan-mutation-write-access"
+	const planPath = "Workflow/demo/planning/plan.json"
+	workspacepkg.SetSessionFolderGuard(sessionID, []string{"Workflow/demo"}, []string{"Workflow/demo"})
+	workspacepkg.SetSessionFolderGuardBlockedWritePaths(sessionID, []string{"Workflow/demo/planning"})
+	defer workspacepkg.ClearSessionShellConfig(sessionID)
+
+	client := workspacepkg.NewClient("http://unused")
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	if err := client.ValidatePathWithContext(ctx, planPath, true); err == nil {
+		t.Fatal("ordinary file write unexpectedly reached the guarded plan")
+	}
+
+	called := false
+	writeFile := withPlanMutationWriteAccess("Workflow/demo", func(callCtx context.Context, path, _ string) error {
+		called = true
+		return client.ValidatePathWithContext(callCtx, path, true)
+	})
+	if err := writeFile(ctx, planPath, `{}`); err != nil {
+		t.Fatalf("dedicated plan mutation write was blocked: %v", err)
+	}
+	if !called {
+		t.Fatal("plan mutation write callback was not called")
+	}
+
+	if err := client.ValidatePathWithContext(ctx, planPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("plan capability leaked back into the caller context: %v", err)
+	}
+}

--- a/agent_go/pkg/workspace/client.go
+++ b/agent_go/pkg/workspace/client.go
@@ -46,6 +46,38 @@ type Client struct {
 	DefaultWorkingDir string            // Default working directory for shell commands (relative to docs-dir)
 }
 
+type internalContextKey string
+
+const systemManagedWritePathsKey internalContextKey = "system_managed_write_paths"
+
+// WithSystemManagedWritePaths grants trusted Go-side tools write access to
+// system-owned paths that remain blocked from shell and general file tools.
+// The capability exists only in the in-process context and is never accepted
+// from HTTP or LLM tool arguments.
+func WithSystemManagedWritePaths(ctx context.Context, paths ...string) context.Context {
+	existing, _ := ctx.Value(systemManagedWritePathsKey).([]string)
+	granted := clonePathList(existing)
+	for _, path := range paths {
+		path = filepath.Clean(strings.TrimSpace(path))
+		if path == "." || path == "" {
+			continue
+		}
+		granted = append(granted, path)
+	}
+	return context.WithValue(ctx, systemManagedWritePathsKey, deduplicateStrings(granted))
+}
+
+func systemManagedWriteAllowed(ctx context.Context, inputPath string) bool {
+	paths, _ := ctx.Value(systemManagedWritePathsKey).([]string)
+	inputPath = filepath.Clean(inputPath)
+	for _, path := range paths {
+		if isPathUnder(inputPath, filepath.Clean(path)) {
+			return true
+		}
+	}
+	return false
+}
+
 // ClientOption is a functional option for configuring the Client
 type ClientOption func(*Client)
 
@@ -199,6 +231,18 @@ func cloneFolderGuard(guard *FolderGuardConfig) *FolderGuardConfig {
 // where session-scoped restrictions must be enforced.
 func (c *Client) ValidatePathWithContext(ctx context.Context, inputPath string, isWrite bool) error {
 	guard := c.resolveEffectiveFolderGuard(ctx)
+	if isWrite && systemManagedWriteAllowed(ctx, inputPath) {
+		// System-managed access may override a write-only deny, but never a hard
+		// read/write deny. This keeps secrets and other absolute exclusions closed.
+		if guard != nil {
+			for _, blocked := range guard.BlockedPaths {
+				if isPathUnder(filepath.Clean(inputPath), filepath.Clean(blocked)) {
+					return fmt.Errorf("path %q is blocked", inputPath)
+				}
+			}
+		}
+		return nil
+	}
 	if guard == nil || !guard.Enabled {
 		return nil
 	}

--- a/agent_go/pkg/workspace/client_test.go
+++ b/agent_go/pkg/workspace/client_test.go
@@ -116,6 +116,33 @@ func TestResolveEffectiveFolderGuardPreservesReadOnlyAndDenyPaths(t *testing.T) 
 	}
 }
 
+func TestSystemManagedWritePathsOverrideWriteOnlyDeny(t *testing.T) {
+	sessionID := "system-managed-write-session"
+	SetSessionFolderGuard(sessionID, []string{"Workflow/demo"}, []string{"Workflow/demo"})
+	SetSessionFolderGuardBlockedPaths(sessionID, []string{"Workflow/demo/secrets"})
+	SetSessionFolderGuardBlockedWritePaths(sessionID, []string{"Workflow/demo/planning"})
+	defer ClearSessionShellConfig(sessionID)
+
+	client := NewClient("http://unused")
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	planPath := "Workflow/demo/planning/plan.json"
+
+	if err := client.ValidatePathWithContext(ctx, planPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("ordinary session write should remain blocked, got %v", err)
+	}
+
+	managedCtx := WithSystemManagedWritePaths(ctx, "Workflow/demo/planning")
+	if err := client.ValidatePathWithContext(managedCtx, planPath, true); err != nil {
+		t.Fatalf("trusted plan write should bypass write-only deny: %v", err)
+	}
+	if err := client.ValidatePathWithContext(managedCtx, "Workflow/demo/secrets/token.txt", true); err == nil || !strings.Contains(err.Error(), "is blocked") {
+		t.Fatalf("system-managed write must not bypass hard deny, got %v", err)
+	}
+	if err := client.ValidatePathWithContext(managedCtx, "Workflow/other/planning/plan.json", true); err == nil {
+		t.Fatal("system-managed capability escaped its workflow planning path")
+	}
+}
+
 // TestValidatePathAgainstGuard_BlockedPathsStillDeniesBoth asserts that the
 // pre-existing BlockedPaths semantic — "deny both reads and writes" — is
 // unchanged by the addition of BlockedWritePaths. These are two independent


### PR DESCRIPTION
## Summary
- keep `planning/` blocked for shell and general workspace tools
- grant dedicated plan mutation tools an in-process, workflow-scoped write capability
- preserve hard-deny paths and prevent capability leakage

## Root cause
`update_message_sequence_step` correctly used the managed plan writer, but the workspace client resolved the session folder guard first and rejected its internal `planning/plan.json` write. This was not a transient lock.

## Verification
- `go test ./...`
- `go vet ./...`
- targeted guard and plan-mutation regression tests
- pre-commit gitleaks, golangci-lint, Go builds, workspace build, Electron directory build