### PR TITLE
Fix child rate-limit watchdog stopping parent schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The high-level loop is documented in [Workflow self-improvement & reporting](doc
 
 A standalone macOS app is available — no Docker, no manual server setup. Each release is published at [Releases](https://github.com/manishiitg/coding-agent-loop/releases/latest).
 
-Rename note: the public product is **AgentWorks** and the GitHub repository is now `coding-agent-loop`. Some release assets and compatibility identifiers still use the historical `Runloop` name so existing installs and update checks remain compatible. The former `mcp-agent-builder-go` repository URL redirects to this repository but should not be used in new documentation.
+Rename note: the public product and macOS bundle are **AgentWorks** and the GitHub repository is `coding-agent-loop`. Release asset filenames and compatibility identifiers still use the historical `Runloop` name so existing installs and update checks remain compatible. The installer upgrades and removes the former `Runloop.app` bundle after `AgentWorks.app` is copied successfully. The former `mcp-agent-builder-go` repository URL redirects to this repository but should not be used in new documentation.
 
 ### Install (one-liner — recommended)
 
@@ -65,7 +65,7 @@ Downloads the latest dmg, installs the Mac app to `/Applications`, ensures the M
 
 ### Install manually
 
-1. Download the macOS dmg from the latest release. During the rename transition, the file may still be named `Runloop-<version>-arm64.dmg`.
+1. Download the macOS dmg from the latest release. During the rename transition, the file remains named `Runloop-<version>-arm64.dmg` so older app versions can update.
 2. Open the dmg, drag the app to Applications.
 
 ### First-launch error: *"AgentWorks is damaged and can't be opened"*
@@ -74,11 +74,11 @@ The current build is **unsigned and not notarized**, so macOS Gatekeeper flags i
 
 **Recommended — Terminal (works on all macOS versions):**
 ```bash
-xattr -cr /Applications/Runloop.app
-```
-If your installed app is already named AgentWorks, use:
-```bash
 xattr -cr /Applications/AgentWorks.app
+```
+For an older release that is still installed under the legacy name, use:
+```bash
+xattr -cr /Applications/Runloop.app
 ```
 Then double-click the app. If macOS still complains, also strip the dmg you downloaded:
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The high-level loop is documented in [Workflow self-improvement & reporting](doc
 
 A standalone macOS app is available — no Docker, no manual server setup. Each release is published at [Releases](https://github.com/manishiitg/coding-agent-loop/releases/latest).
 
-Rename note: the public product and macOS bundle are **AgentWorks** and the GitHub repository is `coding-agent-loop`. Release asset filenames and compatibility identifiers still use the historical `Runloop` name so existing installs and update checks remain compatible. The installer upgrades and removes the former `Runloop.app` bundle after `AgentWorks.app` is copied successfully. The former `mcp-agent-builder-go` repository URL redirects to this repository but should not be used in new documentation.
+Rename note: the public product and macOS bundle are **AgentWorks** and the GitHub repository is `coding-agent-loop`. New desktop releases use `AgentWorks-*` filenames. The historical local data directory is retained so existing local workflows remain available. The former `mcp-agent-builder-go` repository URL redirects to this repository but should not be used in new documentation.
 
 ### Install (one-liner — recommended)
 
@@ -65,7 +65,7 @@ Downloads the latest dmg, installs the Mac app to `/Applications`, ensures the M
 
 ### Install manually
 
-1. Download the macOS dmg from the latest release. During the rename transition, the file remains named `Runloop-<version>-arm64.dmg` so older app versions can update.
+1. Download the `AgentWorks-<version>-arm64.dmg` file from the latest release.
 2. Open the dmg, drag the app to Applications.
 
 ### First-launch error: *"AgentWorks is damaged and can't be opened"*
@@ -82,7 +82,7 @@ xattr -cr /Applications/Runloop.app
 ```
 Then double-click the app. If macOS still complains, also strip the dmg you downloaded:
 ```bash
-xattr -cr ~/Downloads/Runloop-*.dmg
+xattr -cr ~/Downloads/AgentWorks-*.dmg
 ```
 `sudo` is **not** needed — you own the app since you dragged it into Applications.
 

--- a/agent_go/cmd/server/background_agents.go
+++ b/agent_go/cmd/server/background_agents.go
@@ -5,16 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"github.com/manishiitg/coding-agent-loop/agent_go/cmd/server/services"
-	virtualtools "github.com/manishiitg/coding-agent-loop/agent_go/cmd/server/virtual-tools"
-	"github.com/manishiitg/coding-agent-loop/agent_go/internal/events"
-	agent "github.com/manishiitg/coding-agent-loop/agent_go/pkg/agentwrapper"
-	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/common"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/manishiitg/coding-agent-loop/agent_go/cmd/server/services"
+	virtualtools "github.com/manishiitg/coding-agent-loop/agent_go/cmd/server/virtual-tools"
+	"github.com/manishiitg/coding-agent-loop/agent_go/internal/events"
+	agent "github.com/manishiitg/coding-agent-loop/agent_go/pkg/agentwrapper"
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/common"
 
 	mcpagent "github.com/manishiitg/mcpagent/agent"
 	unifiedevents "github.com/manishiitg/mcpagent/events"
@@ -862,9 +863,9 @@ func (api *StreamingAPI) autoNotificationSessionUnreachable(sessionID string) bo
 	}
 }
 
-// markSessionStopped records that a user explicitly stopped this session.
-// In-flight goroutines check this before spawning new workshop sessions or
-// step execution processes. See stoppedSessions field comment for full bug description.
+// markSessionStopped records that this session must not spawn more work. User
+// stops are the common case; fatal runtime cancellation also uses this guard
+// while preserving an error lifecycle status.
 func (api *StreamingAPI) markSessionStopped(sessionID string) {
 	api.stoppedSessionsMu.Lock()
 	api.stoppedSessions[sessionID] = true
@@ -879,8 +880,8 @@ func (api *StreamingAPI) clearSessionStopped(sessionID string) {
 	api.stoppedSessionsMu.Unlock()
 }
 
-// isSessionMarkedStopped returns true if the user explicitly stopped this session
-// and no new user message has reactivated it yet.
+// isSessionMarkedStopped returns true while the session has a hard cancellation
+// guard and no new user message has explicitly reactivated it.
 func (api *StreamingAPI) isSessionMarkedStopped(sessionID string) bool {
 	api.stoppedSessionsMu.RLock()
 	defer api.stoppedSessionsMu.RUnlock()

--- a/agent_go/cmd/server/coding_agent_tmux_reaper.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper.go
@@ -338,11 +338,11 @@ func piCLIConflictStatusShouldStop(status string) bool {
 }
 
 func codingAgentSnapshotIsMainAgent(snapshot terminals.Snapshot) bool {
-	if kind := strings.TrimSpace(snapshot.ExecutionKind); kind != "" && kind != "main_agent" {
-		return false
+	if kind := strings.ToLower(strings.TrimSpace(snapshot.ExecutionKind)); kind != "" {
+		return kind == "main_agent" || kind == "main" || kind == "chat"
 	}
 	owner := strings.TrimSpace(snapshot.OwnerID)
-	return owner == "" || owner == snapshot.SessionID || strings.HasPrefix(owner, "main:")
+	return owner != "" && (owner == snapshot.SessionID || strings.HasPrefix(owner, "main:"))
 }
 
 func codingAgentSnapshotWorkingDir(snapshot terminals.Snapshot) string {

--- a/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
+++ b/agent_go/cmd/server/coding_agent_tmux_reaper_test.go
@@ -415,19 +415,34 @@ func TestSessionHasLiveCodingTmuxTracksReap(t *testing.T) {
 	store := terminals.NewStore()
 	sessionID := "idle-active-session"
 	tmuxSession := "mlp-pi-cli-active"
-	store.HandleEvent(sessionID, codingAgentTmuxReaperChunkEvent(time.Now(), sessionID, "main:"+sessionID, tmuxSession))
+	store.HandleEvent(sessionID, codingAgentTmuxReaperChunkEvent(time.Now(), sessionID, "workflow-step:child", "mlp-pi-cli-child"))
 	api := &StreamingAPI{terminalStore: store}
 
 	if !api.sessionHasLiveCodingTmux(sessionID) {
+		t.Fatal("expected child pane to count as aggregate live session work")
+	}
+	if api.sessionHasLiveMainCodingTmux(sessionID) {
+		t.Fatal("child pane must not count as a live main chat terminal")
+	}
+
+	store.HandleEvent(sessionID, codingAgentTmuxReaperChunkEvent(time.Now(), sessionID, "main:"+sessionID, tmuxSession))
+
+	if !api.sessionHasLiveCodingTmux(sessionID) {
 		t.Fatal("expected a live coding tmux while the pane is Active with a tmux_session")
+	}
+	if !api.sessionHasLiveMainCodingTmux(sessionID) {
+		t.Fatal("expected a live main coding tmux for the main-agent pane")
 	}
 
 	// Reap the pane (the 3h idle path): MarkStale clears Active + TmuxSession.
 	if _, ok := store.MarkStale(sessionID + ":main:" + sessionID); !ok {
 		t.Fatal("expected to mark the terminal stale")
 	}
+	if _, ok := store.MarkStale(sessionID + ":workflow-step:child"); !ok {
+		t.Fatal("expected to mark the child terminal stale")
+	}
 	if api.sessionHasLiveCodingTmux(sessionID) {
-		t.Fatal("expected no live coding tmux after the pane was reaped/stale")
+		t.Fatal("expected no live coding tmux after all panes were reaped/stale")
 	}
 
 	// A nil store / unknown session must be safe (no panic, false).
@@ -436,6 +451,27 @@ func TestSessionHasLiveCodingTmuxTracksReap(t *testing.T) {
 	}
 	if api.sessionHasLiveCodingTmux("never-seen") {
 		t.Fatal("expected false for an unknown session")
+	}
+}
+
+func TestCodingAgentSnapshotIsMainAgentRequiresOwnershipEvidence(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot terminals.Snapshot
+		want     bool
+	}{
+		{name: "unknown metadata", snapshot: terminals.Snapshot{SessionID: "session-1"}, want: false},
+		{name: "explicit main kind", snapshot: terminals.Snapshot{SessionID: "session-1", ExecutionKind: "main_agent"}, want: true},
+		{name: "explicit child kind overrides owner", snapshot: terminals.Snapshot{SessionID: "session-1", ExecutionKind: "workflow_step", OwnerID: "main:session-1"}, want: false},
+		{name: "legacy main owner", snapshot: terminals.Snapshot{SessionID: "session-1", OwnerID: "main:session-1"}, want: true},
+		{name: "child owner", snapshot: terminals.Snapshot{SessionID: "session-1", OwnerID: "workflow-step:collect"}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := codingAgentSnapshotIsMainAgent(test.snapshot); got != test.want {
+				t.Fatalf("codingAgentSnapshotIsMainAgent() = %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/agent_go/cmd/server/coding_tmux_watchdog.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog.go
@@ -120,10 +120,14 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]cod
 
 		isMainAgent := codingAgentSnapshotIsMainAgent(snap)
 		if isMainAgent {
-			log.Printf("[CODING_WATCHDOG] main session %s tmux %s parked on a usage/rate-limit wall - force-stopping session",
+			log.Printf("[CODING_WATCHDOG] main session %s tmux %s parked on a usage/rate-limit wall - failing and canceling session runtime",
 				sessionID, tmux)
-			api.markSessionStopped(sessionID)
-			api.updateSessionStatus(sessionID, "failed")
+			// Persist failure before closing panes: stream goroutines may unwind as
+			// soon as cancellation starts and must not overwrite this as completed.
+			api.updateSessionStatus(sessionID, "error")
+			api.cancelSessionRuntimeWork(sessionID, "provider usage/rate limit reached")
+			delete(streak, watchdogKey)
+			continue
 		} else {
 			log.Printf("[CODING_WATCHDOG] child terminal %s session %s tmux %s parked on a usage/rate-limit wall - closing child only",
 				snap.TerminalID, sessionID, tmux)

--- a/agent_go/cmd/server/coding_tmux_watchdog.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog.go
@@ -23,9 +23,18 @@ const (
 	// codingWatchdogConfirmChecks is how many consecutive rate-limited
 	// observations are required before force-stopping.
 	codingWatchdogConfirmChecks = 2
+	// Only inspect the current tail. Rate-limit text can remain in tmux scrollback
+	// after a provider has recovered and resumed useful work.
+	codingWatchdogRateLimitTailLines = 40
 )
 
 var captureTmuxPanePlainForWatchdog = captureTmuxPanePlain
+var closeCodingCLITmuxForWatchdog = gracefulCloseCodingCLITmuxByName
+
+type codingWatchdogObservation struct {
+	evidence string
+	count    int
+}
 
 func (api *StreamingAPI) startCodingTmuxRateLimitWatchdog() {
 	if api == nil || api.terminalStore == nil {
@@ -34,7 +43,7 @@ func (api *StreamingAPI) startCodingTmuxRateLimitWatchdog() {
 	go func() {
 		ticker := time.NewTicker(codingWatchdogInterval)
 		defer ticker.Stop()
-		streak := make(map[string]int)
+		streak := make(map[string]codingWatchdogObservation)
 		for range ticker.C {
 			api.reapRateLimitedCodingSessionsOnce(streak)
 		}
@@ -43,7 +52,7 @@ func (api *StreamingAPI) startCodingTmuxRateLimitWatchdog() {
 		codingWatchdogInterval, codingWatchdogConfirmChecks)
 }
 
-func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int) {
+func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]codingWatchdogObservation) {
 	// Metadata listing deliberately avoids Store's content reconciliation. Actual
 	// tmux pane state below is authoritative for whether a terminal is still live.
 	// Process supervision must include terminals dismissed from presentation.
@@ -91,22 +100,35 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 			continue
 		}
 		captured := captureTmuxPanePlainForWatchdog(tmux)
-		if !terminals.DetectRateLimit(captured) {
+		evidence := codingWatchdogRateLimitEvidence(captured)
+		if evidence == "" {
 			continue
 		}
 		stillLimited[watchdogKey] = true
-		streak[watchdogKey]++
-		if streak[watchdogKey] < codingWatchdogConfirmChecks {
+		observation := streak[watchdogKey]
+		if observation.evidence == evidence {
+			observation.count++
+		} else {
+			observation = codingWatchdogObservation{evidence: evidence, count: 1}
+		}
+		streak[watchdogKey] = observation
+		if observation.count < codingWatchdogConfirmChecks {
 			log.Printf("[CODING_WATCHDOG] session %s tmux %s looks rate-limited (%d/%d) - waiting to confirm",
-				sessionID, tmux, streak[watchdogKey], codingWatchdogConfirmChecks)
+				sessionID, tmux, observation.count, codingWatchdogConfirmChecks)
 			continue
 		}
 
-		log.Printf("[CODING_WATCHDOG] session %s tmux %s parked on a usage/rate-limit wall - force-stopping",
-			sessionID, tmux)
-		api.markSessionStopped(sessionID)
-		api.updateSessionStatus(sessionID, "failed")
-		gracefulCloseCodingCLITmuxByName(tmux, "provider usage/rate limit reached")
+		isMainAgent := codingAgentSnapshotIsMainAgent(snap)
+		if isMainAgent {
+			log.Printf("[CODING_WATCHDOG] main session %s tmux %s parked on a usage/rate-limit wall - force-stopping session",
+				sessionID, tmux)
+			api.markSessionStopped(sessionID)
+			api.updateSessionStatus(sessionID, "failed")
+		} else {
+			log.Printf("[CODING_WATCHDOG] child terminal %s session %s tmux %s parked on a usage/rate-limit wall - closing child only",
+				snap.TerminalID, sessionID, tmux)
+		}
+		closeCodingCLITmuxForWatchdog(tmux, "provider usage/rate limit reached")
 		killCtx, cancel := context.WithTimeout(context.Background(), terminalTmuxActionTimeout)
 		_ = runTmuxKill(killCtx, tmux)
 		cancel()
@@ -123,6 +145,31 @@ func (api *StreamingAPI) reapRateLimitedCodingSessionsOnce(streak map[string]int
 			delete(streak, watchdogKey)
 		}
 	}
+}
+
+// codingWatchdogRateLimitEvidence returns the normalized visible tail when it
+// contains a rate-limit marker. The watchdog confirms this entire value across
+// polls, so any new output proves the pane is progressing and resets the check.
+// Old rate-limit text outside the current tail is ignored.
+func codingWatchdogRateLimitEvidence(content string) string {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	if len(lines) > codingWatchdogRateLimitTailLines {
+		lines = lines[len(lines)-codingWatchdogRateLimitTailLines:]
+	}
+	normalized := make([]string, 0, len(lines))
+	hasRateLimit := false
+	for _, line := range lines {
+		line = strings.Join(strings.Fields(line), " ")
+		if line == "" {
+			continue
+		}
+		normalized = append(normalized, strings.ToLower(line))
+		hasRateLimit = hasRateLimit || terminals.DetectRateLimit(line)
+	}
+	if !hasRateLimit {
+		return ""
+	}
+	return strings.Join(normalized, "\n")
 }
 
 type codingTmuxPaneState int

--- a/agent_go/cmd/server/coding_tmux_watchdog_test.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog_test.go
@@ -194,16 +194,22 @@ func TestCodingTmuxWatchdogRateLimitedMainStopsSession(t *testing.T) {
 	oldCapture := captureTmuxPanePlainForWatchdog
 	oldKill := runTmuxKill
 	oldClose := closeCodingCLITmuxForWatchdog
+	oldCloseAllRuntime := closeAllCodingCLISessionsForRuntimeCancel
+	oldCloseRuntime := closeCodingAgentTmuxForRuntimeCancel
 	t.Cleanup(func() {
 		runTerminalTmuxOutputCommand = oldOutput
 		captureTmuxPanePlainForWatchdog = oldCapture
 		runTmuxKill = oldKill
 		closeCodingCLITmuxForWatchdog = oldClose
+		closeAllCodingCLISessionsForRuntimeCancel = oldCloseAllRuntime
+		closeCodingAgentTmuxForRuntimeCancel = oldCloseRuntime
 	})
 	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) { return "0", nil }
 	captureTmuxPanePlainForWatchdog = func(string) string { return "You've hit your usage limit" }
 	runTmuxKill = func(context.Context, string) error { return nil }
 	closeCodingCLITmuxForWatchdog = func(string, string) bool { return true }
+	closeAllCodingCLISessionsForRuntimeCancel = func(string, string) {}
+	closeCodingAgentTmuxForRuntimeCancel = func(string, string) bool { return true }
 
 	store := terminals.NewStore()
 	sessionID := "main-rate-limited"
@@ -222,8 +228,8 @@ func TestCodingTmuxWatchdogRateLimitedMainStopsSession(t *testing.T) {
 	api.reapRateLimitedCodingSessionsOnce(streak)
 	api.reapRateLimitedCodingSessionsOnce(streak)
 
-	if got := api.activeSessions[sessionID].Status; got != "failed" {
-		t.Fatalf("main session status = %q, want failed", got)
+	if got := api.activeSessions[sessionID].Status; got != "error" {
+		t.Fatalf("main session status = %q, want error", got)
 	}
 	if !api.isSessionMarkedStopped(sessionID) {
 		t.Fatal("main rate limit did not stop the session")

--- a/agent_go/cmd/server/coding_tmux_watchdog_test.go
+++ b/agent_go/cmd/server/coding_tmux_watchdog_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/manishiitg/coding-agent-loop/agent_go/internal/terminals"
@@ -47,13 +48,16 @@ func TestCodingTmuxWatchdogReconcilesFromActualPaneState(t *testing.T) {
 	originalOutput := runTerminalTmuxOutputCommand
 	originalCapture := captureTmuxPanePlainForWatchdog
 	originalKill := runTmuxKill
+	originalClose := closeCodingCLITmuxForWatchdog
 	t.Cleanup(func() {
 		runTerminalTmuxOutputCommand = originalOutput
 		captureTmuxPanePlainForWatchdog = originalCapture
 		runTmuxKill = originalKill
+		closeCodingCLITmuxForWatchdog = originalClose
 	})
 	captureTmuxPanePlainForWatchdog = func(string) string { return "" }
 	runTmuxKill = func(context.Context, string) error { return nil }
+	closeCodingCLITmuxForWatchdog = func(string, string) bool { return true }
 
 	tests := []struct {
 		name       string
@@ -80,7 +84,7 @@ func TestCodingTmuxWatchdogReconcilesFromActualPaneState(t *testing.T) {
 			runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) {
 				return tc.paneState, tc.paneErr
 			}
-			api.reapRateLimitedCodingSessionsOnce(map[string]int{})
+			api.reapRateLimitedCodingSessionsOnce(map[string]codingWatchdogObservation{})
 
 			snapshot, ok := store.Get(terminalID)
 			if !ok {
@@ -120,14 +124,159 @@ func TestCodingTmuxWatchdogRequiresDistinctTicksPerTerminal(t *testing.T) {
 			sessionID: {SessionID: sessionID, Status: "running"},
 		},
 	}
-	streak := map[string]int{}
+	streak := map[string]codingWatchdogObservation{}
 
 	api.reapRateLimitedCodingSessionsOnce(streak)
 
 	if got := api.activeSessions[sessionID].Status; got != "running" {
 		t.Fatalf("session stopped after one tick across two terminals: %q", got)
 	}
-	if streak["mlp-codex-cli-int-one"] != 1 || streak["mlp-codex-cli-int-two"] != 1 {
+	if streak["mlp-codex-cli-int-one"].count != 1 || streak["mlp-codex-cli-int-two"].count != 1 {
 		t.Fatalf("terminal streaks = %#v, want one observation each", streak)
+	}
+}
+
+func TestCodingTmuxWatchdogRateLimitedChildDoesNotStopParent(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldCapture := captureTmuxPanePlainForWatchdog
+	oldKill := runTmuxKill
+	oldClose := closeCodingCLITmuxForWatchdog
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		captureTmuxPanePlainForWatchdog = oldCapture
+		runTmuxKill = oldKill
+		closeCodingCLITmuxForWatchdog = oldClose
+	})
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) { return "0", nil }
+	captureTmuxPanePlainForWatchdog = func(string) string { return "You've hit your usage limit" }
+	runTmuxKill = func(context.Context, string) error { return nil }
+	closeCodingCLITmuxForWatchdog = func(string, string) bool { return true }
+
+	store := terminals.NewStore()
+	sessionID := "scheduled-parent"
+	terminalID := sessionID + ":workflow-step:collect-insider"
+	store.HandleEvent(sessionID, terminalRouteChunkEvent(
+		sessionID,
+		"workflow-step:collect-insider",
+		"mlp-claude-code-child",
+		"limited",
+		1,
+	))
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+		stoppedSessions: make(map[string]bool),
+	}
+	streak := map[string]codingWatchdogObservation{}
+
+	api.reapRateLimitedCodingSessionsOnce(streak)
+	api.reapRateLimitedCodingSessionsOnce(streak)
+
+	if got := api.activeSessions[sessionID].Status; got != "running" {
+		t.Fatalf("parent status = %q, want running", got)
+	}
+	if api.isSessionMarkedStopped(sessionID) {
+		t.Fatal("child rate limit marked the parent session stopped")
+	}
+	snapshot, ok := store.Get(terminalID)
+	if !ok {
+		t.Fatal("child terminal snapshot missing")
+	}
+	if snapshot.State != "failed" || snapshot.Active {
+		t.Fatalf("child state/active = %q/%v, want failed/false", snapshot.State, snapshot.Active)
+	}
+}
+
+func TestCodingTmuxWatchdogRateLimitedMainStopsSession(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldCapture := captureTmuxPanePlainForWatchdog
+	oldKill := runTmuxKill
+	oldClose := closeCodingCLITmuxForWatchdog
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		captureTmuxPanePlainForWatchdog = oldCapture
+		runTmuxKill = oldKill
+		closeCodingCLITmuxForWatchdog = oldClose
+	})
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) { return "0", nil }
+	captureTmuxPanePlainForWatchdog = func(string) string { return "You've hit your usage limit" }
+	runTmuxKill = func(context.Context, string) error { return nil }
+	closeCodingCLITmuxForWatchdog = func(string, string) bool { return true }
+
+	store := terminals.NewStore()
+	sessionID := "main-rate-limited"
+	event := terminalRouteChunkEvent(sessionID, "main:"+sessionID, "mlp-claude-code-main", "limited", 1)
+	event.ExecutionKind = "main_agent"
+	store.HandleEvent(sessionID, event)
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+		stoppedSessions: make(map[string]bool),
+	}
+	streak := map[string]codingWatchdogObservation{}
+
+	api.reapRateLimitedCodingSessionsOnce(streak)
+	api.reapRateLimitedCodingSessionsOnce(streak)
+
+	if got := api.activeSessions[sessionID].Status; got != "failed" {
+		t.Fatalf("main session status = %q, want failed", got)
+	}
+	if !api.isSessionMarkedStopped(sessionID) {
+		t.Fatal("main rate limit did not stop the session")
+	}
+}
+
+func TestCodingTmuxWatchdogRequiresStableEvidence(t *testing.T) {
+	oldOutput := runTerminalTmuxOutputCommand
+	oldCapture := captureTmuxPanePlainForWatchdog
+	t.Cleanup(func() {
+		runTerminalTmuxOutputCommand = oldOutput
+		captureTmuxPanePlainForWatchdog = oldCapture
+	})
+	runTerminalTmuxOutputCommand = func(context.Context, ...string) (string, error) { return "0", nil }
+	contents := []string{
+		"You've hit your usage limit · resets at 10:00\nretrying request",
+		"You've hit your usage limit · resets at 10:00\nrequest resumed",
+	}
+	captureTmuxPanePlainForWatchdog = func(string) string {
+		content := contents[0]
+		contents = contents[1:]
+		return content
+	}
+
+	store := terminals.NewStore()
+	sessionID := "main-session"
+	store.HandleEvent(sessionID, terminalRouteChunkEvent(sessionID, "main:"+sessionID, "mlp-claude-main", "limited", 1))
+	api := &StreamingAPI{
+		terminalStore: store,
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "running"},
+		},
+		stoppedSessions: make(map[string]bool),
+	}
+	streak := map[string]codingWatchdogObservation{}
+
+	api.reapRateLimitedCodingSessionsOnce(streak)
+	api.reapRateLimitedCodingSessionsOnce(streak)
+
+	if got := streak["mlp-claude-main"].count; got != 1 {
+		t.Fatalf("changing evidence count = %d, want reset to 1", got)
+	}
+	if got := api.activeSessions[sessionID].Status; got != "running" {
+		t.Fatalf("session status = %q, want running", got)
+	}
+}
+
+func TestCodingWatchdogRateLimitEvidenceIgnoresOldScrollback(t *testing.T) {
+	lines := []string{"You've hit your usage limit"}
+	for i := 0; i < codingWatchdogRateLimitTailLines; i++ {
+		lines = append(lines, "current progress")
+	}
+	if got := codingWatchdogRateLimitEvidence(strings.Join(lines, "\n")); got != "" {
+		t.Fatalf("old scrollback evidence = %q, want empty", got)
 	}
 }

--- a/agent_go/cmd/server/polling.go
+++ b/agent_go/cmd/server/polling.go
@@ -49,7 +49,7 @@ func (api *StreamingAPI) canSteerSession(sessionID string) bool {
 	// pane currently looks busy — the busy-content heuristic stands in for the
 	// missing turn-cancel proof, so foreground control goes to a working agent
 	// rather than treating the turn as complete.
-	return api.terminalStore != nil && api.terminalStore.SessionHasBusyCodingTmux(sessionID)
+	return api.terminalStore != nil && api.terminalStore.SessionHasBusyMainCodingTmux(sessionID)
 }
 
 func (api *StreamingAPI) shouldCompleteIdleForegroundSession(sessionID, status string, hasRunningBackgroundAgents bool) bool {

--- a/agent_go/cmd/server/scheduler.go
+++ b/agent_go/cmd/server/scheduler.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/robfig/cron/v3"
 	virtualtools "github.com/manishiitg/coding-agent-loop/agent_go/cmd/server/virtual-tools"
 	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/fsutil"
 	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/schedulerstate"
 	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/workflowtypes"
+	"github.com/robfig/cron/v3"
 )
 
 const scheduledBackgroundNoPollingInstruction = "After launching background workflow or step work, do not babysit it with sleep/list_executions/query_step polling loops. Use at most one immediate query_step if you need to confirm the execution_id/status, then stop; [AUTO-NOTIFICATION] messages will resume the conversation when background work completes."
@@ -1216,88 +1216,7 @@ func (s *SchedulerService) cancelScheduledSessionWork(sessionID, closeReason str
 	if s == nil || s.api == nil || strings.TrimSpace(sessionID) == "" {
 		return
 	}
-	// Make every scheduler-level stop visible to the sequence waiter before
-	// clearing busy state. This prevents the next workflow/Pulse/Org Pulse
-	// message from starting after either a user stop or timeout recovery.
-	s.api.markSessionStopped(sessionID)
-
-	// Cancel agent execution context
-	s.api.agentCancelMux.Lock()
-	if cancelFunc, exists := s.api.agentCancelFuncs[sessionID]; exists {
-		cancelFunc()
-		delete(s.api.agentCancelFuncs, sessionID)
-	}
-	s.api.agentCancelMux.Unlock()
-
-	// Cancel workflow orchestrator contexts
-	s.api.sessionQueryIDMux.Lock()
-	queryIDs := s.api.sessionQueryIDs[sessionID]
-	delete(s.api.sessionQueryIDs, sessionID)
-	s.api.sessionQueryIDMux.Unlock()
-
-	if len(queryIDs) > 0 {
-		s.api.workflowOrchestratorContextMux.Lock()
-		for _, qid := range queryIDs {
-			if cancelFunc, exists := s.api.workflowOrchestratorContexts[qid]; exists {
-				cancelFunc()
-				delete(s.api.workflowOrchestratorContexts, qid)
-			}
-		}
-		s.api.workflowOrchestratorContextMux.Unlock()
-	}
-
-	// Cancel background agents
-	if s.api.bgAgentRegistry != nil {
-		s.api.bgAgentRegistry.CancelAll(sessionID)
-	}
-	s.api.cancelTrackedExecutionsForSession(sessionID)
-	s.api.setSyntheticTurn(sessionID, false)
-	s.api.setSessionBusy(sessionID, false)
-	s.api.pendingMu.Lock()
-	delete(s.api.pendingCompletions, sessionID)
-	delete(s.api.completionRetryScheduled, sessionID)
-	s.api.pendingMu.Unlock()
-	s.api.pendingStartMu.Lock()
-	delete(s.api.pendingStartNotifications, sessionID)
-	delete(s.api.startNotificationRetryScheduled, sessionID)
-	s.api.pendingStartMu.Unlock()
-	s.api.lastQueryMu.Lock()
-	delete(s.api.lastQueryRequests, sessionID)
-	s.api.lastQueryMu.Unlock()
-
-	// Close tmux-backed coding-CLI sessions. Canceling the Go contexts above tears
-	// down the streaming/orchestration server-side, but the CLI processes inside
-	// the tmux panes (the scheduled run's main agent + any step sub-agents) keep
-	// running their current turn until they finish naturally — so the job showed
-	// "stopped" in the UI while the main agent kept going. Mirror handleStopSession:
-	// gracefully close the main-agent session by owner, then enumerate this
-	// session's terminals and tear down each sub-agent pane by name (a scheduled
-	// stop is a hard, full stop — always cancel sub-agents).
-	closeAllCodingCLIInteractiveSessionsForOwner(sessionID, closeReason)
-	if s.api.terminalStore != nil {
-		closedTmux := make(map[string]struct{})
-		for _, snap := range s.api.terminalStore.ListRaw(sessionID) {
-			tmux := strings.TrimSpace(snap.TmuxSession)
-			if tmux == "" {
-				continue
-			}
-			if _, seen := closedTmux[tmux]; !seen {
-				if !closeCodingAgentTmuxSessionByName(tmux, closeReason) {
-					scheduleLogf("[SCHEDULER] failed to close tmux %q (owner %s)", tmux, strings.TrimSpace(snap.OwnerID))
-					continue
-				}
-				closedTmux[tmux] = struct{}{}
-				if registry := s.api.ensureTerminalLeaseRegistry(); registry != nil {
-					registry.MarkClosed(tmux, closeReason, time.Now())
-				}
-			}
-			if snap.Active {
-				s.api.terminalStore.MarkFailed(snap.TerminalID)
-			}
-			s.api.terminalStore.MarkProcessClosed(snap.TerminalID, closeReason)
-		}
-	}
-
+	s.api.cancelSessionRuntimeWork(sessionID, closeReason)
 }
 
 // triggerSchedule is called by the tick loop when a schedule is due.
@@ -3092,6 +3011,7 @@ var schedulerWorkshopMaxInactivity = 10 * time.Minute
 var schedulerGoalAdvisorMaxInactivity = 30 * time.Minute
 var errWorkshopIdleWaitTimeout = errors.New("workshop idle wait timed out")
 var errWorkshopSequenceInterrupted = errors.New("workshop sequence interrupted by user")
+var errWorkshopSessionFailed = errors.New("workshop session failed")
 
 const schedulerWorkshopIdleConsecutiveChecks = 2
 
@@ -3109,6 +3029,10 @@ func (s *SchedulerService) waitForWorkshopIdleWithInactivityTimeout(ctx context.
 	lastObservedProgress := s.workshopLastProgressAt(sessionID)
 	lastProgressAt := time.Now()
 	checkUserInterruption := func() error {
+		if activeSession, exists := s.api.getActiveSession(sessionID); exists &&
+			normalizeSessionLifecycleStatus(activeSession.Status) == sessionLifecycleFailed {
+			return fmt.Errorf("%w: session %s status is %s", errWorkshopSessionFailed, sessionID, activeSession.Status)
+		}
 		if s.api.isSessionMarkedStopped(sessionID) {
 			return fmt.Errorf("%w: session %s was stopped", errWorkshopSequenceInterrupted, sessionID)
 		}

--- a/agent_go/cmd/server/scheduler_test.go
+++ b/agent_go/cmd/server/scheduler_test.go
@@ -2340,6 +2340,25 @@ func TestWaitForWorkshopIdleTreatsTmuxRefreshFailureAsInactivity(t *testing.T) {
 	}
 }
 
+func TestWaitForWorkshopIdleReportsRuntimeFailureBeforeStopGuard(t *testing.T) {
+	sessionID := "session-runtime-failed"
+	api := &StreamingAPI{
+		activeSessions: map[string]*ActiveSessionInfo{
+			sessionID: {SessionID: sessionID, Status: "error"},
+		},
+		stoppedSessions: map[string]bool{sessionID: true},
+	}
+	svc := &SchedulerService{api: api}
+
+	err := svc.waitForWorkshopIdleWithInactivityTimeout(context.Background(), sessionID, time.Minute)
+	if !errors.Is(err, errWorkshopSessionFailed) {
+		t.Fatalf("error = %v, want errWorkshopSessionFailed", err)
+	}
+	if errors.Is(err, errWorkshopSequenceInterrupted) {
+		t.Fatalf("runtime failure was misclassified as user interruption: %v", err)
+	}
+}
+
 func TestWaitForWorkshopIdleAllowsLongRunningTmuxWithProgress(t *testing.T) {
 	oldInterval := schedulerWorkshopIdlePollInterval
 	schedulerWorkshopIdlePollInterval = time.Millisecond

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -5472,7 +5472,7 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 					// "no live tmux" so a genuinely live session is never disrupted by a
 					// spurious relaunch (its existing pane keeps streaming via the seeded
 					// PiSessionID/--resume without a re-launch).
-					if currentRuntime != nil && !api.sessionHasLiveCodingTmux(sessionID) {
+					if currentRuntime != nil && !api.sessionHasLiveMainCodingTmux(sessionID) {
 						restoredRuntime = currentRuntime
 						logfWithContext(queryLogCtx, "[CHAT_HISTORY] Active-tab auto-resume: session %s tmux is gone; routing through --resume re-launch + materialize", sessionID)
 					}
@@ -5495,7 +5495,7 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 			// AND "no live tmux" so a genuinely live session is never disrupted by a
 			// spurious relaunch.
 			if !restoredNativeCodingResume && !modeChangedThisTurn && restoredRuntime == nil &&
-				codingAgentHasNativeResume(finalProvider, underlyingAgent) && !api.sessionHasLiveCodingTmux(sessionID) {
+				codingAgentHasNativeResume(finalProvider, underlyingAgent) && !api.sessionHasLiveMainCodingTmux(sessionID) {
 				if runtime, ok, err := ReadChatHistoryRuntimeForSession(currentUserID, sessionID, workflowPhaseFolder); err != nil {
 					logfWithContext(queryLogCtx, "[CHAT_HISTORY] Materialize guard: failed to read runtime for session %s: %v", sessionID, err)
 				} else if ok && runtime != nil && restoredRuntimeUsesLaunchableTerminalTransport(runtime) {
@@ -5829,6 +5829,27 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[BG AGENT] Stored agent for session %s for synthetic turn reuse", sessionID)
 		}
 
+		// A stop or runtime failure may close the stream while this goroutine is
+		// still unwinding. Preserve that terminal state instead of resurrecting the
+		// session as successfully completed.
+		if activeSession, exists := api.getActiveSession(sessionID); exists {
+			switch normalizeSessionLifecycleStatus(activeSession.Status) {
+			case sessionLifecycleFailed, sessionLifecycleStopped:
+				log.Printf("[COMPLETION] Preserving terminal status %q for session %s", activeSession.Status, sessionID)
+				tracer.EndTrace(traceID, map[string]interface{}{
+					"status": activeSession.Status,
+				})
+				return
+			}
+		}
+		if api.isSessionMarkedStopped(sessionID) {
+			log.Printf("[COMPLETION] Session %s has a cancellation guard; skipping completed status", sessionID)
+			tracer.EndTrace(traceID, map[string]interface{}{
+				"status": "stopped",
+			})
+			return
+		}
+
 		// Update active session status to completed
 		log.Printf("[COMPLETION] Updating session %s status to completed", sessionID)
 		api.updateSessionStatus(sessionID, "completed")
@@ -6093,6 +6114,21 @@ func (api *StreamingAPI) sessionHasLiveCodingTmux(sessionID string) bool {
 	}
 	for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
 		if snapshot.Active && strings.TrimSpace(snapshot.TmuxSession) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionHasLiveMainCodingTmux reports whether the main chat agent has a live
+// tmux pane. A child workflow/background pane is aggregate session activity,
+// but it cannot receive or preserve main-chat input.
+func (api *StreamingAPI) sessionHasLiveMainCodingTmux(sessionID string) bool {
+	if api == nil || api.terminalStore == nil {
+		return false
+	}
+	for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
+		if snapshot.Active && strings.TrimSpace(snapshot.TmuxSession) != "" && codingAgentSnapshotIsMainAgent(snapshot) {
 			return true
 		}
 	}
@@ -6872,7 +6908,7 @@ func (api *StreamingAPI) tryDeliverQueryAsLiveInput(w http.ResponseWriter, r *ht
 		return false
 	}
 	hasActiveForegroundTurn := api.hasActiveTurnCancel(sessionID)
-	if !hasActiveForegroundTurn && !api.sessionHasLiveCodingTmux(sessionID) {
+	if !hasActiveForegroundTurn && !api.sessionHasLiveMainCodingTmux(sessionID) {
 		log.Printf("[QUERY→LIVE] Retained CLI agent for session %s has no active turn and no live tmux; starting a new turn", sessionID)
 		return false
 	}
@@ -6984,7 +7020,7 @@ func (api *StreamingAPI) handleLiveInputMessage(w http.ResponseWriter, r *http.R
 		return
 	}
 	hasActiveForegroundTurn := api.hasActiveTurnCancel(sessionID)
-	if !hasActiveForegroundTurn && agentSupportsLiveInputDelivery(runningAgent) && !api.sessionHasLiveCodingTmux(sessionID) {
+	if !hasActiveForegroundTurn && agentSupportsLiveInputDelivery(runningAgent) && !api.sessionHasLiveMainCodingTmux(sessionID) {
 		log.Printf("[LIVE INPUT] Retained CLI agent for session %s has no active turn and no live tmux; starting next turn", sessionID)
 		api.setSessionBusy(sessionID, false)
 		if api.startNextTurnFromLiveInput(w, r, sessionID, req.Message, runningAgent) {

--- a/agent_go/cmd/server/session_lifecycle.go
+++ b/agent_go/cmd/server/session_lifecycle.go
@@ -7,17 +7,21 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/browser"
-	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/browser"
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
+
 	llmproviders "github.com/manishiitg/multi-llm-provider-go"
 
 	mcpagent "github.com/manishiitg/mcpagent/agent"
 )
+
+var closeAllCodingCLISessionsForRuntimeCancel = closeAllCodingCLIInteractiveSessionsForOwner
+var closeCodingAgentTmuxForRuntimeCancel = closeCodingAgentTmuxSessionByName
 
 // handleCancelCurrentTurn cancels only the currently running LLM turn for a session.
 // It must not mark the session stopped or tear down workshop/background state.
@@ -54,6 +58,85 @@ func (api *StreamingAPI) handleCancelCurrentTurn(w http.ResponseWriter, r *http.
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// cancelSessionRuntimeWork stops all runtime work owned by a session. The
+// stopped guard prevents in-flight goroutines from spawning more work after
+// cancellation; callers remain responsible for recording whether the terminal
+// lifecycle is stopped, failed, or another final state.
+func (api *StreamingAPI) cancelSessionRuntimeWork(sessionID, closeReason string) {
+	if api == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	api.markSessionStopped(sessionID)
+
+	api.agentCancelMux.Lock()
+	if cancelFunc, exists := api.agentCancelFuncs[sessionID]; exists {
+		cancelFunc()
+		delete(api.agentCancelFuncs, sessionID)
+	}
+	api.agentCancelMux.Unlock()
+
+	api.sessionQueryIDMux.Lock()
+	queryIDs := api.sessionQueryIDs[sessionID]
+	delete(api.sessionQueryIDs, sessionID)
+	api.sessionQueryIDMux.Unlock()
+
+	if len(queryIDs) > 0 {
+		api.workflowOrchestratorContextMux.Lock()
+		for _, queryID := range queryIDs {
+			if cancelFunc, exists := api.workflowOrchestratorContexts[queryID]; exists {
+				cancelFunc()
+				delete(api.workflowOrchestratorContexts, queryID)
+			}
+		}
+		api.workflowOrchestratorContextMux.Unlock()
+	}
+
+	if api.bgAgentRegistry != nil {
+		api.bgAgentRegistry.CancelAll(sessionID)
+	}
+	api.cancelTrackedExecutionsForSession(sessionID)
+	api.setSyntheticTurn(sessionID, false)
+	api.setSessionBusy(sessionID, false)
+
+	api.pendingMu.Lock()
+	delete(api.pendingCompletions, sessionID)
+	delete(api.completionRetryScheduled, sessionID)
+	api.pendingMu.Unlock()
+	api.pendingStartMu.Lock()
+	delete(api.pendingStartNotifications, sessionID)
+	delete(api.startNotificationRetryScheduled, sessionID)
+	api.pendingStartMu.Unlock()
+	api.lastQueryMu.Lock()
+	delete(api.lastQueryRequests, sessionID)
+	api.lastQueryMu.Unlock()
+
+	closeAllCodingCLISessionsForRuntimeCancel(sessionID, closeReason)
+	if api.terminalStore == nil {
+		return
+	}
+	closedTmux := make(map[string]struct{})
+	for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
+		tmuxSession := strings.TrimSpace(snapshot.TmuxSession)
+		if tmuxSession == "" {
+			continue
+		}
+		if _, seen := closedTmux[tmuxSession]; !seen {
+			if !closeCodingAgentTmuxForRuntimeCancel(tmuxSession, closeReason) {
+				log.Printf("[SESSION CANCEL] failed to close tmux %q (owner %s)", tmuxSession, strings.TrimSpace(snapshot.OwnerID))
+				continue
+			}
+			closedTmux[tmuxSession] = struct{}{}
+			if registry := api.ensureTerminalLeaseRegistry(); registry != nil {
+				registry.MarkClosed(tmuxSession, closeReason, time.Now())
+			}
+		}
+		if snapshot.Active {
+			api.terminalStore.MarkFailed(snapshot.TerminalID)
+		}
+		api.terminalStore.MarkProcessClosed(snapshot.TerminalID, closeReason)
+	}
 }
 
 // closeAllCodingCLIInteractiveSessionsForOwner tears down the persistent

--- a/agent_go/internal/terminals/rate_limit.go
+++ b/agent_go/internal/terminals/rate_limit.go
@@ -15,7 +15,9 @@ import (
 //
 // Ordering matters: more specific provider-prefixed patterns come
 // first so we attribute correctly. Generic fallback patterns at the
-// end catch any provider that prints a recognizable phrase.
+// end catch any provider that prints a recognizable phrase. Callers that take
+// destructive action must add recency and repeated-observation checks; this
+// matcher also powers a non-destructive UI status badge.
 var rateLimitPatterns = []*regexp.Regexp{
 	// Claude Code: prints messages like "5-hour limit reached", "Your
 	// usage limit will reset at <time>", "You have run out of credits",

--- a/agent_go/internal/terminals/store.go
+++ b/agent_go/internal/terminals/store.go
@@ -311,12 +311,26 @@ func (s *Store) ListRaw(sessionID string) []Snapshot {
 // last-refreshed pane snapshot (the frontend probe refreshes inactive tmux
 // terminals every few seconds), so this is an in-memory read, no tmux capture.
 func (s *Store) SessionHasBusyCodingTmux(sessionID string) bool {
+	return s.sessionHasBusyCodingTmux(sessionID, false)
+}
+
+// SessionHasBusyMainCodingTmux applies the same live-pane busy check but only
+// to the session's main coding agent. Child workflow/background terminals must
+// not make chat input steerable when the main pane is absent.
+func (s *Store) SessionHasBusyMainCodingTmux(sessionID string) bool {
+	return s.sessionHasBusyCodingTmux(sessionID, true)
+}
+
+func (s *Store) sessionHasBusyCodingTmux(sessionID string, mainOnly bool) bool {
 	if s == nil {
 		return false
 	}
 	// Dismissal only hides a terminal from the UI. A dismissed live pane still
 	// owns runtime work and must remain visible to busy/input routing.
 	for _, snapshot := range s.ListRaw(sessionID) {
+		if mainOnly && !currentTerminalIsMainAgent(snapshot) {
+			continue
+		}
 		if strings.TrimSpace(snapshot.TmuxSession) == "" {
 			continue
 		}
@@ -1304,7 +1318,11 @@ func currentTerminalIsMainAgent(snapshot Snapshot) bool {
 		return false
 	}
 	kind := strings.ToLower(strings.TrimSpace(firstNonEmpty(snapshot.ExecutionKind, snapshot.Scope)))
-	return kind == "main_agent" || kind == "main" || kind == "chat"
+	if kind != "" {
+		return kind == "main_agent" || kind == "main" || kind == "chat"
+	}
+	owner := strings.TrimSpace(snapshot.OwnerID)
+	return owner != "" && (owner == snapshot.SessionID || strings.HasPrefix(owner, "main:"))
 }
 
 func shouldPreferTerminalSnapshot(candidate, existing Snapshot) bool {

--- a/agent_go/internal/terminals/store_test.go
+++ b/agent_go/internal/terminals/store_test.go
@@ -2333,6 +2333,41 @@ func TestSessionHasBusyCodingTmuxIgnoresCompletedTerminal(t *testing.T) {
 	}
 }
 
+func TestSessionHasBusyMainCodingTmuxIgnoresBusyChild(t *testing.T) {
+	store := NewStore()
+	store.HandleEvent("session-1", terminalEventWithMetadata(
+		"workflow-step:collect-data",
+		cursorBusyPaneFixture,
+		0,
+		map[string]interface{}{
+			"tmux_session":   "mlp-cursor-cli-child",
+			"execution_kind": "workflow_step",
+		},
+		time.Now(),
+	))
+
+	if !store.SessionHasBusyCodingTmux("session-1") {
+		t.Fatal("busy child should count as aggregate session activity")
+	}
+	if store.SessionHasBusyMainCodingTmux("session-1") {
+		t.Fatal("busy child must not make the main chat agent steerable")
+	}
+
+	store.HandleEvent("session-1", terminalEventWithMetadata(
+		"main:session-1",
+		cursorBusyPaneFixture,
+		0,
+		map[string]interface{}{
+			"tmux_session":   "mlp-cursor-cli-main",
+			"execution_kind": "main_agent",
+		},
+		time.Now(),
+	))
+	if !store.SessionHasBusyMainCodingTmux("session-1") {
+		t.Fatal("busy main pane should make the main chat agent steerable")
+	}
+}
+
 func TestSessionHasRetainedCodingTmuxDoesNotRequireBusyContent(t *testing.T) {
 	store := NewStore()
 	store.HandleEvent("session-1", terminalEventWithMetadata(

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -53,7 +53,7 @@ CSC_IDENTITY_AUTO_DISCOVERY=false \
   npx electron-builder --mac dmg --publish never
 ```
 
-Artifacts currently keep the legacy `Runloop-<version>-arm64.dmg` filename for updater compatibility during the AgentWorks rename. Install: `open desktop/dist/Runloop-*.dmg` → drag the app to Applications. First launch: right-click → Open to bypass Gatekeeper.
+Artifacts keep the legacy `Runloop-<version>-arm64.dmg` filename for updater compatibility, but the bundle inside is `AgentWorks.app`. Install: `open desktop/dist/Runloop-*.dmg` → drag AgentWorks to Applications. First launch: right-click → Open to bypass Gatekeeper.
 
 ### Cutting a release via the release script
 
@@ -101,7 +101,10 @@ Right-click the menu bar icon and choose **Quit AgentWorks (Stop Servers)**, or 
 
 ### Data & Logs
 The app stores data in the system's Application Support directory:
-`~/Library/Application Support/Runloop/`
+`~/Library/Application Support/runloop-desktop/`
+
+The historical data-directory name is retained deliberately so upgrading from
+`Runloop.app` to `AgentWorks.app` does not create an empty workspace.
 
 The data path is still legacy-compatible while the rename is in progress. Do not rename it blindly without a migration.
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -53,7 +53,7 @@ CSC_IDENTITY_AUTO_DISCOVERY=false \
   npx electron-builder --mac dmg --publish never
 ```
 
-Artifacts keep the legacy `Runloop-<version>-arm64.dmg` filename for updater compatibility, but the bundle inside is `AgentWorks.app`. Install: `open desktop/dist/Runloop-*.dmg` → drag AgentWorks to Applications. First launch: right-click → Open to bypass Gatekeeper.
+Artifacts use the `AgentWorks-<version>-arm64.dmg` filename and contain `AgentWorks.app`. Install: `open desktop/dist/AgentWorks-*.dmg` → drag AgentWorks to Applications. First launch: right-click → Open to bypass Gatekeeper.
 
 ### Cutting a release via the release script
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -7,6 +7,12 @@ const detect = require('detect-port');
 const fs = require('fs');
 const crypto = require('crypto');
 
+// Keep the historical data path while presenting the AgentWorks name to macOS.
+// Changing userData would make existing installs appear empty after the rename.
+const COMPAT_USER_DATA_PATH = path.join(app.getPath('appData'), 'runloop-desktop');
+app.setName('AgentWorks');
+app.setPath('userData', COMPAT_USER_DATA_PATH);
+
 // Dynamic ports (assigned at runtime)
 let dynamicAgentPort = 0;
 let dynamicWorkspacePort = 0;
@@ -268,24 +274,24 @@ if (process.env.ELECTRON_REMOTE_DEBUG_PORT) {
 
 function migrateLegacyUserData() {
   const userDataPath = app.getPath('userData');
-  const legacyProductName = ['Agent', 'Forge'].join('');
-  const legacyUserDataPath = path.join(path.dirname(userDataPath), legacyProductName);
-
-  if (legacyUserDataPath === userDataPath || !fs.existsSync(legacyUserDataPath)) {
-    return;
-  }
-
   const hasCurrentData = fs.existsSync(userDataPath) && fs.readdirSync(userDataPath).length > 0;
   if (hasCurrentData) {
     return;
   }
 
-  try {
-    fs.mkdirSync(userDataPath, { recursive: true });
-    fs.cpSync(legacyUserDataPath, userDataPath, { recursive: true, errorOnExist: false });
-    console.log(`[main] Migrated legacy user data from ${legacyUserDataPath} to ${userDataPath}`);
-  } catch (error) {
-    console.warn('[main] Failed to migrate legacy AgentWorks user data:', error);
+  const legacyProductNames = [['Agent', 'Forge'].join(''), 'Runloop'];
+  for (const legacyProductName of legacyProductNames) {
+    const legacyUserDataPath = path.join(path.dirname(userDataPath), legacyProductName);
+    if (legacyUserDataPath === userDataPath || !fs.existsSync(legacyUserDataPath)) continue;
+
+    try {
+      fs.mkdirSync(userDataPath, { recursive: true });
+      fs.cpSync(legacyUserDataPath, userDataPath, { recursive: true, errorOnExist: false });
+      console.log(`[main] Migrated legacy user data from ${legacyUserDataPath} to ${userDataPath}`);
+      return;
+    } catch (error) {
+      console.warn(`[main] Failed to migrate legacy user data from ${legacyUserDataPath}:`, error);
+    }
   }
 }
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -279,19 +279,18 @@ function migrateLegacyUserData() {
     return;
   }
 
-  const legacyProductNames = [['Agent', 'Forge'].join(''), 'Runloop'];
-  for (const legacyProductName of legacyProductNames) {
-    const legacyUserDataPath = path.join(path.dirname(userDataPath), legacyProductName);
-    if (legacyUserDataPath === userDataPath || !fs.existsSync(legacyUserDataPath)) continue;
+  const legacyProductName = ['Agent', 'Forge'].join('');
+  const legacyUserDataPath = path.join(path.dirname(userDataPath), legacyProductName);
+  if (legacyUserDataPath === userDataPath || !fs.existsSync(legacyUserDataPath)) {
+    return;
+  }
 
-    try {
-      fs.mkdirSync(userDataPath, { recursive: true });
-      fs.cpSync(legacyUserDataPath, userDataPath, { recursive: true, errorOnExist: false });
-      console.log(`[main] Migrated legacy user data from ${legacyUserDataPath} to ${userDataPath}`);
-      return;
-    } catch (error) {
-      console.warn(`[main] Failed to migrate legacy user data from ${legacyUserDataPath}:`, error);
-    }
+  try {
+    fs.mkdirSync(userDataPath, { recursive: true });
+    fs.cpSync(legacyUserDataPath, userDataPath, { recursive: true, errorOnExist: false });
+    console.log(`[main] Migrated legacy user data from ${legacyUserDataPath} to ${userDataPath}`);
+  } catch (error) {
+    console.warn('[main] Failed to migrate legacy AgentWorks user data:', error);
   }
 }
 
@@ -1580,7 +1579,7 @@ async function downloadAndPrepareUpdate(targetVersion) {
   updateState.version = versionNoV;
   updateState.dmgPath = null;
 
-  const dmgName = `Runloop-${versionNoV}-arm64.dmg`;
+  const dmgName = `AgentWorks-${versionNoV}-arm64.dmg`;
   const url = `https://github.com/manishiitg/coding-agent-loop/releases/download/v${versionNoV}/${dmgName}`;
   const dir = updateCacheDir();
   try { fs.mkdirSync(dir, { recursive: true }); } catch (_) {}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,8 @@
   },
   "build": {
     "appId": "com.mcp-agent-builder.desktop",
-    "productName": "Runloop",
+    "productName": "AgentWorks",
+    "artifactName": "Runloop-${version}-${arch}-mac.${ext}",
     "publish": [
       "github"
     ],
@@ -24,6 +25,9 @@
         "dmg",
         "zip"
       ]
+    },
+    "dmg": {
+      "artifactName": "Runloop-${version}-${arch}.${ext}"
     },
     "extraResources": [
       {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,6 @@
   "build": {
     "appId": "com.mcp-agent-builder.desktop",
     "productName": "AgentWorks",
-    "artifactName": "Runloop-${version}-${arch}-mac.${ext}",
     "publish": [
       "github"
     ],
@@ -25,9 +24,6 @@
         "dmg",
         "zip"
       ]
-    },
-    "dmg": {
-      "artifactName": "Runloop-${version}-${arch}.${ext}"
     },
     "extraResources": [
       {

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # AgentWorks installer — downloads the latest macOS dmg from GitHub Releases,
-# upgrades either the legacy Runloop.app or AgentWorks.app installation, and
-# strips the quarantine flag so Gatekeeper does not reject the unsigned build.
+# installs AgentWorks.app, and strips the quarantine flag so Gatekeeper does
+# not reject the unsigned build.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/manishiitg/coding-agent-loop/main/install.sh | bash
@@ -12,8 +12,6 @@ set -euo pipefail
 
 REPO="manishiitg/coding-agent-loop"
 APP_NAME="AgentWorks"
-LEGACY_APP_NAME="Runloop"
-RELEASE_ASSET_NAME="Runloop"
 INSTALL_DIR="/Applications"
 
 log()  { printf '\033[1;34m[agentworks]\033[0m %s\n' "$*"; }
@@ -142,20 +140,18 @@ log "Installing version $VERSION"
 
 # ---- Quit running app -------------------------------------------------------
 
-for running_app in "$APP_NAME" "$LEGACY_APP_NAME"; do
-  if pgrep -fq "${running_app}.app/Contents/MacOS"; then
-    log "Quitting running ${running_app}…"
-    osascript -e "tell application \"${running_app}\" to quit" 2>/dev/null || true
-    sleep 1
-    # Force-kill anything still alive (helpers, leftover servers).
-    pkill -f "${running_app}.app" 2>/dev/null || true
-  fi
-done
+if pgrep -fq "${APP_NAME}.app/Contents/MacOS"; then
+  log "Quitting running ${APP_NAME}…"
+  osascript -e "tell application \"${APP_NAME}\" to quit" 2>/dev/null || true
+  sleep 1
+  # Force-kill anything still alive (helpers, leftover servers).
+  pkill -f "${APP_NAME}.app" 2>/dev/null || true
+fi
 
 # ---- Download dmg -----------------------------------------------------------
 
 VERSION_NO_V="${VERSION#v}"
-DMG_NAME="${RELEASE_ASSET_NAME}-${VERSION_NO_V}-arm64.dmg"
+DMG_NAME="${APP_NAME}-${VERSION_NO_V}-arm64.dmg"
 DMG_URL="https://github.com/${REPO}/releases/download/${VERSION}/${DMG_NAME}"
 
 TMP_DIR="$(mktemp -d -t runloop-install)"
@@ -188,13 +184,9 @@ detach_mount() { hdiutil detach -quiet "$MOUNT_POINT" 2>/dev/null || true; }
 trap 'detach_mount; rm -rf "$TMP_DIR"' EXIT
 
 SOURCE_APP="${MOUNT_POINT}/${APP_NAME}.app"
-if [ ! -d "$SOURCE_APP" ]; then
-  SOURCE_APP="${MOUNT_POINT}/${LEGACY_APP_NAME}.app"
-fi
-[ -d "$SOURCE_APP" ] || die "Could not find ${APP_NAME}.app or ${LEGACY_APP_NAME}.app inside the dmg."
+[ -d "$SOURCE_APP" ] || die "Could not find ${APP_NAME}.app inside the dmg."
 
 DEST_APP="${INSTALL_DIR}/${APP_NAME}.app"
-LEGACY_DEST_APP="${INSTALL_DIR}/${LEGACY_APP_NAME}.app"
 if [ -e "$DEST_APP" ]; then
   log "Removing existing ${DEST_APP}…"
   rm -rf "$DEST_APP" || die "Could not remove existing app. Try: sudo rm -rf '$DEST_APP'"
@@ -202,13 +194,6 @@ fi
 
 log "Copying ${APP_NAME}.app to ${INSTALL_DIR}…"
 cp -R "$SOURCE_APP" "$DEST_APP" || die "Copy failed. Make sure $INSTALL_DIR is writable, or run with sudo."
-
-# Remove the old bundle only after the new copy succeeds. The app keeps its
-# historical bundle id and user-data path, so workflows and settings remain.
-if [ "$LEGACY_DEST_APP" != "$DEST_APP" ] && [ -e "$LEGACY_DEST_APP" ]; then
-  log "Removing legacy ${LEGACY_DEST_APP}…"
-  rm -rf "$LEGACY_DEST_APP" || warn "Could not remove the legacy app. Remove it manually after confirming AgentWorks opens."
-fi
 
 ensure_mcpbridge
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Runloop installer — downloads the latest macOS dmg from GitHub Releases,
-# installs Runloop.app to /Applications, and strips the quarantine flag so
-# Gatekeeper doesn't show "Runloop is damaged".
+# AgentWorks installer — downloads the latest macOS dmg from GitHub Releases,
+# upgrades either the legacy Runloop.app or AgentWorks.app installation, and
+# strips the quarantine flag so Gatekeeper does not reject the unsigned build.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/manishiitg/coding-agent-loop/main/install.sh | bash
@@ -11,12 +11,14 @@
 set -euo pipefail
 
 REPO="manishiitg/coding-agent-loop"
-APP_NAME="Runloop"
+APP_NAME="AgentWorks"
+LEGACY_APP_NAME="Runloop"
+RELEASE_ASSET_NAME="Runloop"
 INSTALL_DIR="/Applications"
 
-log()  { printf '\033[1;34m[runloop]\033[0m %s\n' "$*"; }
-warn() { printf '\033[1;33m[runloop]\033[0m %s\n' "$*" >&2; }
-die()  { printf '\033[1;31m[runloop]\033[0m %s\n' "$*" >&2; exit 1; }
+log()  { printf '\033[1;34m[agentworks]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[agentworks]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[agentworks]\033[0m %s\n' "$*" >&2; exit 1; }
 
 # ---- Preflight --------------------------------------------------------------
 
@@ -140,18 +142,20 @@ log "Installing version $VERSION"
 
 # ---- Quit running app -------------------------------------------------------
 
-if pgrep -fq "${APP_NAME}.app/Contents/MacOS"; then
-  log "Quitting running ${APP_NAME}…"
-  osascript -e "tell application \"${APP_NAME}\" to quit" 2>/dev/null || true
-  sleep 1
-  # Force-kill anything still alive (helpers, leftover servers)
-  pkill -f "${APP_NAME}.app" 2>/dev/null || true
-fi
+for running_app in "$APP_NAME" "$LEGACY_APP_NAME"; do
+  if pgrep -fq "${running_app}.app/Contents/MacOS"; then
+    log "Quitting running ${running_app}…"
+    osascript -e "tell application \"${running_app}\" to quit" 2>/dev/null || true
+    sleep 1
+    # Force-kill anything still alive (helpers, leftover servers).
+    pkill -f "${running_app}.app" 2>/dev/null || true
+  fi
+done
 
 # ---- Download dmg -----------------------------------------------------------
 
 VERSION_NO_V="${VERSION#v}"
-DMG_NAME="${APP_NAME}-${VERSION_NO_V}-arm64.dmg"
+DMG_NAME="${RELEASE_ASSET_NAME}-${VERSION_NO_V}-arm64.dmg"
 DMG_URL="https://github.com/${REPO}/releases/download/${VERSION}/${DMG_NAME}"
 
 TMP_DIR="$(mktemp -d -t runloop-install)"
@@ -184,9 +188,13 @@ detach_mount() { hdiutil detach -quiet "$MOUNT_POINT" 2>/dev/null || true; }
 trap 'detach_mount; rm -rf "$TMP_DIR"' EXIT
 
 SOURCE_APP="${MOUNT_POINT}/${APP_NAME}.app"
-[ -d "$SOURCE_APP" ] || die "Could not find ${APP_NAME}.app inside the dmg."
+if [ ! -d "$SOURCE_APP" ]; then
+  SOURCE_APP="${MOUNT_POINT}/${LEGACY_APP_NAME}.app"
+fi
+[ -d "$SOURCE_APP" ] || die "Could not find ${APP_NAME}.app or ${LEGACY_APP_NAME}.app inside the dmg."
 
 DEST_APP="${INSTALL_DIR}/${APP_NAME}.app"
+LEGACY_DEST_APP="${INSTALL_DIR}/${LEGACY_APP_NAME}.app"
 if [ -e "$DEST_APP" ]; then
   log "Removing existing ${DEST_APP}…"
   rm -rf "$DEST_APP" || die "Could not remove existing app. Try: sudo rm -rf '$DEST_APP'"
@@ -194,6 +202,13 @@ fi
 
 log "Copying ${APP_NAME}.app to ${INSTALL_DIR}…"
 cp -R "$SOURCE_APP" "$DEST_APP" || die "Copy failed. Make sure $INSTALL_DIR is writable, or run with sudo."
+
+# Remove the old bundle only after the new copy succeeds. The app keeps its
+# historical bundle id and user-data path, so workflows and settings remain.
+if [ "$LEGACY_DEST_APP" != "$DEST_APP" ] && [ -e "$LEGACY_DEST_APP" ]; then
+  log "Removing legacy ${LEGACY_DEST_APP}…"
+  rm -rf "$LEGACY_DEST_APP" || warn "Could not remove the legacy app. Remove it manually after confirming AgentWorks opens."
+fi
 
 ensure_mcpbridge
 

--- a/scripts/desktop-release.sh
+++ b/scripts/desktop-release.sh
@@ -272,10 +272,10 @@ gh api "repos/$REPO/releases?per_page=100" \
 echo "==> Verifying assets"
 expected_assets=(
   "latest-mac.yml"
-  "Runloop-$version-arm64-mac.zip"
-  "Runloop-$version-arm64-mac.zip.blockmap"
-  "Runloop-$version-arm64.dmg"
-  "Runloop-$version-arm64.dmg.blockmap"
+  "AgentWorks-$version-arm64-mac.zip"
+  "AgentWorks-$version-arm64-mac.zip.blockmap"
+  "AgentWorks-$version-arm64.dmg"
+  "AgentWorks-$version-arm64.dmg.blockmap"
 )
 
 release_assets="$(gh release view "$tag" --repo "$REPO" --json assets --jq '.assets[].name')"


### PR DESCRIPTION
## Summary
- isolate coding-CLI rate-limit handling to the terminal that actually hit the provider limit
- preserve the scheduled parent session when a workflow child/background terminal is rate-limited
- require an unchanged recent pane tail across consecutive watchdog polls before destructive cleanup
- ignore stale rate-limit text outside the current pane tail
- treat unknown terminal ownership as non-main instead of allowing destructive parent cleanup
- separate aggregate session activity from main-agent tmux liveness for chat routing, restore, and steering
- fail and cancel the complete runtime only when the main agent itself reaches a confirmed provider limit
- preserve failed/stopped lifecycle states while streaming goroutines unwind, and report runtime failure before the user-stop guard

## Live RCA
The `tectonicusadaytrading` schedule session `schedule-cron--874d0946_1783969235420386000` launched child tmux `mlp-claude-code-1783969899652049000-934042cf` for `collect-insider`. The watchdog detected a rate-limit phrase at 00:42:05 and 00:42:35, then marked the shared parent session failed/stopped. Other workflow work continued and completed successfully after 44m25s at 01:15:24, but the completion was ignored because the parent had already been marked stopped. This left the visible orchestrator terminal parked at "Continuing to wait" and the schedule history incorrectly reported a user interruption.

## Lifecycle safeguards
- child rate limits close only the affected child terminal
- main rate limits cancel foreground work, orchestrator contexts, tracked executions, background agents, and all owned tmux panes
- a failure cancellation guard cannot later be overwritten as `completed`
- scheduler waits distinguish runtime failure from an explicit user interruption
- child/background panes still count toward overall session activity, but cannot make main chat input steerable or suppress main-terminal restoration

## Tests
- child rate limit closes only the child and keeps the parent running
- stable main-agent rate limit fails and cancels the main session
- changing pane output resets confirmation
- stale scrollback evidence is ignored
- unknown ownership is not classified as main
- child-only tmux activity is excluded from main-agent liveness and steering
- runtime failure is classified before the stop guard
- full `go test ./...`
- `go vet ./...`
- repository pre-commit build/lint/secret checks
