### PR TITLE
Improve workflow auth, planning writes, and LLM setup

### DIFF
--- a/agent_go/cmd/server/delegation.go
+++ b/agent_go/cmd/server/delegation.go
@@ -177,15 +177,31 @@ func (api *StreamingAPI) executeDelegatedTask(ctx context.Context, parentReq Que
 	// Emit delegation_start event (after model and server resolution so we can include all info)
 	api.emitDelegationStartEvent(sessionID, delegationID, currentDepth, instruction, reasoningLevel, modelID, serversList, backgroundAgentID, agentTemplateName)
 
-	// Load merged API keys (env + workspace)
-	apiKeys := MergedProviderAPIKeys(ctx)
-
 	// Get user ID from context for per-user OAuth token isolation
-	subAgentUserID := ""
+	subAgentUserID := strings.TrimSpace(parentReq.userID)
 	if userID, ok := ctx.Value(common.UserIDKey).(string); ok {
 		subAgentUserID = userID
 	}
 	log.Printf("[USER_ID_DEBUGGING] Sub-agent: subAgentUserID=%q (from parent context UserIDKey)", subAgentUserID)
+
+	// Load provider keys and add the private workflow credential only for
+	// workflow-owned delegations. Normal multi-agent chats must not inherit a
+	// credential merely because they reference a workflow folder.
+	apiKeys := MergedProviderAPIKeys(ctx)
+	workflowOwnedDelegation := parentReq.AgentMode == "workflow" || parentReq.AgentMode == "workflow_phase" || strings.TrimSpace(parentReq.PhaseID) != ""
+	if workflowOwnedDelegation {
+		workflowPath := strings.TrimSpace(parentReq.SelectedFolder)
+		if workflowPath == "" && parentReq.PresetQueryID != "" {
+			if resolved, resolveErr := api.resolveWorkspacePathFromPreset(context.Background(), parentReq.PresetQueryID); resolveErr == nil {
+				workflowPath = resolved
+			}
+		}
+		var credentialErr error
+		apiKeys, credentialErr = api.workflowProviderAPIKeys(ctx, subAgentUserID, workflowPath, apiKeys)
+		if credentialErr != nil {
+			return "", fmt.Errorf("load delegated workflow provider credentials: %w", credentialErr)
+		}
+	}
 
 	// Determine sub-agent session ID: isolated when share_browser=false, shared otherwise
 	subAgentSessionID := sessionID

--- a/agent_go/cmd/server/server.go
+++ b/agent_go/cmd/server/server.go
@@ -1591,6 +1591,9 @@ func runServer(cmd *cobra.Command, args []string) {
 	apiRouter.HandleFunc("/secrets/workflow/store", api.handleStoreWorkflowSecret).Methods("PUT", "OPTIONS")
 	apiRouter.HandleFunc("/secrets/workflow/store/{name}", api.handleDeleteWorkflowSecret).Methods("DELETE", "OPTIONS")
 	apiRouter.HandleFunc("/secrets/workflow/stored", api.handleListStoredWorkflowSecrets).Methods("GET", "OPTIONS")
+	apiRouter.HandleFunc("/workflow-provider-credentials/claude-code", api.handleGetWorkflowClaudeCodeCredential).Methods("GET", "OPTIONS")
+	apiRouter.HandleFunc("/workflow-provider-credentials/claude-code", api.handleStoreWorkflowClaudeCodeCredential).Methods("PUT", "OPTIONS")
+	apiRouter.HandleFunc("/workflow-provider-credentials/claude-code", api.handleDeleteWorkflowClaudeCodeCredential).Methods("DELETE", "OPTIONS")
 
 	// Provider API keys (encrypted file storage for scheduled runs)
 	apiRouter.HandleFunc("/provider-keys", api.handleSaveProviderKeys).Methods("PUT", "OPTIONS")
@@ -3188,7 +3191,12 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 		if workflowLLMConfig == nil {
 			workflowLLMConfig = &orchestrator.LLMConfig{}
 		}
-		workflowLLMConfig.APIKeys = MergedProviderAPIKeys(r.Context())
+		workflowKeys, credentialErr := api.workflowProviderAPIKeys(r.Context(), currentUserID, manifestWorkspacePath, MergedProviderAPIKeys(r.Context()))
+		if credentialErr != nil {
+			http.Error(w, "Failed to load workflow provider credentials", http.StatusInternalServerError)
+			return
+		}
+		workflowLLMConfig.APIKeys = workflowKeys
 
 		// Create workflow orchestrator for this request.
 		// Note: req.MaxTurns is already normalized earlier in the handler:
@@ -3728,6 +3736,13 @@ func (api *StreamingAPI) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Load merged API keys (env + workspace) while r.Context() is still valid (before goroutine)
 	mergedAPIKeys := MergedProviderAPIKeys(r.Context())
+	if isWorkflowPhase && workflowPhaseFolder != "" {
+		var credentialErr error
+		mergedAPIKeys, credentialErr = api.workflowProviderAPIKeys(r.Context(), currentUserID, workflowPhaseFolder, mergedAPIKeys)
+		if credentialErr != nil {
+			logfWithContext(queryLogCtx.WithWorkflow(workflowPhaseFolder), "[WORKFLOW_AUTH] Failed to load provider credentials: %v", credentialErr)
+		}
+	}
 
 	queryInputLaneRelease := releaseInputLane
 	if queryInputLaneRelease != nil {
@@ -7390,11 +7405,15 @@ func (api *StreamingAPI) buildWorkshopConfig(
 	if workshopLLMConfig == nil {
 		workshopLLMConfig = &orchestrator.LLMConfig{}
 	}
+	baseAPIKeys := MergedProviderAPIKeys(ctx)
 	if len(apiKeys) > 0 && apiKeys[0] != nil {
-		workshopLLMConfig.APIKeys = apiKeys[0]
-	} else {
-		workshopLLMConfig.APIKeys = MergedProviderAPIKeys(ctx)
+		baseAPIKeys = apiKeys[0]
 	}
+	workshopAPIKeys, credentialErr := api.workflowProviderAPIKeys(ctx, currentUserID, workspacePath, baseAPIKeys)
+	if credentialErr != nil {
+		return nil, fmt.Errorf("load workflow provider credentials: %w", credentialErr)
+	}
+	workshopLLMConfig.APIKeys = workshopAPIKeys
 
 	cfg := &todo_creation_human.WorkshopConfig{
 		WorkspacePath:     workspacePath,

--- a/agent_go/cmd/server/workflow_provider_auth.go
+++ b/agent_go/cmd/server/workflow_provider_auth.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/manishiitg/mcpagent/llm"
+	llmproviders "github.com/manishiitg/multi-llm-provider-go"
+)
+
+const claudeCodeProviderID = "claude-code"
+
+type workflowProviderCredentialRequest struct {
+	WorkspacePath  string `json:"workspace_path"`
+	EncryptedValue string `json:"encrypted_value"`
+}
+
+type workflowProviderCredentialStatus struct {
+	Configured bool       `json:"configured"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+}
+
+func (api *StreamingAPI) handleGetWorkflowClaudeCodeCredential(w http.ResponseWriter, r *http.Request) {
+	workspacePath := strings.TrimSpace(r.URL.Query().Get("workspace_path"))
+	if workspacePath == "" {
+		http.Error(w, "workspace_path is required", http.StatusBadRequest)
+		return
+	}
+	userID := GetUserIDFromContext(r.Context())
+	credential, err := api.chatStore.GetWorkflowProviderCredential(r.Context(), userID, workspacePath, claudeCodeProviderID)
+	if err != nil {
+		http.Error(w, "Failed to load workflow provider credential", http.StatusInternalServerError)
+		return
+	}
+	status := workflowProviderCredentialStatus{Configured: credential != nil}
+	if credential != nil {
+		updatedAt := credential.UpdatedAt
+		status.UpdatedAt = &updatedAt
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status)
+}
+
+func (api *StreamingAPI) handleStoreWorkflowClaudeCodeCredential(w http.ResponseWriter, r *http.Request) {
+	var req workflowProviderCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	req.WorkspacePath = strings.TrimSpace(req.WorkspacePath)
+	req.EncryptedValue = strings.TrimSpace(req.EncryptedValue)
+	if req.WorkspacePath == "" || req.EncryptedValue == "" {
+		http.Error(w, "workspace_path and encrypted_value are required", http.StatusBadRequest)
+		return
+	}
+
+	userID := GetUserIDFromContext(r.Context())
+	if api.workflowHasBusySession(userID, req.WorkspacePath) {
+		http.Error(w, "Stop the active workflow before changing its Claude Code token", http.StatusConflict)
+		return
+	}
+	token, err := decryptSecretValue(req.EncryptedValue, userID)
+	if err != nil {
+		http.Error(w, "Invalid encrypted credential", http.StatusBadRequest)
+		return
+	}
+	if err := validateClaudeCodeOAuthToken(r.Context(), token); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := api.chatStore.UpsertWorkflowProviderCredential(r.Context(), userID, req.WorkspacePath, claudeCodeProviderID, req.EncryptedValue); err != nil {
+		http.Error(w, "Failed to store workflow provider credential", http.StatusInternalServerError)
+		return
+	}
+	api.closeIdleWorkflowClaudeCodeSessions(userID, req.WorkspacePath, "workflow Claude Code token changed")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}
+
+func (api *StreamingAPI) handleDeleteWorkflowClaudeCodeCredential(w http.ResponseWriter, r *http.Request) {
+	workspacePath := strings.TrimSpace(r.URL.Query().Get("workspace_path"))
+	if workspacePath == "" {
+		http.Error(w, "workspace_path is required", http.StatusBadRequest)
+		return
+	}
+	userID := GetUserIDFromContext(r.Context())
+	if api.workflowHasBusySession(userID, workspacePath) {
+		http.Error(w, "Stop the active workflow before removing its Claude Code token", http.StatusConflict)
+		return
+	}
+	if err := api.chatStore.DeleteWorkflowProviderCredential(r.Context(), userID, workspacePath, claudeCodeProviderID); err != nil {
+		http.Error(w, "Failed to delete workflow provider credential", http.StatusInternalServerError)
+		return
+	}
+	api.closeIdleWorkflowClaudeCodeSessions(userID, workspacePath, "workflow Claude Code token removed")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}
+
+func validateClaudeCodeOAuthToken(parent context.Context, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("Claude Code token is required")
+	}
+	configDir, err := os.MkdirTemp("", "claude-auth-check-*")
+	if err != nil {
+		return fmt.Errorf("could not prepare Claude Code credential check")
+	}
+	defer os.RemoveAll(configDir)
+
+	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "claude", "auth", "status", "--json")
+	cmd.Env = claudeCredentialCheckEnv(os.Environ(), configDir, token)
+	output, err := cmd.Output()
+	if err != nil {
+		if errorsIsCommandNotFound(err) {
+			return fmt.Errorf("Claude Code CLI is not installed")
+		}
+		return fmt.Errorf("Claude Code did not accept the workflow token")
+	}
+	var status struct {
+		LoggedIn   bool   `json:"loggedIn"`
+		AuthMethod string `json:"authMethod"`
+	}
+	if err := json.Unmarshal(output, &status); err != nil {
+		return fmt.Errorf("Claude Code returned an unreadable authentication status")
+	}
+	if !status.LoggedIn || status.AuthMethod != "oauth_token" {
+		return fmt.Errorf("Claude Code did not recognize this as an OAuth token")
+	}
+	return nil
+}
+
+func claudeCredentialCheckEnv(base []string, configDir, token string) []string {
+	blocked := map[string]bool{
+		"ANTHROPIC_API_KEY":       true,
+		"ANTHROPIC_AUTH_TOKEN":    true,
+		"ANTHROPIC_BASE_URL":      true,
+		"CLAUDE_CODE_OAUTH_TOKEN": true,
+		"CLAUDE_CONFIG_DIR":       true,
+	}
+	out := make([]string, 0, len(base)+2)
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if blocked[key] {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, "CLAUDE_CONFIG_DIR="+configDir, "CLAUDE_CODE_OAUTH_TOKEN="+token)
+}
+
+func errorsIsCommandNotFound(err error) bool {
+	var execErr *exec.Error
+	return errors.As(err, &execErr)
+}
+
+func (api *StreamingAPI) loadWorkflowClaudeCodeOAuthToken(ctx context.Context, userID, workflowPath string) (*string, error) {
+	if strings.TrimSpace(userID) == "" || strings.TrimSpace(workflowPath) == "" {
+		return nil, nil
+	}
+	credential, err := api.chatStore.GetWorkflowProviderCredential(ctx, userID, workflowPath, claudeCodeProviderID)
+	if err != nil || credential == nil {
+		return nil, err
+	}
+	token, err := decryptSecretValue(credential.EncryptedValue, userID)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt workflow Claude Code credential: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, nil
+	}
+	return &token, nil
+}
+
+// workflowProviderAPIKeys clones the normal provider configuration and adds
+// private credentials for exactly one user/workflow. It is the only Builder
+// path allowed to populate ClaudeCodeOAuthToken.
+func (api *StreamingAPI) workflowProviderAPIKeys(ctx context.Context, userID, workflowPath string, base *llm.ProviderAPIKeys) (*llm.ProviderAPIKeys, error) {
+	keys := base.Clone()
+	if keys == nil {
+		keys = &llm.ProviderAPIKeys{}
+	}
+	token, err := api.loadWorkflowClaudeCodeOAuthToken(ctx, userID, workflowPath)
+	if err != nil {
+		// Preserve unrelated provider credentials while failing closed for the
+		// workflow token itself. Callers can then decide whether this workflow
+		// operation should stop or continue with Claude Code's saved login.
+		keys.ClaudeCodeOAuthToken = nil
+		return keys, err
+	}
+	keys.ClaudeCodeOAuthToken = token
+	return keys, nil
+}
+
+func normalizeWorkflowCredentialPath(workflowPath string) string {
+	return strings.Trim(strings.ReplaceAll(strings.TrimSpace(workflowPath), "\\", "/"), "/")
+}
+
+func (api *StreamingAPI) workflowSessionIDs(userID, workflowPath string) []string {
+	wantedUser := strings.TrimSpace(userID)
+	wanted := normalizeWorkflowCredentialPath(workflowPath)
+	if wantedUser == "" || wanted == "" {
+		return nil
+	}
+	api.activeSessionsMux.RLock()
+	defer api.activeSessionsMux.RUnlock()
+	ids := make([]string, 0)
+	for sessionID, session := range api.activeSessions {
+		if session == nil || strings.TrimSpace(session.UserID) != wantedUser || normalizeWorkflowCredentialPath(session.WorkspacePath) != wanted {
+			continue
+		}
+		ids = append(ids, sessionID)
+	}
+	return ids
+}
+
+func (api *StreamingAPI) workflowHasBusySession(userID, workflowPath string) bool {
+	for _, sessionID := range api.workflowSessionIDs(userID, workflowPath) {
+		hasBackgroundAgents := api.bgAgentRegistry != nil && api.bgAgentRegistry.HasRunningAgents(sessionID)
+		if api.isSessionBusy(sessionID) || api.canSteerSession(sessionID) || api.hasRunningTrackedExecutionForSession(sessionID) || hasBackgroundAgents {
+			return true
+		}
+	}
+	return false
+}
+
+func (api *StreamingAPI) closeIdleWorkflowClaudeCodeSessions(userID, workflowPath, reason string) {
+	for _, sessionID := range api.workflowSessionIDs(userID, workflowPath) {
+		llmproviders.CloseClaudeCodeInteractiveSessionForOwner(sessionID, reason)
+		if api.terminalStore == nil {
+			continue
+		}
+		for _, snapshot := range api.terminalStore.ListRaw(sessionID) {
+			if !strings.HasPrefix(strings.TrimSpace(snapshot.TmuxSession), "mlp-claude-code") {
+				continue
+			}
+			llmproviders.CloseClaudeCodeInteractiveSessionByTmux(snapshot.TmuxSession, reason)
+			api.terminalStore.MarkProcessClosed(snapshot.TerminalID, reason)
+		}
+	}
+}

--- a/agent_go/cmd/server/workflow_provider_auth_test.go
+++ b/agent_go/cmd/server/workflow_provider_auth_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/chathistory"
+	"github.com/manishiitg/mcpagent/llm"
+)
+
+func TestWorkflowSessionIDsAreUserAndWorkflowScoped(t *testing.T) {
+	api := &StreamingAPI{activeSessions: map[string]*ActiveSessionInfo{
+		"alice-target": {
+			SessionID:     "alice-target",
+			UserID:        "alice",
+			WorkspacePath: "Workflow/customer-renewals/",
+			LastActivity:  time.Now(),
+		},
+		"bob-same-path": {
+			SessionID:     "bob-same-path",
+			UserID:        "bob",
+			WorkspacePath: "Workflow/customer-renewals",
+		},
+		"alice-other": {
+			SessionID:     "alice-other",
+			UserID:        "alice",
+			WorkspacePath: "Workflow/support-triage",
+		},
+	}}
+
+	ids := api.workflowSessionIDs("alice", `Workflow\customer-renewals`)
+	if len(ids) != 1 || ids[0] != "alice-target" {
+		t.Fatalf("workflowSessionIDs() = %v, want [alice-target]", ids)
+	}
+	if ids := api.workflowSessionIDs("", "Workflow/customer-renewals"); len(ids) != 0 {
+		t.Fatalf("workflowSessionIDs(empty user) = %v, want none", ids)
+	}
+}
+
+func TestValidateClaudeCodeOAuthTokenUsesIsolatedAuthEnvironment(t *testing.T) {
+	fakeBin := t.TempDir()
+	capturePath := filepath.Join(fakeBin, "auth-env.txt")
+	claudePath := filepath.Join(fakeBin, "claude")
+	script := `#!/bin/sh
+printf '%s|%s|%s|%s|%s' "$ANTHROPIC_API_KEY" "$ANTHROPIC_AUTH_TOKEN" "$ANTHROPIC_BASE_URL" "$CLAUDE_CODE_OAUTH_TOKEN" "$CLAUDE_CONFIG_DIR" > "$CLAUDE_AUTH_CAPTURE"
+printf '{"loggedIn":true,"authMethod":"oauth_token","apiProvider":"firstParty"}\n'
+`
+	if err := os.WriteFile(claudePath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CLAUDE_AUTH_CAPTURE", capturePath)
+	t.Setenv("ANTHROPIC_API_KEY", "ambient-api-key")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "ambient-auth-token")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://ambient.example")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "ambient-oauth-token")
+
+	const workflowToken = "workflow-oauth-token"
+	if err := validateClaudeCodeOAuthToken(context.Background(), workflowToken); err != nil {
+		t.Fatalf("validateClaudeCodeOAuthToken() error = %v", err)
+	}
+	captured, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured auth env: %v", err)
+	}
+	parts := strings.Split(string(captured), "|")
+	if len(parts) != 5 {
+		t.Fatalf("captured env = %q", string(captured))
+	}
+	if parts[0] != "" || parts[1] != "" || parts[2] != "" {
+		t.Fatalf("ambient Anthropic credentials reached validation: %q", string(captured))
+	}
+	if parts[3] != workflowToken {
+		t.Fatalf("OAuth token = %q, want workflow token", parts[3])
+	}
+	if strings.TrimSpace(parts[4]) == "" {
+		t.Fatal("validation did not isolate Claude config directory")
+	}
+}
+
+func TestWorkflowProviderAPIKeysAreUserAndWorkflowScoped(t *testing.T) {
+	store, err := chathistory.NewFilesystemStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFilesystemStore() error = %v", err)
+	}
+	api := &StreamingAPI{chatStore: store}
+	ctx := context.Background()
+	const userID = "alice"
+	const workflowA = "Workflow/customer-renewals"
+	const workflowB = "Workflow/support-triage"
+	const workflowToken = "workflow-oauth-token"
+
+	encrypted := encryptProviderCredentialForTest(t, workflowToken, userID)
+	if err := store.UpsertWorkflowProviderCredential(ctx, userID, workflowA, claudeCodeProviderID, encrypted); err != nil {
+		t.Fatalf("UpsertWorkflowProviderCredential() error = %v", err)
+	}
+	apiKey := "direct-anthropic-key"
+	base := &llm.ProviderAPIKeys{Anthropic: &apiKey}
+
+	keysA, err := api.workflowProviderAPIKeys(ctx, userID, workflowA, base)
+	if err != nil {
+		t.Fatalf("workflowProviderAPIKeys(workflowA) error = %v", err)
+	}
+	if keysA.ClaudeCodeOAuthToken == nil || *keysA.ClaudeCodeOAuthToken != workflowToken {
+		t.Fatalf("workflow A OAuth token = %#v", keysA.ClaudeCodeOAuthToken)
+	}
+	if keysA.Anthropic == nil || *keysA.Anthropic != apiKey {
+		t.Fatalf("direct Anthropic provider key was not preserved: %#v", keysA.Anthropic)
+	}
+
+	keysB, err := api.workflowProviderAPIKeys(ctx, userID, workflowB, base)
+	if err != nil {
+		t.Fatalf("workflowProviderAPIKeys(workflowB) error = %v", err)
+	}
+	if keysB.ClaudeCodeOAuthToken != nil {
+		t.Fatalf("workflow B received workflow A token: %#v", keysB.ClaudeCodeOAuthToken)
+	}
+	keysOtherUser, err := api.workflowProviderAPIKeys(ctx, "bob", workflowA, base)
+	if err != nil {
+		t.Fatalf("workflowProviderAPIKeys(other user) error = %v", err)
+	}
+	if keysOtherUser.ClaudeCodeOAuthToken != nil {
+		t.Fatalf("other user received Alice's token: %#v", keysOtherUser.ClaudeCodeOAuthToken)
+	}
+
+	workflowSecrets, err := store.ListWorkflowSecrets(ctx, userID, workflowA)
+	if err != nil {
+		t.Fatalf("ListWorkflowSecrets() error = %v", err)
+	}
+	if len(workflowSecrets) != 0 {
+		t.Fatalf("provider credential leaked into workflow secrets: %+v", workflowSecrets)
+	}
+}
+
+func encryptProviderCredentialForTest(t *testing.T, value, userID string) string {
+	t.Helper()
+	key := deriveSecretsKey()
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes.NewCipher() error = %v", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("cipher.NewGCM() error = %v", err)
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("rand.Read() error = %v", err)
+	}
+	ciphertext := aead.Seal(nonce, nonce, []byte(value), []byte(userID))
+	return base64.StdEncoding.EncodeToString(ciphertext)
+}

--- a/agent_go/go.mod
+++ b/agent_go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/manishiitg/coding-agent-loop/workspace v0.0.0
 	github.com/manishiitg/mcpagent v1.7.10
-	github.com/manishiitg/multi-llm-provider-go v0.7.2
+	github.com/manishiitg/multi-llm-provider-go v0.7.3
 	github.com/mark3labs/mcp-go v0.45.0
 	github.com/openai/openai-go/v3 v3.36.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/agent_go/pkg/chathistory/fs_store.go
+++ b/agent_go/pkg/chathistory/fs_store.go
@@ -24,6 +24,7 @@ import (
 //	config/bot-connectors.json          — operator-level bot connector configs
 //	_users/<userID>/secrets.json                         — per-user encrypted secret blobs
 //	_users/<userID>/workflow_secrets/<workflow-hash>.json - per-workflow encrypted secret blobs
+//	_users/<userID>/workflow_provider_credentials/<workflow-hash>.json - private provider auth
 //
 // Both are loaded into memory on first access and mutated under narrow
 // mutexes. The store is built for single-instance deployments.
@@ -37,8 +38,9 @@ type FilesystemStore struct {
 	botCfgLegacyFile string
 
 	// Secrets mutexes, created on-demand.
-	secretsMu         sync.Map // userID -> *sync.Mutex
-	workflowSecretsMu sync.Map // userID + workflow path -> *sync.Mutex
+	secretsMu                     sync.Map // userID -> *sync.Mutex
+	workflowSecretsMu             sync.Map // userID + workflow path -> *sync.Mutex
+	workflowProviderCredentialsMu sync.Map // userID + workflow path -> *sync.Mutex
 }
 
 // sanitizeUserID returns a safe folder segment for a user ID. Empty or
@@ -222,6 +224,11 @@ type workflowSecretsDocument struct {
 	Secrets      map[string]*userSecretRecord `json:"secrets"`
 }
 
+type workflowProviderCredentialsDocument struct {
+	WorkflowPath string                       `json:"workflow_path"`
+	Credentials  map[string]*userSecretRecord `json:"credentials"`
+}
+
 func normalizeWorkflowSecretPath(workflowPath string) (string, error) {
 	workflowPath = strings.TrimSpace(filepath.ToSlash(workflowPath))
 	workflowPath = strings.Trim(workflowPath, "/")
@@ -256,6 +263,14 @@ func (s *FilesystemStore) workflowSecretsFile(userID, workflowPath string) (stri
 	return filepath.Join(s.rootDir, "_users", sanitizeUserID(userID), "workflow_secrets", workflowSecretPathHash(normalized)+".json"), normalized, nil
 }
 
+func (s *FilesystemStore) workflowProviderCredentialsFile(userID, workflowPath string) (string, string, error) {
+	normalized, err := normalizeWorkflowSecretPath(workflowPath)
+	if err != nil {
+		return "", "", err
+	}
+	return filepath.Join(s.rootDir, "_users", sanitizeUserID(userID), "workflow_provider_credentials", workflowSecretPathHash(normalized)+".json"), normalized, nil
+}
+
 // secretsLock returns a per-user mutex, created on demand.
 func (s *FilesystemStore) secretsLock(userID string) *sync.Mutex {
 	key := sanitizeUserID(userID)
@@ -278,6 +293,20 @@ func (s *FilesystemStore) workflowSecretsLock(userID, workflowPath string) *sync
 	}
 	m := &sync.Mutex{}
 	actual, _ := s.workflowSecretsMu.LoadOrStore(key, m)
+	return actual.(*sync.Mutex)
+}
+
+func (s *FilesystemStore) workflowProviderCredentialsLock(userID, workflowPath string) *sync.Mutex {
+	normalized, err := normalizeWorkflowSecretPath(workflowPath)
+	if err != nil {
+		normalized = strings.TrimSpace(workflowPath)
+	}
+	key := sanitizeUserID(userID) + ":" + workflowSecretPathHash(normalized)
+	if m, ok := s.workflowProviderCredentialsMu.Load(key); ok {
+		return m.(*sync.Mutex)
+	}
+	m := &sync.Mutex{}
+	actual, _ := s.workflowProviderCredentialsMu.LoadOrStore(key, m)
 	return actual.(*sync.Mutex)
 }
 
@@ -481,6 +510,110 @@ func (s *FilesystemStore) ListWorkflowSecrets(ctx context.Context, userID, workf
 		})
 	}
 	return out, nil
+}
+
+func (s *FilesystemStore) loadWorkflowProviderCredentialsLocked(userID, workflowPath string) (string, map[string]*userSecretRecord, error) {
+	path, normalized, err := s.workflowProviderCredentialsFile(userID, workflowPath)
+	if err != nil {
+		return "", nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return normalized, make(map[string]*userSecretRecord), nil
+		}
+		return "", nil, err
+	}
+	if len(data) == 0 {
+		return normalized, make(map[string]*userSecretRecord), nil
+	}
+	var doc workflowProviderCredentialsDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return "", nil, fmt.Errorf("chathistory: parse %s: %w", path, err)
+	}
+	if doc.Credentials == nil {
+		doc.Credentials = make(map[string]*userSecretRecord)
+	}
+	return normalized, doc.Credentials, nil
+}
+
+func (s *FilesystemStore) saveWorkflowProviderCredentialsLocked(userID, workflowPath string, credentials map[string]*userSecretRecord) error {
+	path, normalized, err := s.workflowProviderCredentialsFile(userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	doc := workflowProviderCredentialsDocument{WorkflowPath: normalized, Credentials: credentials}
+	return fsutil.WriteJSONAtomic(path, doc, 0600)
+}
+
+func (s *FilesystemStore) UpsertWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider, encryptedValue string) error {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if existing, ok := credentials[provider]; ok {
+		existing.EncryptedValue = encryptedValue
+		existing.UpdatedAt = now
+	} else {
+		credentials[provider] = &userSecretRecord{EncryptedValue: encryptedValue, CreatedAt: now, UpdatedAt: now}
+	}
+	return s.saveWorkflowProviderCredentialsLocked(userID, normalized, credentials)
+}
+
+func (s *FilesystemStore) GetWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) (*WorkflowProviderCredential, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return nil, fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(userID, workflowPath)
+	if err != nil {
+		return nil, err
+	}
+	rec, ok := credentials[provider]
+	if !ok {
+		return nil, nil
+	}
+	return &WorkflowProviderCredential{
+		UserID:         sanitizeUserID(userID),
+		WorkflowPath:   normalized,
+		Provider:       provider,
+		EncryptedValue: rec.EncryptedValue,
+		CreatedAt:      rec.CreatedAt,
+		UpdatedAt:      rec.UpdatedAt,
+	}, nil
+}
+
+func (s *FilesystemStore) DeleteWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) error {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	if _, ok := credentials[provider]; !ok {
+		return nil
+	}
+	delete(credentials, provider)
+	return s.saveWorkflowProviderCredentialsLocked(userID, normalized, credentials)
 }
 
 // Compile-time check that FilesystemStore satisfies Store.

--- a/agent_go/pkg/chathistory/fs_store_test.go
+++ b/agent_go/pkg/chathistory/fs_store_test.go
@@ -55,3 +55,40 @@ func TestFilesystemStoreWorkflowSecretsRoundTrip(t *testing.T) {
 		t.Fatalf("ListWorkflowSecrets(after delete) = %+v, want none", secretsA)
 	}
 }
+
+func TestFilesystemStoreWorkflowProviderCredentialsAreIsolated(t *testing.T) {
+	store, err := NewFilesystemStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFilesystemStore() error = %v", err)
+	}
+	ctx := context.Background()
+	const workflowA = "Workflow/customer-renewals"
+	const workflowB = "Workflow/support-triage"
+
+	if err := store.UpsertWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code", "cipher-a"); err != nil {
+		t.Fatalf("UpsertWorkflowProviderCredential() error = %v", err)
+	}
+	if err := store.UpsertWorkflowProviderCredential(ctx, "bob", workflowA, "claude-code", "cipher-b"); err != nil {
+		t.Fatalf("UpsertWorkflowProviderCredential(second user) error = %v", err)
+	}
+
+	alice, err := store.GetWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code")
+	if err != nil || alice == nil || alice.EncryptedValue != "cipher-a" {
+		t.Fatalf("alice credential = %+v, err=%v", alice, err)
+	}
+	bob, err := store.GetWorkflowProviderCredential(ctx, "bob", workflowA, "claude-code")
+	if err != nil || bob == nil || bob.EncryptedValue != "cipher-b" {
+		t.Fatalf("bob credential = %+v, err=%v", bob, err)
+	}
+	other, err := store.GetWorkflowProviderCredential(ctx, "alice", workflowB, "claude-code")
+	if err != nil || other != nil {
+		t.Fatalf("other workflow credential = %+v, err=%v; want nil", other, err)
+	}
+	if err := store.DeleteWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code"); err != nil {
+		t.Fatalf("DeleteWorkflowProviderCredential() error = %v", err)
+	}
+	alice, err = store.GetWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code")
+	if err != nil || alice != nil {
+		t.Fatalf("deleted credential = %+v, err=%v; want nil", alice, err)
+	}
+}

--- a/agent_go/pkg/chathistory/store.go
+++ b/agent_go/pkg/chathistory/store.go
@@ -65,6 +65,18 @@ type UserSecret struct {
 	UpdatedAt      time.Time `json:"updated_at"`
 }
 
+// WorkflowProviderCredential is an encrypted provider-runtime credential
+// scoped to one user and workflow. Unlike UserSecret, it is never exposed to
+// workflow tools or injected into the step environment.
+type WorkflowProviderCredential struct {
+	UserID         string    `json:"user_id"`
+	WorkflowPath   string    `json:"workflow_path"`
+	Provider       string    `json:"provider"`
+	EncryptedValue string    `json:"encrypted_value"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
 // Store is the persistence interface for bot connector configs and per-user
 // secrets. Everything else (chat sessions, events, bot conversations) is
 // in-memory on StreamingAPI / BotConversationManager and has no durable form.
@@ -83,6 +95,11 @@ type Store interface {
 	UpsertWorkflowSecret(ctx context.Context, userID, workflowPath, name, encryptedValue string) error
 	DeleteWorkflowSecret(ctx context.Context, userID, workflowPath, name string) error
 	ListWorkflowSecrets(ctx context.Context, userID, workflowPath string) ([]UserSecret, error)
+
+	// Workflow provider credentials (private runtime auth, never tool secrets).
+	UpsertWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider, encryptedValue string) error
+	GetWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) (*WorkflowProviderCredential, error)
+	DeleteWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) error
 
 	Close() error
 }

--- a/agent_go/pkg/chathistory/workspace_api_store.go
+++ b/agent_go/pkg/chathistory/workspace_api_store.go
@@ -39,8 +39,9 @@ type WorkspaceAPIStore struct {
 	botCfgFile       string
 	botCfgLegacyFile string
 
-	secretsMu         sync.Map // userID -> *sync.Mutex
-	workflowSecretsMu sync.Map // userID + workflow path -> *sync.Mutex
+	secretsMu                     sync.Map // userID -> *sync.Mutex
+	workflowSecretsMu             sync.Map // userID + workflow path -> *sync.Mutex
+	workflowProviderCredentialsMu sync.Map // userID + workflow path -> *sync.Mutex
 }
 
 // NewWorkspaceAPIStore constructs a Store backed by the workspace API.
@@ -299,6 +300,14 @@ func (s *WorkspaceAPIStore) workflowSecretsFile(userID, workflowPath string) (st
 	return "_users/" + sanitizeUserID(userID) + "/workflow_secrets/" + workflowSecretPathHash(normalized) + ".json", normalized, nil
 }
 
+func (s *WorkspaceAPIStore) workflowProviderCredentialsFile(userID, workflowPath string) (string, string, error) {
+	normalized, err := normalizeWorkflowSecretPath(workflowPath)
+	if err != nil {
+		return "", "", err
+	}
+	return "_users/" + sanitizeUserID(userID) + "/workflow_provider_credentials/" + workflowSecretPathHash(normalized) + ".json", normalized, nil
+}
+
 func (s *WorkspaceAPIStore) secretsLock(userID string) *sync.Mutex {
 	key := sanitizeUserID(userID)
 	if m, ok := s.secretsMu.Load(key); ok {
@@ -320,6 +329,20 @@ func (s *WorkspaceAPIStore) workflowSecretsLock(userID, workflowPath string) *sy
 	}
 	m := &sync.Mutex{}
 	actual, _ := s.workflowSecretsMu.LoadOrStore(key, m)
+	return actual.(*sync.Mutex)
+}
+
+func (s *WorkspaceAPIStore) workflowProviderCredentialsLock(userID, workflowPath string) *sync.Mutex {
+	normalized, err := normalizeWorkflowSecretPath(workflowPath)
+	if err != nil {
+		normalized = strings.TrimSpace(workflowPath)
+	}
+	key := sanitizeUserID(userID) + ":" + workflowSecretPathHash(normalized)
+	if m, ok := s.workflowProviderCredentialsMu.Load(key); ok {
+		return m.(*sync.Mutex)
+	}
+	m := &sync.Mutex{}
+	actual, _ := s.workflowProviderCredentialsMu.LoadOrStore(key, m)
 	return actual.(*sync.Mutex)
 }
 
@@ -533,6 +556,111 @@ func (s *WorkspaceAPIStore) ListWorkflowSecrets(ctx context.Context, userID, wor
 		})
 	}
 	return out, nil
+}
+
+func (s *WorkspaceAPIStore) loadWorkflowProviderCredentialsLocked(ctx context.Context, userID, workflowPath string) (string, map[string]*userSecretRecord, error) {
+	path, normalized, err := s.workflowProviderCredentialsFile(userID, workflowPath)
+	if err != nil {
+		return "", nil, err
+	}
+	data, exists, err := s.readFile(ctx, path)
+	if err != nil {
+		return "", nil, err
+	}
+	if !exists || len(data) == 0 {
+		return normalized, make(map[string]*userSecretRecord), nil
+	}
+	var doc workflowProviderCredentialsDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return "", nil, fmt.Errorf("chathistory: parse %s: %w", path, err)
+	}
+	if doc.Credentials == nil {
+		doc.Credentials = make(map[string]*userSecretRecord)
+	}
+	return normalized, doc.Credentials, nil
+}
+
+func (s *WorkspaceAPIStore) saveWorkflowProviderCredentialsLocked(ctx context.Context, userID, workflowPath string, credentials map[string]*userSecretRecord) error {
+	path, normalized, err := s.workflowProviderCredentialsFile(userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	doc := workflowProviderCredentialsDocument{WorkflowPath: normalized, Credentials: credentials}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("chathistory: marshal %s: %w", path, err)
+	}
+	return s.writeFile(ctx, path, data)
+}
+
+func (s *WorkspaceAPIStore) UpsertWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider, encryptedValue string) error {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(ctx, userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if existing, ok := credentials[provider]; ok {
+		existing.EncryptedValue = encryptedValue
+		existing.UpdatedAt = now
+	} else {
+		credentials[provider] = &userSecretRecord{EncryptedValue: encryptedValue, CreatedAt: now, UpdatedAt: now}
+	}
+	return s.saveWorkflowProviderCredentialsLocked(ctx, userID, normalized, credentials)
+}
+
+func (s *WorkspaceAPIStore) GetWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) (*WorkflowProviderCredential, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return nil, fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(ctx, userID, workflowPath)
+	if err != nil {
+		return nil, err
+	}
+	rec, ok := credentials[provider]
+	if !ok {
+		return nil, nil
+	}
+	return &WorkflowProviderCredential{
+		UserID:         sanitizeUserID(userID),
+		WorkflowPath:   normalized,
+		Provider:       provider,
+		EncryptedValue: rec.EncryptedValue,
+		CreatedAt:      rec.CreatedAt,
+		UpdatedAt:      rec.UpdatedAt,
+	}, nil
+}
+
+func (s *WorkspaceAPIStore) DeleteWorkflowProviderCredential(ctx context.Context, userID, workflowPath, provider string) error {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return fmt.Errorf("chathistory: provider is required")
+	}
+	mux := s.workflowProviderCredentialsLock(userID, workflowPath)
+	mux.Lock()
+	defer mux.Unlock()
+
+	normalized, credentials, err := s.loadWorkflowProviderCredentialsLocked(ctx, userID, workflowPath)
+	if err != nil {
+		return err
+	}
+	if _, ok := credentials[provider]; !ok {
+		return nil
+	}
+	delete(credentials, provider)
+	return s.saveWorkflowProviderCredentialsLocked(ctx, userID, normalized, credentials)
 }
 
 var _ Store = (*WorkspaceAPIStore)(nil)

--- a/agent_go/pkg/chathistory/workspace_api_store_test.go
+++ b/agent_go/pkg/chathistory/workspace_api_store_test.go
@@ -226,3 +226,41 @@ func TestWorkspaceAPIStoreWorkflowSecretsRoundTrip(t *testing.T) {
 		t.Fatalf("ListWorkflowSecrets(after delete) = %+v, want none", secretsA)
 	}
 }
+
+func TestWorkspaceAPIStoreWorkflowProviderCredentialsAreIsolated(t *testing.T) {
+	server := newWorkspaceAPITestServer(t, nil)
+	defer server.Close()
+	store, err := NewWorkspaceAPIStore(server.URL)
+	if err != nil {
+		t.Fatalf("NewWorkspaceAPIStore() error = %v", err)
+	}
+	ctx := context.Background()
+	const workflowA = "Workflow/customer-renewals"
+	const workflowB = "Workflow/support-triage"
+
+	if err := store.UpsertWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code", "cipher-a"); err != nil {
+		t.Fatalf("UpsertWorkflowProviderCredential() error = %v", err)
+	}
+	if err := store.UpsertWorkflowProviderCredential(ctx, "bob", workflowA, "claude-code", "cipher-b"); err != nil {
+		t.Fatalf("UpsertWorkflowProviderCredential(second user) error = %v", err)
+	}
+	alice, err := store.GetWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code")
+	if err != nil || alice == nil || alice.EncryptedValue != "cipher-a" {
+		t.Fatalf("alice credential = %+v, err=%v", alice, err)
+	}
+	bob, err := store.GetWorkflowProviderCredential(ctx, "bob", workflowA, "claude-code")
+	if err != nil || bob == nil || bob.EncryptedValue != "cipher-b" {
+		t.Fatalf("bob credential = %+v, err=%v", bob, err)
+	}
+	other, err := store.GetWorkflowProviderCredential(ctx, "alice", workflowB, "claude-code")
+	if err != nil || other != nil {
+		t.Fatalf("other workflow credential = %+v, err=%v; want nil", other, err)
+	}
+	if err := store.DeleteWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code"); err != nil {
+		t.Fatalf("DeleteWorkflowProviderCredential() error = %v", err)
+	}
+	alice, err = store.GetWorkflowProviderCredential(ctx, "alice", workflowA, "claude-code")
+	if err != nil || alice != nil {
+		t.Fatalf("deleted credential = %+v, err=%v; want nil", alice, err)
+	}
+}

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/interactive_workshop_manager.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/interactive_workshop_manager.go
@@ -238,7 +238,7 @@ func (iwm *InteractiveWorkshopManager) ensureWorkshopBootstrapFilesExist(ctx con
 	if marshalErr != nil {
 		return fmt.Errorf("failed to marshal empty plan.json bootstrap: %w", marshalErr)
 	}
-	if writeErr := iwm.controller.WriteWorkspaceFile(ctx, "planning/plan.json", string(data)); writeErr != nil {
+	if writeErr := iwm.controller.writeManagedPlanningFile(ctx, "plan.json", string(data)); writeErr != nil {
 		return fmt.Errorf("failed to bootstrap empty planning/plan.json: %w", writeErr)
 	}
 
@@ -1611,7 +1611,7 @@ func (iwm *InteractiveWorkshopManager) markChangelogArtifactReviewed(ctx context
 		if err != nil {
 			return "", fmt.Errorf("marshal %s: %w", changelogPath, err)
 		}
-		if err := iwm.controller.WriteWorkspaceFile(ctx, changelogPath, string(data)); err != nil {
+		if err := iwm.controller.writeManagedPlanningFile(ctx, filepath.Join("changelog", file), string(data)); err != nil {
 			return "", fmt.Errorf("write %s: %w", changelogPath, err)
 		}
 		touchedFiles = append(touchedFiles, file)

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_agent.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_agent.go
@@ -1002,7 +1002,8 @@ func writePlanChangelogEntry(
 	if err != nil {
 		return fmt.Errorf("marshal plan changelog: %w", err)
 	}
-	if err := writeFile(ctx, changelogPath, string(data)); err != nil {
+	writeCtx := withPlanningFileMutationWriteAccess(ctx, workspacePath, filepath.Join("changelog", planChangelogSessionFile))
+	if err := writeFile(writeCtx, changelogPath, string(data)); err != nil {
 		return fmt.Errorf("write plan changelog: %w", err)
 	}
 	logger.Info(fmt.Sprintf("📝 Plan changelog: %s — %s", entry.Tool, entry.Reason))

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_file_write_access.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_file_write_access.go
@@ -1,0 +1,21 @@
+package step_based_workflow
+
+import (
+	"context"
+	"path/filepath"
+
+	workspacepkg "github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
+)
+
+// withPlanningFileMutationWriteAccess grants a trusted Go-side writer access
+// to one exact file under planning/. Raw shell and general workspace tools stay
+// blocked from the file and from the rest of planning/.
+func withPlanningFileMutationWriteAccess(ctx context.Context, workspacePath, planningRelativePath string) context.Context {
+	managedPath := normalizePathForWorkspaceAPI(filepath.Join("planning", planningRelativePath), workspacePath)
+	return workspacepkg.WithSystemManagedWritePaths(ctx, managedPath)
+}
+
+func (hcpo *StepBasedWorkflowOrchestrator) writeManagedPlanningFile(ctx context.Context, planningRelativePath, content string) error {
+	writeCtx := withPlanningFileMutationWriteAccess(ctx, hcpo.GetWorkspacePath(), planningRelativePath)
+	return hcpo.WriteWorkspaceFile(writeCtx, filepath.Join("planning", planningRelativePath), content)
+}

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_write_access_test.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/planning_write_access_test.go
@@ -2,11 +2,14 @@ package step_based_workflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/common"
 	workspacepkg "github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
+	loggerv2 "github.com/manishiitg/mcpagent/logger/v2"
 )
 
 func TestPlanMutationWriteAccessDoesNotUnblockGeneralFileWrites(t *testing.T) {
@@ -36,5 +39,87 @@ func TestPlanMutationWriteAccessDoesNotUnblockGeneralFileWrites(t *testing.T) {
 
 	if err := client.ValidatePathWithContext(ctx, planPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
 		t.Fatalf("plan capability leaked back into the caller context: %v", err)
+	}
+}
+
+func TestPlanningFileMutationWriteAccessIsExact(t *testing.T) {
+	const (
+		sessionID     = "planning-file-mutation-write-access"
+		workspacePath = "Workflow/demo"
+		managedPath   = workspacePath + "/planning/changelog/changelog-test.json"
+	)
+	workspacepkg.SetSessionFolderGuard(sessionID, []string{workspacePath}, []string{workspacePath})
+	workspacepkg.SetSessionFolderGuardBlockedWritePaths(sessionID, []string{workspacePath + "/planning"})
+	defer workspacepkg.ClearSessionShellConfig(sessionID)
+
+	client := workspacepkg.NewClient("http://unused")
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	managedCtx := withPlanningFileMutationWriteAccess(ctx, workspacePath, "changelog/changelog-test.json")
+
+	if err := client.ValidatePathWithContext(managedCtx, managedPath, true); err != nil {
+		t.Fatalf("exact managed planning file should be writable: %v", err)
+	}
+	for _, blockedSibling := range []string{
+		workspacePath + "/planning/plan.json",
+		workspacePath + "/planning/changelog/other.json",
+	} {
+		if err := client.ValidatePathWithContext(managedCtx, blockedSibling, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+			t.Fatalf("managed file capability unlocked sibling %s: %v", blockedSibling, err)
+		}
+	}
+	if err := client.ValidatePathWithContext(ctx, managedPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("managed file capability leaked into caller context: %v", err)
+	}
+}
+
+func TestWritePlanChangelogEntryUsesManagedFileAccess(t *testing.T) {
+	const (
+		sessionID     = "plan-changelog-managed-write-access"
+		workspacePath = "Workflow/demo"
+		filename      = "changelog-test.json"
+		changelogPath = workspacePath + "/planning/changelog/" + filename
+	)
+	workspacepkg.SetSessionFolderGuard(sessionID, []string{workspacePath}, []string{workspacePath})
+	workspacepkg.SetSessionFolderGuardBlockedWritePaths(sessionID, []string{workspacePath + "/planning"})
+	defer workspacepkg.ClearSessionShellConfig(sessionID)
+
+	planChangelogSessionMutex.Lock()
+	previousFile := planChangelogSessionFile
+	previousStart := planChangelogSessionStart
+	planChangelogSessionFile = filename
+	planChangelogSessionStart = time.Now().UTC()
+	planChangelogSessionMutex.Unlock()
+	t.Cleanup(func() {
+		planChangelogSessionMutex.Lock()
+		planChangelogSessionFile = previousFile
+		planChangelogSessionStart = previousStart
+		planChangelogSessionMutex.Unlock()
+	})
+
+	client := workspacepkg.NewClient("http://unused")
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	wrote := false
+	err := writePlanChangelogEntry(
+		ctx,
+		workspacePath,
+		PlanChangelogEntry{Tool: "update_step_config", Reason: "test managed changelog write"},
+		func(context.Context, string) (string, error) { return "", errors.New("not found") },
+		func(writeCtx context.Context, path, _ string) error {
+			wrote = true
+			if path != changelogPath {
+				t.Fatalf("unexpected changelog path: %s", path)
+			}
+			return client.ValidatePathWithContext(writeCtx, path, true)
+		},
+		loggerv2.NewNoop(),
+	)
+	if err != nil {
+		t.Fatalf("typed changelog write was blocked: %v", err)
+	}
+	if !wrote {
+		t.Fatal("typed changelog writer was not called")
+	}
+	if err := client.ValidatePathWithContext(ctx, changelogPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("changelog capability leaked into caller context: %v", err)
 	}
 }

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/step_config.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/step_config.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	loggerv2 "github.com/manishiitg/mcpagent/logger/v2"
 	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/orchestrator"
+	loggerv2 "github.com/manishiitg/mcpagent/logger/v2"
 )
 
 // StepConfig represents a single step's configuration in step_config.json
@@ -241,12 +241,24 @@ func (hcpo *StepBasedWorkflowOrchestrator) WriteStepConfigsToSubdir(ctx context.
 		return fmt.Errorf("failed to marshal step_config.json: %w", err)
 	}
 
+	// planning/ is protected from raw file writes. This method is the typed,
+	// validated step-config writer, so grant it access to this exact managed file
+	// without exposing the rest of planning/ to agents or general file tools.
+	writeCtx := withStepConfigMutationWriteAccess(ctx, hcpo.GetWorkspacePath(), configSubdir)
+
 	// WriteWorkspaceFile will automatically create the directory structure via the workspace API
-	if err := hcpo.WriteWorkspaceFile(ctx, configPath, string(jsonData)); err != nil {
+	if err := hcpo.WriteWorkspaceFile(writeCtx, configPath, string(jsonData)); err != nil {
 		return fmt.Errorf("failed to write step_config.json: %w", err)
 	}
 
 	return nil
+}
+
+func withStepConfigMutationWriteAccess(ctx context.Context, workspacePath, configSubdir string) context.Context {
+	if filepath.Clean(configSubdir) != "planning" {
+		return ctx
+	}
+	return withPlanningFileMutationWriteAccess(ctx, workspacePath, "step_config.json")
 }
 
 // ReadStepOverrides reads step overrides from workflow.json execution_defaults.

--- a/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/step_config_write_access_test.go
+++ b/agent_go/pkg/orchestrator/agents/workflow/step_based_workflow/step_config_write_access_test.go
@@ -1,0 +1,75 @@
+package step_based_workflow
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/common"
+	"github.com/manishiitg/coding-agent-loop/agent_go/pkg/orchestrator"
+	workspacepkg "github.com/manishiitg/coding-agent-loop/agent_go/pkg/workspace"
+	loggerv2 "github.com/manishiitg/mcpagent/logger/v2"
+)
+
+func TestWriteStepConfigsToSubdirUsesFileScopedPlanningAccess(t *testing.T) {
+	const (
+		sessionID      = "step-config-mutation-write-access"
+		workspacePath  = "Workflow/demo"
+		stepConfigPath = workspacePath + "/planning/step_config.json"
+	)
+
+	wroteStepConfig := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/documents/"+stepConfigPath {
+			t.Errorf("unexpected write path: %s", r.URL.Path)
+		}
+		wroteStepConfig = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer server.Close()
+
+	workspacepkg.SetSessionFolderGuard(sessionID, []string{workspacePath}, []string{workspacePath})
+	workspacepkg.SetSessionFolderGuardBlockedWritePaths(sessionID, []string{workspacePath + "/planning"})
+	defer workspacepkg.ClearSessionShellConfig(sessionID)
+
+	client := workspacepkg.NewClient(server.URL)
+	ctx := context.WithValue(context.Background(), common.ChatSessionIDKey, sessionID)
+	if err := client.ValidatePathWithContext(ctx, stepConfigPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("ordinary file write should remain blocked, got %v", err)
+	}
+
+	base, err := orchestrator.NewBaseOrchestrator(
+		loggerv2.NewNoop(), nil, orchestrator.OrchestratorTypeWorkflow, "", 0, "",
+		nil, nil, false, &orchestrator.LLMConfig{}, 1, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("NewBaseOrchestrator: %v", err)
+	}
+	base.WorkspaceClient = client
+	base.SetWorkspacePath(workspacePath)
+	hcpo := &StepBasedWorkflowOrchestrator{BaseOrchestrator: base}
+
+	if err := hcpo.WriteStepConfigsToSubdir(ctx, "planning", []StepConfig{{ID: "step-1"}}); err != nil {
+		t.Fatalf("typed step-config write was blocked: %v", err)
+	}
+	if !wroteStepConfig {
+		t.Fatal("typed step-config writer did not reach the workspace API")
+	}
+
+	managedCtx := withStepConfigMutationWriteAccess(ctx, workspacePath, "planning")
+	if err := client.ValidatePathWithContext(managedCtx, stepConfigPath, true); err != nil {
+		t.Fatalf("managed step-config path should be writable: %v", err)
+	}
+	if err := client.ValidatePathWithContext(managedCtx, workspacePath+"/planning/plan.json", true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("step-config capability must not unlock plan.json, got %v", err)
+	}
+	if err := client.ValidatePathWithContext(ctx, stepConfigPath, true); err == nil || !strings.Contains(err.Error(), "blocked for writes") {
+		t.Fatalf("step-config capability leaked into the caller context: %v", err)
+	}
+}

--- a/frontend/src/api/secrets.ts
+++ b/frontend/src/api/secrets.ts
@@ -72,6 +72,29 @@ export const secretsApi = {
     });
     return response.data;
   },
+
+  getWorkflowClaudeCodeCredentialStatus: async (workspacePath: string): Promise<{ configured: boolean; updated_at?: string }> => {
+    const response = await api.get('/api/workflow-provider-credentials/claude-code', {
+      params: { workspace_path: workspacePath },
+    });
+    return response.data;
+  },
+
+  storeWorkflowClaudeCodeCredential: async (workspacePath: string, token: string): Promise<{ success: boolean }> => {
+    const encrypted = await secretsApi.encrypt(token);
+    const response = await api.put('/api/workflow-provider-credentials/claude-code', {
+      workspace_path: workspacePath,
+      encrypted_value: encrypted.encrypted,
+    });
+    return response.data;
+  },
+
+  deleteWorkflowClaudeCodeCredential: async (workspacePath: string): Promise<{ success: boolean }> => {
+    const response = await api.delete('/api/workflow-provider-credentials/claude-code', {
+      params: { workspace_path: workspacePath },
+    });
+    return response.data;
+  },
 };
 
 export default secretsApi;

--- a/frontend/src/components/ModePresetBar.tsx
+++ b/frontend/src/components/ModePresetBar.tsx
@@ -443,7 +443,7 @@ export const ModePresetBar: React.FC = () => {
         await refreshPresets()
         setShowPresetModal(false)
         setEditingPreset(null)
-        return
+        return true
       }
 
       // Multi-agent mode: save the user's chat capability profile.
@@ -471,6 +471,7 @@ export const ModePresetBar: React.FC = () => {
 
       setShowPresetModal(false)
       setEditingPreset(null)
+      return true
     } catch (error) {
       console.error('[ModePresetBar] Failed to save preset:', error)
       // Surface the failure — previously this was swallowed (no toast), so a
@@ -484,6 +485,7 @@ export const ModePresetBar: React.FC = () => {
             ? error.message
             : 'Unknown error'
       useChatStore.getState().addToast(`Failed to save configuration: ${detail}`, 'error')
+      return false
     }
   }, [editingPreset, savePreset, handlePresetClick, refreshPresets])
 

--- a/frontend/src/components/ModePresetBar.tsx
+++ b/frontend/src/components/ModePresetBar.tsx
@@ -438,12 +438,10 @@ export const ModePresetBar: React.FC = () => {
             llm_config: llmConfig || undefined,
           },
         }
-        await agentApi.updateWorkflowManifest(payload)
-        // Refresh manifests and rebuild workflow presets in zustand (triggers re-renders)
-        await refreshPresets()
-        setShowPresetModal(false)
-        setEditingPreset(null)
-        return true
+		await agentApi.updateWorkflowManifest(payload)
+		// Refresh manifests and rebuild workflow presets in zustand (triggers re-renders)
+		await refreshPresets()
+		return true
       }
 
       // Multi-agent mode: save the user's chat capability profile.

--- a/frontend/src/components/PresetModal.tsx
+++ b/frontend/src/components/PresetModal.tsx
@@ -3,12 +3,11 @@ import { Button } from './ui/Button';
 import { Input } from './ui/Input';
 import { Textarea } from './ui/Textarea';
 import { Card } from './ui/Card';
-import { Folder, Plus, X, Settings, Info, Download, Trash2, SlidersHorizontal } from 'lucide-react';
+import { CheckCircle2, ChevronDown, Download, Folder, KeyRound, Loader2, Plus, Settings, SlidersHorizontal, Trash2, X } from 'lucide-react';
 import { FolderSelectionDialog } from './FolderSelectionDialog';
 import { ToolSelectionSection } from './ToolSelectionSection';
 import { SkillSelectionSection } from './skills/SkillSelectionSection';
 import { SecretSelectionSection } from './secrets/SecretSelectionSection';
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from './ui/tooltip';
 import ConfirmationDialog from './ui/ConfirmationDialog';
 import type { CustomPreset } from '../types/preset';
 import type { PlannerFile, PresetLLMConfig, AgentLLMConfig, AgentLLMFallback, LLMProvider } from '../services/api-types';
@@ -23,11 +22,38 @@ import ModalPortal from './ui/ModalPortal';
 import { getWorkflowLLMOptions, getWorkflowLLMTierDefaults, getWorkflowProviderOptions } from '../utils/workflowLLMTierDefaults';
 import { llmOptionMatchesRef, llmOptionsKey } from '../utils/llmConfigDisplay';
 import { chromeCdpInstallCommand, chromeCdpLaunchCommand, chromeCdpVerifyCommand, chromeCdpZipUrl, mergeCdpPorts } from '../utils/cdpSetup';
+import { secretsApi } from '../api/secrets';
+import { useChatStore } from '../stores/useChatStore';
+
+type WorkflowLLMRoleKey = 'tier1' | 'tier2' | 'tier3' | 'builder' | 'maintenance' | 'pulse';
+
+type WorkflowLLMRoleRow = {
+  key: WorkflowLLMRoleKey;
+  label: string;
+  description: string;
+  value: AgentLLMConfig | null;
+  defaultValue: AgentLLMConfig | null;
+  onSelect: (llm: LLMOption) => void;
+  onReset: () => void;
+  fallbacks?: AgentLLMFallback[];
+  setFallbacks?: React.Dispatch<React.SetStateAction<AgentLLMFallback[]>>;
+};
+
+function agentLLMUsesProvider(config: AgentLLMConfig | null | undefined, provider: string): boolean {
+  return config?.provider === provider || Boolean(config?.fallbacks?.some(fallback => fallback.provider === provider));
+}
+
+function sameAgentLLM(left: AgentLLMConfig | null | undefined, right: AgentLLMConfig | null | undefined): boolean {
+  if (!left || !right) return left === right;
+  return left.provider === right.provider
+    && left.model_id === right.model_id
+    && llmOptionsKey(left.options) === llmOptionsKey(right.options);
+}
 
 interface PresetModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (label: string, query: string, selectedServers?: string[], selectedTools?: string[], selectedSkills?: string[], agentMode?: 'multi-agent' | 'workflow', selectedFolder?: PlannerFile, llmConfig?: PresetLLMConfig, useCodeExecutionMode?: boolean, selectedSecrets?: string[], selectedGlobalSecretNames?: string[] | null, browserMode?: 'none' | 'auto' | 'headless' | 'cdp', cdpPorts?: number[]) => void;
+  onSave: (label: string, query: string, selectedServers?: string[], selectedTools?: string[], selectedSkills?: string[], agentMode?: 'multi-agent' | 'workflow', selectedFolder?: PlannerFile, llmConfig?: PresetLLMConfig, useCodeExecutionMode?: boolean, selectedSecrets?: string[], selectedGlobalSecretNames?: string[] | null, browserMode?: 'none' | 'auto' | 'headless' | 'cdp', cdpPorts?: number[]) => boolean | void | Promise<boolean | void>;
   editingPreset?: CustomPreset | null;
   availableServers?: string[];
   hideAgentModeSelection?: boolean;
@@ -83,6 +109,12 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
   const [tier2Fallbacks, setTier2Fallbacks] = useState<AgentLLMFallback[]>([]);
   const [tier3Fallbacks, setTier3Fallbacks] = useState<AgentLLMFallback[]>([]);
   const [showWorkflowLLMAdvanced, setShowWorkflowLLMAdvanced] = useState(false);
+  const [expandedWorkflowLLMRole, setExpandedWorkflowLLMRole] = useState<WorkflowLLMRoleKey | null>(null);
+  const [claudeCodeToken, setClaudeCodeToken] = useState('');
+  const [claudeCredentialConfigured, setClaudeCredentialConfigured] = useState(false);
+  const [isLoadingClaudeCredential, setIsLoadingClaudeCredential] = useState(false);
+  const [isDeletingClaudeCredential, setIsDeletingClaudeCredential] = useState(false);
+  const [isSavingPreset, setIsSavingPreset] = useState(false);
 
   const { selectedModeCategory, getAgentModeFromCategory } = useModeStore();
   const primaryConfig = useLLMStore(state => state.primaryConfig);
@@ -252,13 +284,16 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
     return `${config.provider}/${config.model_id}`;
   }, []);
 
-  const getEffectiveTierLLM = useCallback((tierNum: number) => {
-    if (tierNum === 1) return effectiveTier1LLM;
-    if (tierNum === 2) return effectiveTier2LLM;
-    return effectiveTier3LLM;
-  }, [effectiveTier1LLM, effectiveTier2LLM, effectiveTier3LLM]);
   // Draft create paths can collide with existing workflows, so only load scoped secrets for persisted workflows.
   const workflowSecretPath = editingPreset ? selectedFolder?.filepath : undefined;
+  const workflowCredentialPath = editingPreset ? selectedFolder?.filepath : undefined;
+
+  const usesClaudeCode = useMemo(() => {
+    return selectedWorkflowLLMOption?.provider === 'claude-code'
+      || [effectiveTier1LLM, effectiveTier2LLM, effectiveTier3LLM, effectiveBuilderLLM, effectiveMaintenanceLLM, effectivePulseLLM]
+        .some(config => agentLLMUsesProvider(config, 'claude-code'))
+      || [...tier1Fallbacks, ...tier2Fallbacks, ...tier3Fallbacks].some(fallback => fallback.provider === 'claude-code');
+  }, [effectiveBuilderLLM, effectiveMaintenanceLLM, effectivePulseLLM, effectiveTier1LLM, effectiveTier2LLM, effectiveTier3LLM, selectedWorkflowLLMOption?.provider, tier1Fallbacks, tier2Fallbacks, tier3Fallbacks]);
 
   const hasAdvancedWorkflowLLMConfig = useCallback((presetLLM?: PresetLLMConfig | null) => {
     return presetLLM?.mode === 'explicit';
@@ -276,7 +311,53 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
     setTier1Fallbacks([]);
     setTier2Fallbacks([]);
     setTier3Fallbacks([]);
+    setExpandedWorkflowLLMRole(null);
   }, [providerManifest]);
+
+  const useManagedWorkflowLLMDefaults = useCallback(() => {
+    const provider = selectedWorkflowLLMOption?.provider || currentLLMOption?.provider;
+    if (provider) {
+      setLlmConfig({ schema_version: 2, mode: 'provider_profile', provider: provider as LLMProvider });
+    }
+    setShowWorkflowLLMAdvanced(false);
+    setExpandedWorkflowLLMRole(null);
+    setBuilderLLM(null);
+    setMaintenanceLLM(null);
+    setPulseLLM(null);
+    setTier1LLM(null);
+    setTier2LLM(null);
+    setTier3LLM(null);
+    setTier1Fallbacks([]);
+    setTier2Fallbacks([]);
+    setTier3Fallbacks([]);
+  }, [currentLLMOption?.provider, selectedWorkflowLLMOption?.provider]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setExpandedWorkflowLLMRole(null);
+    setClaudeCodeToken('');
+  }, [editingPreset?.id, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || effectiveAgentMode !== 'workflow' || !workflowCredentialPath) {
+      setClaudeCredentialConfigured(false);
+      setIsLoadingClaudeCredential(false);
+      return;
+    }
+    let cancelled = false;
+    setIsLoadingClaudeCredential(true);
+    void secretsApi.getWorkflowClaudeCodeCredentialStatus(workflowCredentialPath)
+      .then(status => {
+        if (!cancelled) setClaudeCredentialConfigured(status.configured);
+      })
+      .catch(() => {
+        if (!cancelled) setClaudeCredentialConfigured(false);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingClaudeCredential(false);
+      });
+    return () => { cancelled = true; };
+  }, [effectiveAgentMode, isOpen, workflowCredentialPath]);
 
   useEffect(() => {
     if (editingPreset) {
@@ -405,14 +486,34 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
     setSelectedFolder(makeWorkflowFolder(folderName));
   }, [makeWorkflowFolder, sanitizeWorkflowFolderName]);
 
-  const handleSubmit = useCallback((e: React.FormEvent) => {
+  const handleDeleteClaudeCredential = useCallback(async () => {
+    const workspacePath = selectedFolder?.filepath;
+    if (!workspacePath) return;
+    setIsDeletingClaudeCredential(true);
+    try {
+      await secretsApi.deleteWorkflowClaudeCodeCredential(workspacePath);
+      setClaudeCredentialConfigured(false);
+      setClaudeCodeToken('');
+      useChatStore.getState().addToast('Workflow Claude Code token removed; saved Claude login will be used.', 'success');
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : 'Unknown error';
+      useChatStore.getState().addToast(`Failed to remove Claude Code token: ${detail}`, 'error');
+    } finally {
+      setIsDeletingClaudeCredential(false);
+    }
+  }, [selectedFolder?.filepath]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     const isQueryRequired = effectiveAgentMode !== 'workflow';
-    if (label.trim() && (!isQueryRequired || query.trim())) {
-      if (effectiveAgentMode === 'workflow' && !selectedFolder) {
-        alert('Folder selection is required for workflow presets');
-        return;
-      }
+    if (!label.trim() || (isQueryRequired && !query.trim())) return;
+    if (effectiveAgentMode === 'workflow' && !selectedFolder) {
+      alert('Folder selection is required for workflow presets');
+      return;
+    }
+
+    setIsSavingPreset(true);
+    try {
       
       // Debug: Log what we're sending
       console.log('[PresetModal] Saving preset with:', {
@@ -488,7 +589,7 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
       const cdpPorts = browserMode === 'auto' || browserMode === 'cdp'
         ? mergeCdpPorts(cdpPort, editingPreset?.cdpPorts)
         : [];
-      onSave(
+      const saved = await onSave(
         label.trim(),
         effectiveAgentMode === 'workflow' ? '' : query.trim(),
         selectedServers,
@@ -503,9 +604,24 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
         browserMode, // Browser mode: none|auto|headless|cdp
         cdpPorts
       );
+      if (saved === false) return;
+      if (effectiveAgentMode === 'workflow' && usesClaudeCode && claudeCodeToken.trim() && selectedFolder?.filepath) {
+        await secretsApi.storeWorkflowClaudeCodeCredential(selectedFolder.filepath, claudeCodeToken.trim());
+        setClaudeCredentialConfigured(true);
+        setClaudeCodeToken('');
+        useChatStore.getState().addToast('Workflow Claude Code token saved.', 'success');
+      }
       onClose();
+    } catch (error) {
+      const serverDetail = (error as { response?: { data?: unknown } })?.response?.data;
+      const detail = typeof serverDetail === 'string' && serverDetail.trim() !== ''
+        ? serverDetail.trim()
+        : error instanceof Error ? error.message : 'Unknown error';
+      useChatStore.getState().addToast(`Failed to save automation: ${detail}`, 'error');
+    } finally {
+      setIsSavingPreset(false);
     }
-  }, [label, query, effectiveAgentMode, selectedFolder, selectedServers, selectedTools, selectedSkills, selectedSecrets, selectedGlobalSecrets, llmConfig, builderLLM, effectiveBuilderLLM, maintenanceLLM, effectiveMaintenanceLLM, pulseLLM, effectivePulseLLM, browserMode, cdpPort, editingPreset?.cdpPorts, tier1Fallbacks, tier2Fallbacks, tier3Fallbacks, onSave, onClose, defaultAgentLLM, effectiveTier1LLM, effectiveTier2LLM, effectiveTier3LLM, showWorkflowLLMAdvanced]);
+  }, [label, query, effectiveAgentMode, selectedFolder, selectedServers, selectedTools, selectedSkills, selectedSecrets, selectedGlobalSecrets, llmConfig, builderLLM, effectiveBuilderLLM, maintenanceLLM, effectiveMaintenanceLLM, pulseLLM, effectivePulseLLM, browserMode, cdpPort, editingPreset?.cdpPorts, tier1Fallbacks, tier2Fallbacks, tier3Fallbacks, onSave, onClose, defaultAgentLLM, effectiveTier1LLM, effectiveTier2LLM, effectiveTier3LLM, showWorkflowLLMAdvanced, usesClaudeCode, claudeCodeToken]);
 
   // Close modal on escape key
   useEffect(() => {
@@ -539,6 +655,132 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
       setDeletingWorkflow(false);
     }
   }, [editingPreset, onDeleteWorkflow]);
+
+  const executionLLMRows: WorkflowLLMRoleRow[] = [
+    {
+      key: 'tier1', label: 'High reasoning', description: 'First runs and complex execution.',
+      value: effectiveTier1LLM, defaultValue: workflowDefaultTierLLMs?.tier1 || defaultAgentLLM,
+      onSelect: llm => setTier1LLM(toAgentLLMConfig(llm)),
+      onReset: () => { setTier1LLM(null); setTier1Fallbacks([]); },
+      fallbacks: tier1Fallbacks, setFallbacks: setTier1Fallbacks,
+    },
+    {
+      key: 'tier2', label: 'Medium reasoning', description: 'Execution after useful learnings exist.',
+      value: effectiveTier2LLM, defaultValue: workflowDefaultTierLLMs?.tier2 || defaultAgentLLM,
+      onSelect: llm => setTier2LLM(toAgentLLMConfig(llm)),
+      onReset: () => { setTier2LLM(null); setTier2Fallbacks([]); },
+      fallbacks: tier2Fallbacks, setFallbacks: setTier2Fallbacks,
+    },
+    {
+      key: 'tier3', label: 'Low reasoning', description: 'Validation and mature learned tasks.',
+      value: effectiveTier3LLM, defaultValue: workflowDefaultTierLLMs?.tier3 || defaultAgentLLM,
+      onSelect: llm => setTier3LLM(toAgentLLMConfig(llm)),
+      onReset: () => { setTier3LLM(null); setTier3Fallbacks([]); },
+      fallbacks: tier3Fallbacks, setFallbacks: setTier3Fallbacks,
+    },
+  ];
+  const supportLLMRows: WorkflowLLMRoleRow[] = [
+    {
+      key: 'builder', label: 'Builder', description: 'Chat, planning, evaluation design, and coordination.',
+      value: effectiveBuilderLLM, defaultValue: workflowDefaultTierLLMs?.builder || workflowDefaultTierLLMs?.tier1 || defaultAgentLLM,
+      onSelect: llm => setBuilderLLM(toAgentLLMConfig(llm)), onReset: () => setBuilderLLM(null),
+    },
+    {
+      key: 'maintenance', label: 'Maintenance', description: 'Harden, Goal Advisor, and deeper health reviews.',
+      value: effectiveMaintenanceLLM, defaultValue: workflowDefaultTierLLMs?.maintenance || workflowDefaultTierLLMs?.tier1 || defaultAgentLLM,
+      onSelect: llm => setMaintenanceLLM(toAgentLLMConfig(llm)), onReset: () => setMaintenanceLLM(null),
+    },
+    {
+      key: 'pulse', label: 'Pulse', description: 'Scheduled post-run QA and routine coordination.',
+      value: effectivePulseLLM, defaultValue: workflowDefaultTierLLMs?.pulse || defaultAgentLLM,
+      onSelect: llm => setPulseLLM(toAgentLLMConfig(llm)), onReset: () => setPulseLLM(null),
+    },
+  ];
+  const allWorkflowLLMRows = [...executionLLMRows, ...supportLLMRows];
+  const isWorkflowLLMRoleCustomized = (row: WorkflowLLMRoleRow) => !sameAgentLLM(row.value, row.defaultValue) || Boolean(row.fallbacks?.length);
+  const customizedWorkflowLLMRoleCount = allWorkflowLLMRows.filter(isWorkflowLLMRoleCustomized).length;
+
+  const renderWorkflowLLMRoleRow = (row: WorkflowLLMRoleRow) => {
+    const expanded = expandedWorkflowLLMRole === row.key;
+    const customized = isWorkflowLLMRoleCustomized(row);
+    const fallbacks = row.fallbacks ?? [];
+    const setFallbacks = row.setFallbacks;
+    return (
+      <div key={row.key} className="border-t border-gray-200 first:border-t-0 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={() => setExpandedWorkflowLLMRole(expanded ? null : row.key)}
+          className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/70"
+          aria-expanded={expanded}
+        >
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-medium text-gray-800 dark:text-gray-100">{row.label}</span>
+              <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${customized
+                ? 'bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300'
+                : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
+              }`}>
+                {customized ? 'Customized' : 'Provider default'}
+              </span>
+            </div>
+            <div className="mt-0.5 truncate text-[11px] text-gray-500 dark:text-gray-400">{row.description}</div>
+          </div>
+          <div className="min-w-0 max-w-[45%] text-right">
+            <div className="truncate font-mono text-[11px] text-gray-700 dark:text-gray-200" title={formatAgentLLMConfig(row.value)}>
+              {formatAgentLLMConfig(row.value)}
+            </div>
+            {fallbacks.length > 0 && <div className="text-[10px] text-gray-400">{fallbacks.length} fallback{fallbacks.length === 1 ? '' : 's'}</div>}
+          </div>
+          <ChevronDown className={`h-3.5 w-3.5 shrink-0 text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+        </button>
+        {expanded && (
+          <div className="space-y-3 border-t border-gray-100 bg-white px-3 py-3 dark:border-gray-700 dark:bg-gray-900/40">
+            <LLMRoleSelector
+              availableLLMs={workflowLLMOptions}
+              value={row.value}
+              onLLMSelect={row.onSelect}
+              disabled={false}
+            />
+            {customized && (
+              <button type="button" onClick={row.onReset} className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400">
+                Reset this role to provider default
+              </button>
+            )}
+            {setFallbacks && (
+              <details className="rounded-md border border-gray-200 bg-gray-50 px-2.5 py-2 dark:border-gray-700 dark:bg-gray-800/60">
+                <summary className="cursor-pointer text-xs font-medium text-gray-600 dark:text-gray-300">
+                  Fallbacks{fallbacks.length > 0 ? ` (${fallbacks.length})` : ''}
+                </summary>
+                <div className="mt-2 space-y-2">
+                  {fallbacks.map((fallback, index) => (
+                    <span key={`${row.key}-fallback-${index}`} className="mr-1 inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-xs dark:bg-gray-700">
+                      {fallback.provider}/{fallback.model_id.split('/').pop()}
+                      <button type="button" onClick={() => setFallbacks(previous => previous.filter((_, itemIndex) => itemIndex !== index))} className="text-gray-400 hover:text-red-500" aria-label={`Remove ${row.label} fallback`}>
+                        <X className="h-3 w-3" />
+                      </button>
+                    </span>
+                  ))}
+                  <LLMSelectionDropdown
+                    availableLLMs={workflowLLMOptions.filter(llm => {
+                      const key = llmOptionKey(llm);
+                      return !(row.value && llmConfigKey(row.value) === key) && !fallbacks.some(fallback => llmConfigKey(fallback) === key);
+                    })}
+                    selectedLLM={null}
+                    onLLMSelect={llm => setFallbacks(previous => [...previous, toAgentLLMFallback(llm)])}
+                    onRefresh={loadDefaultsFromBackend}
+                    disabled={false}
+                    inModal={true}
+                    openDirection="down"
+                    placeholder="+ Add fallback"
+                  />
+                </div>
+              </details>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   if (!isOpen) return null;
 
@@ -576,8 +818,9 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
               form="preset-form"
               variant="outline"
               size="sm"
-              disabled={!label.trim() || (effectiveAgentMode !== 'workflow' && !query.trim()) || (effectiveAgentMode === 'workflow' && !selectedFolder)}
+              disabled={isSavingPreset || !label.trim() || (effectiveAgentMode !== 'workflow' && !query.trim()) || (effectiveAgentMode === 'workflow' && !selectedFolder)}
             >
+              {isSavingPreset && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
               {editingPreset ? 'Update' : 'Save'} {effectiveAgentMode === 'workflow' ? 'Automation' : 'Preset'}
             </Button>
             <Button
@@ -655,209 +898,92 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
 
                     {showWorkflowLLMAdvanced && (
                       <>
-                        <div className="flex justify-end">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <div className="text-xs font-medium text-gray-800 dark:text-gray-100">Customize only what you need</div>
+                            <div className="mt-0.5 text-[11px] leading-snug text-gray-500 dark:text-gray-400">
+                              All roles keep the coding-agent defaults until you change one. Open a row to edit it.
+                            </div>
+                          </div>
                           <button
                             type="button"
-                            onClick={() => {
-                              setShowWorkflowLLMAdvanced(false);
-                              setMaintenanceLLM(null);
-                              setPulseLLM(null);
-                            }}
-                            className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                            onClick={useManagedWorkflowLLMDefaults}
+                            className="shrink-0 text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
                           >
-                            Use simple setup
+                            Use managed defaults
                           </button>
                         </div>
-                    {[
-                          { label: 'Tier 1 - High Reasoning', tooltip: 'Used for first-time execution (no learnings yet) and initial learning extraction.', desc: 'Most capable model for complex first-time tasks.', llm: tier1LLM, setLLM: setTier1LLM, fallbacks: tier1Fallbacks, setFallbacks: setTier1Fallbacks, num: 1 },
-                          { label: 'Tier 2 - Medium Reasoning', tooltip: 'Used for execution with existing learnings and learning refinement.', desc: 'Balanced model for tasks with existing learnings.', llm: tier2LLM, setLLM: setTier2LLM, fallbacks: tier2Fallbacks, setFallbacks: setTier2Fallbacks, num: 2 },
-                          { label: 'Tier 3 - Low Reasoning', tooltip: 'Used for validation (always) and mature learning refinement (2+ runs).', desc: 'Cost-efficient model for validation and mature learnings.', llm: tier3LLM, setLLM: setTier3LLM, fallbacks: tier3Fallbacks, setFallbacks: setTier3Fallbacks, num: 3 },
-                        ].map((tier) => {
-                          const effectiveTierLLM = getEffectiveTierLLM(tier.num);
-                          return (
-                        <div key={tier.num}>
-                          <div className="flex items-center gap-1.5 mb-2">
-                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
-                              {tier.label}
-                            </label>
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="w-3 h-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-xs">
-                                  <p className="text-xs">{tier.tooltip}</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          </div>
-                          <LLMRoleSelector
-                            availableLLMs={workflowLLMOptions}
-                            value={effectiveTierLLM}
-                            onLLMSelect={(llm) => tier.setLLM(toAgentLLMConfig(llm))}
-                            disabled={false}
-                          />
-                          <div className="mt-1 font-mono text-[11px] text-gray-700 dark:text-gray-300" title={formatAgentLLMConfig(effectiveTierLLM)}>
-                            {formatAgentLLMConfig(effectiveTierLLM)}
-                          </div>
-                          <div className="mt-1.5">
-                            {tier.fallbacks.map((fb, i) => (
-                              <span key={`t${tier.num}-fb-${i}`} className="inline-flex items-center gap-1 mr-1 mb-1 px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-xs rounded-full">
-                                {fb.provider}/{fb.model_id.split('/').pop()}
-                                <button type="button" onClick={() => tier.setFallbacks(prev => prev.filter((_, idx) => idx !== i))} className="text-gray-400 hover:text-red-500">
-                                  <X className="w-3 h-3" />
-                                </button>
-                              </span>
-                            ))}
-                            <LLMSelectionDropdown
-                              availableLLMs={workflowLLMOptions.filter(llm => {
-                                const key = llmOptionKey(llm);
-                                return !(
-                                  effectiveTierLLM &&
-                                  llmConfigKey(effectiveTierLLM) === key
-                                ) && !tier.fallbacks.some(fb => llmConfigKey(fb) === key);
-                              })}
-                              selectedLLM={null}
-                              onLLMSelect={(llm) => tier.setFallbacks(prev => [...prev, toAgentLLMFallback(llm)])}
-                              onRefresh={loadDefaultsFromBackend}
-                              disabled={false}
-                              inModal={true}
-                              openDirection="down"
-                              placeholder="+ Add fallback"
-                            />
-                          </div>
-                          <div className="text-xs text-gray-500 mt-1">
-                            {tier.desc}
-                          </div>
-                        </div>
-                          );
-                        })}
-                        {/* Builder LLM */}
-                        <div>
-                          <div className="flex items-center gap-1.5 mb-2">
-                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
-                              Builder LLM
-                            </label>
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="w-3 h-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-xs">
-                                  <p className="text-xs">Runs the workflow Builder chat, planning, evaluation design, and coordination.</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          </div>
-                          <LLMRoleSelector
-                            availableLLMs={workflowLLMOptions}
-                            value={effectiveBuilderLLM}
-                            onLLMSelect={(llm) => setBuilderLLM(toAgentLLMConfig(llm))}
-                            disabled={false}
-                          />
-                          <div className="mt-1 font-mono text-[11px] text-gray-700 dark:text-gray-300" title={formatAgentLLMConfig(effectiveBuilderLLM)}>
-                            {formatAgentLLMConfig(effectiveBuilderLLM)}
-                          </div>
-                          <div className="text-xs text-gray-500 mt-1">
-                            Used for chat, planning, evaluation design, and workflow coordination.
-                          </div>
-                        </div>
-                        {/* Maintenance LLM */}
-                        <div>
-                          <div className="flex items-center justify-between gap-2 mb-2">
-                            <div className="flex items-center gap-1.5">
-                              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
-                                Maintenance LLM
-                              </label>
-                              <TooltipProvider>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Info className="w-3 h-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help" />
-                                  </TooltipTrigger>
-                                  <TooltipContent className="max-w-xs">
-                                    <p className="text-xs">Used by Harden, Goal Advisor, and deeper report, eval, knowledge-base, and database reviews.</p>
-                                  </TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
+                        <div className="space-y-3">
+                          <div>
+                            <div className="mb-1.5 flex items-center justify-between px-1">
+                              <span className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Execution</span>
+                              <span className="text-[10px] text-gray-400">The workflow chooses the tier automatically</span>
                             </div>
-                            {maintenanceLLM && (
-                              <button
-                                type="button"
-                                onClick={() => setMaintenanceLLM(null)}
-                                className="text-xs text-red-400 hover:text-red-600"
-                              >
-                                Clear
-                              </button>
-                            )}
-                          </div>
-                          <LLMRoleSelector
-                            availableLLMs={workflowLLMOptions}
-                            value={effectiveMaintenanceLLM}
-                            onLLMSelect={(llm) => setMaintenanceLLM(toAgentLLMConfig(llm))}
-                            disabled={false}
-                          />
-                          <div className="mt-1 font-mono text-[11px] text-gray-700 dark:text-gray-300" title={formatAgentLLMConfig(effectiveMaintenanceLLM)}>
-                            {formatAgentLLMConfig(effectiveMaintenanceLLM)}
-                          </div>
-                          <div className="text-xs text-gray-500 mt-1">
-                            Used for expensive maintenance and strategic review work selected by Pulse.
-                          </div>
-                        </div>
-                        {/* Pulse LLM */}
-                        <div>
-                          <div className="flex items-center justify-between gap-2 mb-2">
-                            <div className="flex items-center gap-1.5">
-                              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400">
-                                Pulse LLM
-                              </label>
-                              <TooltipProvider>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Info className="w-3 h-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help" />
-                                  </TooltipTrigger>
-                                  <TooltipContent className="max-w-xs">
-                                    <p className="text-xs">Optional override used only by scheduled Pulse/post-run QA. Leave empty to use the provider Pulse default when available.</p>
-                                  </TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
+                            <div className="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900/40">
+                              {executionLLMRows.map(renderWorkflowLLMRoleRow)}
                             </div>
-                            {pulseLLM && (
-                              <button
-                                type="button"
-                                onClick={() => setPulseLLM(null)}
-                                className="text-xs text-red-400 hover:text-red-600"
-                              >
-                                Clear
-                              </button>
-                            )}
                           </div>
-                          <LLMRoleSelector
-                            availableLLMs={workflowLLMOptions}
-                            value={effectivePulseLLM}
-                            onLLMSelect={(llm) => setPulseLLM(toAgentLLMConfig(llm))}
-                            disabled={false}
-                          />
-                          <div className="mt-1 font-mono text-[11px] text-gray-700 dark:text-gray-300" title={formatAgentLLMConfig(effectivePulseLLM)}>
-                            {formatAgentLLMConfig(effectivePulseLLM)}
+                          <div>
+                            <div className="mb-1.5 px-1 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Workflow agents</div>
+                            <div className="overflow-hidden rounded-md border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900/40">
+                              {supportLLMRows.map(renderWorkflowLLMRoleRow)}
+                            </div>
                           </div>
-                          <div className="text-xs text-gray-500 mt-1">
-                            Used only for scheduled Pulse after normal runs. Empty means Pulse uses the provider Pulse default when available.
+                          <div className="text-[11px] text-gray-500 dark:text-gray-400">
+                            {customizedWorkflowLLMRoleCount === 0
+                              ? 'No custom roles yet. Everything follows the current provider defaults.'
+                              : `${customizedWorkflowLLMRoleCount} customized role${customizedWorkflowLLMRoleCount === 1 ? '' : 's'}; all other roles use provider defaults.`}
                           </div>
-                        </div>
-                        {/* Info panel */}
-                        <div className="text-xs text-gray-500 pt-2 border-t border-gray-200 dark:border-gray-700 space-y-1">
-                          <div className="font-medium text-gray-600 dark:text-gray-400">Auto-selection rules:</div>
-                          <div>Execution: Tier 1 → Tier 2 (after first learning)</div>
-                          <div>Learning: Tier 2 → Tier 3 (after 2+ runs)</div>
-                          <div>Validation: Always Tier 3</div>
-                          <div>Builder LLM: Chat, planning, evaluation design, and coordination</div>
-                          <div>Maintenance LLM: Harden, Goal Advisor, and deeper health reviews</div>
-                          <div>Pulse LLM: Optional post-run QA override; empty uses the provider Pulse default when available</div>
                         </div>
                       </>
                     )}
                   </div>
                 </div>
+
+                {usesClaudeCode && (
+                  <div>
+                    <label className="mb-2 flex items-center gap-2 text-sm font-medium">
+                      <KeyRound className="h-4 w-4" />
+                      Claude Code login for this automation
+                    </label>
+                    <div className="rounded-md border border-violet-200 bg-violet-50/60 p-3 dark:border-violet-800 dark:bg-violet-950/20">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="text-xs leading-relaxed text-gray-600 dark:text-gray-300">
+                          Optional. Paste a long-lived token from <code className="font-mono">claude setup-token</code>. It is private to this user and workflow. If empty, Claude Code uses its saved login.
+                        </div>
+                        {isLoadingClaudeCredential ? (
+                          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-gray-400" />
+                        ) : claudeCredentialConfigured ? (
+                          <span className="inline-flex shrink-0 items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
+                            <CheckCircle2 className="h-3.5 w-3.5" /> Configured
+                          </span>
+                        ) : null}
+                      </div>
+                      <input
+                        type="password"
+                        autoComplete="off"
+                        value={claudeCodeToken}
+                        onChange={event => setClaudeCodeToken(event.target.value)}
+                        placeholder={claudeCredentialConfigured ? 'Paste a replacement token' : 'Paste Claude Code token'}
+                        className="mt-3 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-mono text-gray-900 outline-none focus:border-violet-500 dark:border-slate-600 dark:bg-slate-900 dark:text-gray-100"
+                      />
+                      <div className="mt-2 flex items-center justify-between gap-3">
+                        <span className="text-[11px] text-gray-500 dark:text-gray-400">Terminal Anthropic API keys are not used for this Claude Code session.</span>
+                        {claudeCredentialConfigured && (
+                          <button
+                            type="button"
+                            onClick={handleDeleteClaudeCredential}
+                            disabled={isDeletingClaudeCredential || isSavingPreset}
+                            className="inline-flex shrink-0 items-center gap-1 text-xs text-red-600 hover:text-red-700 disabled:opacity-50 dark:text-red-400"
+                          >
+                            {isDeletingClaudeCredential ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                            Remove token
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Right Column - Folder, Tools, and Options */}

--- a/frontend/src/components/PresetModal.tsx
+++ b/frontend/src/components/PresetModal.tsx
@@ -512,8 +512,9 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
       return;
     }
 
-    setIsSavingPreset(true);
-    try {
+	setIsSavingPreset(true);
+	let manifestSaved = false;
+	try {
       
       // Debug: Log what we're sending
       console.log('[PresetModal] Saving preset with:', {
@@ -603,8 +604,9 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
         selectedGlobalSecrets, // Per-preset global secret selection (null=all)
         browserMode, // Browser mode: none|auto|headless|cdp
         cdpPorts
-      );
-      if (saved === false) return;
+	  );
+	  if (saved === false) return;
+	  manifestSaved = true;
       if (effectiveAgentMode === 'workflow' && usesClaudeCode && claudeCodeToken.trim() && selectedFolder?.filepath) {
         await secretsApi.storeWorkflowClaudeCodeCredential(selectedFolder.filepath, claudeCodeToken.trim());
         setClaudeCredentialConfigured(true);
@@ -617,7 +619,10 @@ const PresetModal: React.FC<PresetModalProps> = React.memo(({
       const detail = typeof serverDetail === 'string' && serverDetail.trim() !== ''
         ? serverDetail.trim()
         : error instanceof Error ? error.message : 'Unknown error';
-      useChatStore.getState().addToast(`Failed to save automation: ${detail}`, 'error');
+	  const message = manifestSaved
+	    ? `Automation configuration was saved, but the Claude Code token was not saved: ${detail}`
+	    : `Failed to save automation: ${detail}`;
+	  useChatStore.getState().addToast(message, 'error');
     } finally {
       setIsSavingPreset(false);
     }

--- a/frontend/src/components/PresetSelectionOverlay.tsx
+++ b/frontend/src/components/PresetSelectionOverlay.tsx
@@ -107,7 +107,7 @@ export const PresetSelectionOverlay: React.FC<PresetSelectionOverlayProps> = ({
       
       if (!newPreset) {
         console.error('Failed to create preset')
-        return
+        return false
       }
       
       // Close the modal
@@ -126,9 +126,11 @@ export const PresetSelectionOverlay: React.FC<PresetSelectionOverlayProps> = ({
         onPresetSelected(newPreset.id)
         onClose()
       }
+      return true
     } catch (error) {
       console.error('Failed to create preset:', error)
       // You might want to show an error message to the user here
+      return false
     }
   }
 


### PR DESCRIPTION
## What changed

- add an optional, encrypted Claude Code OAuth token scoped to one user and one workflow
- isolate token validation/runtime injection from ambient Anthropic API-key variables
- fix trusted planning writers so `update_step_config`, plan bootstrap, and plan changelog writes can update only their exact managed files while raw planning writes remain blocked
- simplify advanced workflow LLM configuration into six compact role rows with one editor open at a time
- show Claude token setup only when the workflow actually uses Claude Code
- prevent credential storage when the workflow manifest save fails

## Root cause

The planning guard correctly blocks general writes under `planning/`, but several typed backend writers were not using the trusted write capability. `update_step_config` therefore reached the guard as an ordinary file write and was rejected even though the designated tool was used.

## Validation

- `go test ./...`
- pre-commit golangci-lint and Go/workspace builds
- `npm run build` (bundle budget passed)
- local visual QA of the compact LLM editor and Claude credential panel
- browser console checked with no errors

## Follow-up fixes
- wired workflow Claude OAuth tokens through llm-provider-mcp v0.7.3 into the actual Claude tmux process
- kept normal saved Claude login behavior when no workflow token is configured
- prevented the preset modal from closing before token persistence completes
- reports partial save accurately and allows token retry

Companion provider PR: manishiitg/llm-provider-mcp#31

## Final validation
- agent_go: go test ./...
- frontend: npm run build
- frontend: 26 files / 121 tests passed
- provider: focused configuration and Claude tmux tests
- golangci-lint and gitleaks passed